### PR TITLE
Label based configcheck cleanup

### DIFF
--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -145,6 +145,10 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		model.NewValidationReconciler(ctx, r.Client, loggingResources, &secretLoaderFactory{Client: r.Client, Path: fluentd.OutputSecretPath}),
 	}
 
+	if logging.Spec.FluentdSpec != nil && logging.Spec.SyslogNGSpec != nil {
+		return ctrl.Result{}, errors.New("fluentd and syslogNG cannot be enabled simultaneously")
+	}
+
 	if logging.Spec.FluentdSpec != nil {
 		fluentdConfig, secretList, err := r.clusterConfigurationFluentd(loggingResources)
 		if err != nil {

--- a/pkg/resources/configcheck/configcheck.go
+++ b/pkg/resources/configcheck/configcheck.go
@@ -1,0 +1,101 @@
+// Copyright © 2023 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configcheck
+
+import (
+	"context"
+	"emperror.dev/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const hashLabel = "logging.banzaicloud.io/config-hash"
+
+func WithHashLabel(accessor v1.Object, hash string) {
+	l := accessor.GetLabels()
+	l[hashLabel] = hash
+	accessor.SetLabels(l)
+}
+
+func hasHashLabel(accessor v1.Object, hash string) (has bool, match bool) {
+	l := accessor.GetLabels()
+	var val string
+	val, has = l[hashLabel]
+	return has, val == hash
+}
+
+type ConfigCheckCleaner struct {
+	client client.Client
+	labels client.MatchingLabels
+}
+
+func NewConfigCheckCleaner(client client.Client, component string) *ConfigCheckCleaner {
+	return &ConfigCheckCleaner{
+		client: client,
+		labels: map[string]string{
+			"app.kubernetes.io/component": component,
+		},
+	}
+}
+
+// SecretCleanup cleans up configcheck secrets that have the logging.banzaicloud.io/config-hash label, but
+// doesn't match the current config hash
+func (c *ConfigCheckCleaner) SecretCleanup(ctx context.Context, hash string) (multierr error) {
+	allCheckSecrets := &corev1.SecretList{}
+	if err := c.client.List(context.TODO(), allCheckSecrets, c.labels); err != nil {
+		return errors.Wrap(err, "failed to list configcheck secrets")
+	}
+
+	for _, secret := range allCheckSecrets.Items {
+		if _, match := hasHashLabel(&secret, hash); match {
+			continue
+		}
+		if err := c.client.Delete(ctx, &secret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				multierr = errors.Combine(multierr,
+					errors.Wrapf(err, "failed to remove config check secret %s", secret.Name))
+				continue
+			}
+		}
+	}
+
+	return
+}
+
+// PodCleanup cleans up configcheck pods that have the logging.banzaicloud.io/config-hash label, but
+// doesn't match the current config hash
+func (c *ConfigCheckCleaner) PodCleanup(ctx context.Context, hash string) (multierr error) {
+	allCheckPods := &corev1.PodList{}
+	if err := c.client.List(context.TODO(), allCheckPods, c.labels); err != nil {
+		return errors.Wrap(err, "failed to list configcheck pods")
+	}
+
+	for _, pod := range allCheckPods.Items {
+		if _, match := hasHashLabel(&pod, hash); match {
+			continue
+		}
+		if err := c.client.Delete(ctx, &pod); err != nil {
+			if !apierrors.IsNotFound(err) {
+				multierr = errors.Combine(multierr,
+					errors.Wrapf(err, "failed to remove config check pod %s", pod.Name))
+				continue
+			}
+		}
+	}
+
+	return
+}

--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -22,6 +22,7 @@ import (
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	"github.com/kube-logging/logging-operator/pkg/compression"
+	"github.com/kube-logging/logging-operator/pkg/resources/configcheck"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,10 +71,12 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	if err != nil {
 		return nil, err
 	}
+	configcheck.WithHashLabel(checkSecret, hashKey)
 	checkSecretAppConfig, err := r.newCheckSecretAppConfig(hashKey)
 	if err != nil {
 		return nil, err
 	}
+	configcheck.WithHashLabel(checkSecretAppConfig, hashKey)
 
 	err = r.Client.Create(ctx, checkSecret)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -88,12 +91,14 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	if err != nil {
 		return nil, err
 	}
+	configcheck.WithHashLabel(checkOutputSecret, hashKey)
 	err = r.Client.Create(ctx, checkOutputSecret)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, errors.WrapIf(err, "failed to create output secret for fluentd configcheck")
 	}
 
 	pod := r.newCheckPod(hashKey)
+	configcheck.WithHashLabel(pod, hashKey)
 
 	existingPods := &corev1.PodList{}
 	err = r.Client.List(ctx, existingPods, client.MatchingLabels(pod.Labels))
@@ -154,49 +159,6 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	}
 
 	return &ConfigCheckResult{}, nil
-}
-
-func (r *Reconciler) configCheckCleanup(currentHash string) (removedHashes []string, multierr error) {
-	for configHash := range r.Logging.Status.ConfigCheckResults {
-		if configHash == currentHash {
-			continue
-		}
-		newSecret, err := r.newCheckSecret(configHash)
-		if err != nil {
-			multierr = errors.Combine(multierr,
-				errors.Wrapf(err, "failed to create config check secret %s", configHash))
-			continue
-		}
-		if err := r.Client.Delete(context.TODO(), newSecret); err != nil {
-			if !apierrors.IsNotFound(err) {
-				multierr = errors.Combine(multierr,
-					errors.Wrapf(err, "failed to remove config check secret %s", configHash))
-				continue
-			}
-		}
-		checkOutputSecret, err := r.newCheckOutputSecret(configHash)
-		if err != nil {
-			multierr = errors.Combine(multierr,
-				errors.Wrapf(err, "failed to create config check output secret %s", configHash))
-			continue
-		}
-		if err := r.Client.Delete(context.TODO(), checkOutputSecret); err != nil {
-			if !apierrors.IsNotFound(err) {
-				multierr = errors.Combine(multierr,
-					errors.Wrapf(err, "failed to remove config check output secret %s", configHash))
-				continue
-			}
-		}
-		if err := r.Client.Delete(context.TODO(), r.newCheckPod(configHash)); err != nil {
-			if !apierrors.IsNotFound(err) {
-				multierr = errors.Combine(multierr,
-					errors.Wrapf(err, "failed to remove config check pod %s", configHash))
-				continue
-			}
-		}
-		removedHashes = append(removedHashes, configHash)
-	}
-	return
 }
 
 func (r *Reconciler) newCheckSecret(hashKey string) (*corev1.Secret, error) {

--- a/pkg/resources/syslogng/configcheck.go
+++ b/pkg/resources/syslogng/configcheck.go
@@ -22,6 +22,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/merge"
+	"github.com/kube-logging/logging-operator/pkg/resources/configcheck"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +55,7 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	if err != nil {
 		return nil, err
 	}
+	configcheck.WithHashLabel(checkSecret, hashKey)
 	err = r.Client.Create(ctx, checkSecret)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, errors.WrapIf(err, "failed to create secret for syslog-ng configcheck")
@@ -63,6 +65,7 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	if err != nil {
 		return nil, err
 	}
+	configcheck.WithHashLabel(checkOutputSecret, hashKey)
 	err = r.Client.Create(ctx, checkOutputSecret)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, errors.WrapIf(err, "failed to create output secret for syslog-ng configcheck")
@@ -72,6 +75,7 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	if err != nil {
 		return nil, errors.WrapIff(err, "failed to create resource description for config check pod %s", hashKey)
 	}
+	configcheck.WithHashLabel(pod, hashKey)
 
 	existingPods := &corev1.PodList{}
 	err = r.Client.List(ctx, existingPods, client.MatchingLabels(pod.Labels))
@@ -134,57 +138,9 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	return &ConfigCheckResult{}, nil
 }
 
-func (r *Reconciler) configCheckCleanup(currentHash string) (removedHashes []string, multierr error) {
-	for configHash := range r.Logging.Status.ConfigCheckResults {
-		if configHash == currentHash {
-			continue
-		}
-		newSecret, err := r.newCheckSecret(configHash)
-		if err != nil {
-			multierr = errors.Combine(multierr,
-				errors.Wrapf(err, "failed to create config check secret %s", configHash))
-			continue
-		}
-		if err := r.Client.Delete(context.TODO(), newSecret); err != nil {
-			if !apierrors.IsNotFound(err) {
-				multierr = errors.Combine(multierr,
-					errors.Wrapf(err, "failed to remove config check secret %s", configHash))
-				continue
-			}
-		}
-		checkOutputSecret, err := r.newCheckOutputSecret(configHash)
-		if err != nil {
-			multierr = errors.Combine(multierr,
-				errors.Wrapf(err, "failed to create config check output secret %s", configHash))
-			continue
-		}
-		if err := r.Client.Delete(context.TODO(), checkOutputSecret); err != nil {
-			if !apierrors.IsNotFound(err) {
-				multierr = errors.Combine(multierr,
-					errors.Wrapf(err, "failed to remove config check output secret %s", configHash))
-				continue
-			}
-		}
-		checkPod, err := r.newCheckPod(configHash)
-		if err != nil {
-			multierr = errors.Append(multierr, errors.WrapIff(err, "failed to create resource description for config check pod %s", configHash))
-			continue
-		}
-		if err := r.Client.Delete(context.TODO(), checkPod); err != nil {
-			if !apierrors.IsNotFound(err) {
-				multierr = errors.Combine(multierr,
-					errors.Wrapf(err, "failed to remove config check pod %s", configHash))
-				continue
-			}
-		}
-		removedHashes = append(removedHashes, configHash)
-	}
-	return
-}
-
 func (r *Reconciler) newCheckSecret(hashKey string) (*corev1.Secret, error) {
 	return &corev1.Secret{
-		ObjectMeta: r.SyslogNGObjectMeta(fmt.Sprintf("syslog-ng-configcheck-%s", hashKey), ComponentConfigCheck),
+		ObjectMeta: r.SyslogNGObjectMeta(resourceName(hashKey), ComponentConfigCheck),
 		Data: map[string][]byte{
 			configKey: []byte(r.config),
 		},
@@ -205,7 +161,7 @@ func (r *Reconciler) newCheckOutputSecret(hashKey string) (*corev1.Secret, error
 
 func (r *Reconciler) newCheckPod(hashKey string) (*corev1.Pod, error) {
 	pod := &corev1.Pod{
-		ObjectMeta: r.SyslogNGObjectMeta(fmt.Sprintf("syslog-ng-configcheck-%s", hashKey), ComponentConfigCheck),
+		ObjectMeta: r.SyslogNGObjectMeta(resourceName(hashKey), ComponentConfigCheck),
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,
 			ServiceAccountName: r.getServiceAccountName(),
@@ -214,7 +170,7 @@ func (r *Reconciler) newCheckPod(hashKey string) (*corev1.Pod, error) {
 					Name: "config",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: r.Logging.QualifiedName(fmt.Sprintf("syslog-ng-configcheck-%s", hashKey)),
+							SecretName: r.Logging.QualifiedName(resourceName(hashKey)),
 						},
 					},
 				},
@@ -281,4 +237,8 @@ func (r *Reconciler) newCheckPod(hashKey string) (*corev1.Pod, error) {
 	err := merge.Merge(&pod.Spec, r.Logging.Spec.SyslogNGSpec.ConfigCheckPodOverrides)
 
 	return pod, err
+}
+
+func resourceName(hash string) string {
+	return fmt.Sprintf("syslog-ng-configcheck-%s", hash)
 }

--- a/pkg/resources/syslogng/configcheck.go
+++ b/pkg/resources/syslogng/configcheck.go
@@ -140,7 +140,7 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 
 func (r *Reconciler) newCheckSecret(hashKey string) (*corev1.Secret, error) {
 	return &corev1.Secret{
-		ObjectMeta: r.SyslogNGObjectMeta(resourceName(hashKey), ComponentConfigCheck),
+		ObjectMeta: r.SyslogNGObjectMeta(configCheckResourceName(hashKey), ComponentConfigCheck),
 		Data: map[string][]byte{
 			configKey: []byte(r.config),
 		},
@@ -161,7 +161,7 @@ func (r *Reconciler) newCheckOutputSecret(hashKey string) (*corev1.Secret, error
 
 func (r *Reconciler) newCheckPod(hashKey string) (*corev1.Pod, error) {
 	pod := &corev1.Pod{
-		ObjectMeta: r.SyslogNGObjectMeta(resourceName(hashKey), ComponentConfigCheck),
+		ObjectMeta: r.SyslogNGObjectMeta(configCheckResourceName(hashKey), ComponentConfigCheck),
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,
 			ServiceAccountName: r.getServiceAccountName(),
@@ -170,7 +170,7 @@ func (r *Reconciler) newCheckPod(hashKey string) (*corev1.Pod, error) {
 					Name: "config",
 					VolumeSource: corev1.VolumeSource{
 						Secret: &corev1.SecretVolumeSource{
-							SecretName: r.Logging.QualifiedName(resourceName(hashKey)),
+							SecretName: r.Logging.QualifiedName(configCheckResourceName(hashKey)),
 						},
 					},
 				},
@@ -239,6 +239,6 @@ func (r *Reconciler) newCheckPod(hashKey string) (*corev1.Pod, error) {
 	return pod, err
 }
 
-func resourceName(hash string) string {
+func configCheckResourceName(hash string) string {
 	return fmt.Sprintf("syslog-ng-configcheck-%s", hash)
 }

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/secret"
 	"github.com/go-logr/logr"
 	"github.com/kube-logging/logging-operator/pkg/resources"
+	"github.com/kube-logging/logging-operator/pkg/resources/configcheck"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -132,27 +133,33 @@ func (r *Reconciler) Reconcile() (*reconcile.Result, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// Fail when the current config is invalid
+		if result, ok := r.Logging.Status.ConfigCheckResults[hash]; ok && !result {
+			return nil, errors.Errorf("current config is invalid")
+		}
+
+		// Cleanup previous configcheck results
 		if result, ok := r.Logging.Status.ConfigCheckResults[hash]; ok {
-			// We already have an existing configcheck result:
-			// - bail out if it was unsuccessful
-			// - cleanup previous results if it's successful
-			if !result {
-				return nil, errors.Errorf("current config is invalid")
-			}
-			var removedHashes []string
-			if removedHashes, err = r.configCheckCleanup(hash); err != nil {
-				r.Log.Error(err, "failed to cleanup resources")
-			} else {
-				if len(removedHashes) > 0 {
-					for _, removedHash := range removedHashes {
-						delete(r.Logging.Status.ConfigCheckResults, removedHash)
-					}
-					if err := r.Client.Status().Patch(ctx, r.Logging, patchBase); err != nil {
-						return nil, errors.WrapWithDetails(err, "failed to patch status", "logging", r.Logging)
-					} else {
-						// explicitly ask for a requeue to short circuit the controller loop after the status update
-						return &reconcile.Result{Requeue: true}, nil
-					}
+			cleaner := configcheck.NewConfigCheckCleaner(r.Client, ComponentConfigCheck)
+
+			var cleanupErrs error
+			cleanupErrs = errors.Append(cleanupErrs, cleaner.SecretCleanup(ctx, hash))
+			cleanupErrs = errors.Append(cleanupErrs, cleaner.PodCleanup(ctx, hash))
+
+			if cleanupErrs != nil {
+				// Errors with the cleanup should not block the reconciliation, we just note it
+				r.Log.Error(err, "issues during configcheck cleanup, moving on")
+			} else if len(r.Logging.Status.ConfigCheckResults) > 1 {
+				//
+				r.Logging.Status.ConfigCheckResults = map[string]bool{
+					hash: result,
+				}
+				if err := r.Client.Status().Patch(ctx, r.Logging, patchBase); err != nil {
+					return nil, errors.WrapWithDetails(err, "failed to patch status", "logging", r.Logging)
+				} else {
+					// explicitly ask for a requeue to short circuit the controller loop after the status update
+					return &reconcile.Result{Requeue: true}, nil
 				}
 			}
 		} else {


### PR DESCRIPTION
The PR applies a new logic for cleaning up configcheck resources (secrets and the pod) so that it should be more robust. 

The previous logic was leveraging the config hashes registered in the logging operator status, which could potentially miss obsolete configcheck resources if the hash was not added to the status properly (or was removed prematurely).

The current logic adds a label to each resource and removes all the resources that are not relevant anymore based on the value of the label.

Additionally we make sure that fluentd and syslogng are not configured simultaneously because the two reconcilers would fight for the single `configCheckResults` field in the logging resource status.