### PR TITLE
chore: renovate tuning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,17 @@
     "go": "1.20"
   },
   "ignoreDeps": [
-    "github.com/MakeNowJust/heredoc/v2",
-    "github.com/onsi/ginkgo/v2"
+    "github.com/shurcooL/vfsgen",
+    "golang.org/x/exp"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["k8s.io/client-go"],
+      "allowedVersions": "/^v[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
- disable major upgrades by default
- disable golang.org/x/exp package
- use consistent k8s version for client-go