### PR TITLE
replace fixed syslog-ng persist file flag with guessed dynamic

### DIFF
--- a/pkg/resources/kubetool/utils.go
+++ b/pkg/resources/kubetool/utils.go
@@ -19,11 +19,31 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func FindContainerByName(cnrs []corev1.Container, name string) *corev1.Container {
+	for i := range cnrs {
+		cnr := &cnrs[i]
+		if cnr.Name == name {
+			return cnr
+		}
+	}
+	return nil
+}
+
 func FindVolumeByName(vols []corev1.Volume, name string) *corev1.Volume {
 	for i := range vols {
 		vol := &vols[i]
 		if vol.Name == name {
 			return vol
+		}
+	}
+	return nil
+}
+
+func FindVolumeMountByName(mnts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range mnts {
+		mnt := &mnts[i]
+		if mnt.Name == name {
+			return mnt
 		}
 	}
 	return nil

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/merge"
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	util "github.com/cisco-open/operator-tools/pkg/utils"
+	"github.com/kube-logging/logging-operator/pkg/resources/kubetool"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -73,6 +74,20 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 		return desired, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
 	}
 
+	// HACK: try to _guess_ if user has configured a persistent volume for buffers and move syslog-ng's persist file there
+	buffersVolumeName := "buffers"
+	if name := r.Logging.Spec.SyslogNGSpec.BufferVolumeMetrics.MountName; name != "" {
+		buffersVolumeName = name
+	}
+	syslogngContainer := kubetool.FindContainerByName(desired.Spec.Template.Spec.Containers, containerName)
+	if mnt := kubetool.FindVolumeMountByName(syslogngContainer.VolumeMounts, buffersVolumeName); mnt != nil {
+		if !sliceAny(syslogngContainer.Args, func(arg string) bool { return strings.Contains(arg, "--persist-file") }) {
+			persistFilePath := filepath.Join(mnt.MountPath, "/syslog-ng.persist")
+			persistFileFlag := fmt.Sprintf("--persist-file=%q", persistFilePath)
+			syslogngContainer.Args = append(syslogngContainer.Args, persistFileFlag)
+		}
+	}
+
 	return desired, reconciler.StatePresent, nil
 }
 
@@ -89,7 +104,6 @@ func syslogNGContainer(spec *v1beta1.SyslogNGSpec) corev1.Container {
 		Args: []string{
 			"--cfgfile=" + configDir + "/" + configKey,
 			"--control=" + socketPath,
-			"--persist-file=" + filepath.Join(bufferPath, "/syslog-ng.persist"),
 			"--no-caps",
 			"-Fe",
 		},
@@ -358,4 +372,13 @@ func generateConfigReloaderConfig(configDir string) string {
 		}
 	  }
 	`, filepath.Join(configDir, "..data"), socketPath)
+}
+
+func sliceAny[S ~[]E, E any](s S, fn func(E) bool) bool {
+	for _, e := range s {
+		if fn(e) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This fixes an issue when persist file creation fails because there is no `/buffers` directory in the syslog-ng statefulset's syslog-ng container.

The new logic removes the hard coded `--persist-file` flag from syslog-ng's args and only adds it if it finds a volume mount "for buffers".