### PR TITLE
chore(e2e/charts): update version logging-operator

### DIFF
--- a/e2e/charts/logging-operator-logging/Chart.yaml
+++ b/e2e/charts/logging-operator-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: logging-operator-logging
-version: 4.1.0-dev.1
+version: 4.1.0-dev.2
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to configure logging resource for the Logging operator.
 keywords:

--- a/e2e/charts/logging-operator/Chart.yaml
+++ b/e2e/charts/logging-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: logging-operator
-version: 4.1.0-dev.1
+version: 4.1.0-dev.2
 appVersion: 4.0.0
 kubeVersion: ">=1.16.0-0"
 description: Logging operator for Kubernetes based on Fluentd and Fluentbit.


### PR DESCRIPTION
- set logging operator to 4.1.0-dev.2 is already part of old repo:
https://github.com/kube-logging/helm-charts/commit/3e5afecff0d8739ea3c60dc6548c6f08793680f5#diff-165b025fc40a9ffab354b3891bea38ea4b28acccaf314c8238eed95ffa3640ae