### PR TITLE
fix(e2e/charts): add logging-operator-logging syslogNG + errorOutputRef support

### DIFF
--- a/docs/configuration/crds/v1beta1/logging_types.md
+++ b/docs/configuration/crds/v1beta1/logging_types.md
@@ -22,7 +22,7 @@ Default: -
 
 ### skipInvalidResources (bool, optional) {#loggingspec-skipinvalidresources}
 
-Skip Invalid Resources 
+Whether to skip invalid Flow and ClusterFlow resources 
 
 Default: -
 

--- a/e2e/charts/logging-operator-logging/Chart.yaml
+++ b/e2e/charts/logging-operator-logging/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: logging-operator-logging
-version: 4.1.0-dev.2
+version: 4.1.0-dev.3
 kubeVersion: ">=1.16.0-0"
 description: A Helm chart to configure logging resource for the Logging operator.
 keywords:

--- a/e2e/charts/logging-operator-logging/templates/logging.yaml
+++ b/e2e/charts/logging-operator-logging/templates/logging.yaml
@@ -28,8 +28,6 @@ spec:
     {{- with .Values.fluentbit }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- else }}
-  fluentbit: {}
   {{- end }}
   {{- if or .Values.tls.enabled .Values.fluentd }}
   fluentd:
@@ -42,8 +40,6 @@ spec:
     {{- with .Values.fluentd }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- else }}
-  fluentd: {}
   {{- end }}
   {{- with .Values.syslogNG }}
   syslogNG:
@@ -72,8 +68,6 @@ spec:
   {{- with .Values.nodeAgents }}
   nodeAgents:
     {{ toYaml . | nindent 4 }}
-  {{- else }}
-  nodeAgents: []
   {{- end }}
   {{- with .Values.enableRecreateWorkloadOnImmutableFieldChange }}
   enableRecreateWorkloadOnImmutableFieldChange: {{ . }}

--- a/e2e/charts/logging-operator-logging/templates/logging.yaml
+++ b/e2e/charts/logging-operator-logging/templates/logging.yaml
@@ -5,51 +5,17 @@ metadata:
   labels:
 {{ include "logging-operator-logging.labels" . | indent 4 }}
 spec:
-  {{- with .Values.enableRecreateWorkloadOnImmutableFieldChange }}
-  enableRecreateWorkloadOnImmutableFieldChange: {{ . }}
-  {{- end}}
   {{- with .Values.loggingRef }}
   loggingRef: {{ . }}
   {{- end }}
   {{- with .Values.flowConfigCheckDisabled }}
   flowConfigCheckDisabled: {{ . }}
   {{- end }}
-  {{- with .Values.flowConfigOverride }}
-  flowConfigOverride: {{ . }}
-  {{- end }}
-  {{- with .Values.allowClusterResourcesFromAllNamespaces }}
-  allowClusterResourcesFromAllNamespaces: {{ . }}
-  {{- end }}
   {{- with .Values.skipInvalidResources }}
   skipInvalidResources: {{ . }}
   {{- end }}
-  {{- if .Values.watchNamespaces }}
-  watchNamespaces:
-{{ toYaml .Values.watchNamespaces | indent 4 }}
-  {{- end }}
-  clusterDomain: {{ .Values.clusterDomain }}
-  controlNamespace: {{ .Values.controlNamespace | default .Release.Namespace }}
-  {{- if .Values.defaultFlow }}
-  defaultFlow:
-{{ toYaml .Values.defaultFlow | indent 4 }}
-  {{- end }}
-  {{- if .Values.globalFilters }}
-  globalFilters:
-{{ toYaml .Values.globalFilters | indent 4 }}
-  {{- end }}
-  {{- if or .Values.tls.enabled .Values.fluentd }}
-  fluentd:
-    {{- if .Values.tls.enabled }}
-    tls:
-      enabled: true
-      secretName: {{ .Values.tls.fluentdSecretName | default (printf "%s-%s" (include "logging-operator-logging.name" . ) "fluentd-tls" ) }}
-      sharedKey: "{{ .Values.tls.sharedKey }}"
-    {{- end }}
-    {{- if .Values.fluentd }}
-{{ toYaml .Values.fluentd | indent 4 }}
-    {{- end }}
-  {{- else }}
-  fluentd: {}
+  {{- with .Values.flowConfigOverride }}
+  flowConfigOverride: {{ . }}
   {{- end }}
   {{- if or .Values.tls.enabled .Values.fluentbit }}
   fluentbit:
@@ -59,15 +25,56 @@ spec:
       secretName: {{ .Values.tls.fluentbitSecretName | default (printf "%s-%s" (include "logging-operator-logging.name" . ) "fluentbit-tls" ) }}
       sharedKey: "{{ .Values.tls.sharedKey }}"
     {{- end }}
-    {{- if .Values.fluentbit }}
-{{ toYaml .Values.fluentbit | indent 4 }}
+    {{- with .Values.fluentbit }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- else }}
   fluentbit: {}
   {{- end }}
-  {{- if .Values.nodeAgents }}
+  {{- if or .Values.tls.enabled .Values.fluentd }}
+  fluentd:
+    {{- if .Values.tls.enabled }}
+    tls:
+      enabled: true
+      secretName: {{ .Values.tls.fluentdSecretName | default (printf "%s-%s" (include "logging-operator-logging.name" . ) "fluentd-tls" ) }}
+      sharedKey: "{{ .Values.tls.sharedKey }}"
+    {{- end }}
+    {{- with .Values.fluentd }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
+  fluentd: {}
+  {{- end }}
+  {{- with .Values.syslogNG }}
+  syslogNG:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.defaultFlow }}
+  defaultFlow:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.errorOutputRef }}
+  errorOutputRef: {{ . }}
+  {{- end }}
+  {{- with .Values.globalFilters }}
+  globalFilters:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.watchNamespaces }}
+  watchNamespaces:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  clusterDomain: {{ .Values.clusterDomain }}
+  controlNamespace: {{ .Values.controlNamespace | default .Release.Namespace }}
+  {{- with .Values.allowClusterResourcesFromAllNamespaces }}
+  allowClusterResourcesFromAllNamespaces: {{ . }}
+  {{- end }}
+  {{- with .Values.nodeAgents }}
   nodeAgents:
-{{ toYaml .Values.nodeAgents | indent 4 }}
+    {{ toYaml . | nindent 4 }}
   {{- else }}
   nodeAgents: []
   {{- end }}
+  {{- with .Values.enableRecreateWorkloadOnImmutableFieldChange }}
+  enableRecreateWorkloadOnImmutableFieldChange: {{ . }}
+  {{- end}}

--- a/e2e/charts/logging-operator-logging/values.yaml
+++ b/e2e/charts/logging-operator-logging/values.yaml
@@ -2,18 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Reference name of the logging deployment
-loggingRef: ""
-# Disable configuration check before deploy
-flowConfigCheckDisabled: false
-# Use static configuration instead of generated config.
-flowConfigOverride: ""
-
 nameOverride: ""
 fullnameOverride: ""
-
-# -- Permit deletion and recreation of resources on update of immutable field.
-enableRecreateWorkloadOnImmutableFieldChange: false
 
 tls:
   # -- Enable secure connection between fluentd and fluent-bit
@@ -28,10 +18,24 @@ tls:
   # Shared key between nodes (fluentd-fluentbit)
   sharedKey: ""
 
-# -- Fluent-bit configurations https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentbit_types/
+
+
+# -- Reference to the logging system. Each of the loggingRefs can manage a fluentbit daemonset and a fluentd statefulset.
+loggingRef: ""
+
+# -- Disable configuration check before applying new fluentd configuration.
+flowConfigCheckDisabled: false
+
+# -- Whether to skip invalid Flow and ClusterFlow resources
+skipInvalidResources: false
+
+# -- Override generated config. This is a raw configuration string for troubleshooting purposes.
+flowConfigOverride: ""
+
+# -- Fluent-bit configurations https://kube-logging.github.io/docs/configuration/crds/v1beta1/fluentbit_types/
 fluentbit: {}
 
-# -- Fluentd configurations https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/fluentd_types/
+# -- Fluentd configurations https://kube-logging.github.io/docs/configuration/crds/v1beta1/fluentd_types/
 fluentd: {}
 # 20Gi persistent storage is configured for fluentd by default.
 # Here is an example, on how to override it:
@@ -44,7 +48,31 @@ fluentd: {}
 #          requests:
 #            storage: 40Gi
 
-# -- Node agents definitions
+# -- Syslog-NG statefulset configuration
+syslogNG: {}
+
+# -- Default flow for unmatched logs. This Flow configuration collects all logs that didn’t matched any other Flow.
+defaultFlow: {}
+
+# -- GlobalOutput name to flush ERROR events to
+errorOutputRef: ""
+
+# -- Global filters to apply on logs before any match or filter mechanism.
+globalFilters: []
+
+# -- Limit namespaces to watch Flow and Output custom resources.
+watchNamespaces: []
+
+# -- Cluster domain name to be used when templating URLs to services
+clusterDomain: "cluster.local"
+
+# -- Namespace for cluster wide configuration resources like ClusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well.
+controlNamespace: ""
+
+# -- Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources
+allowClusterResourcesFromAllNamespaces: false
+
+# -- NodeAgent Configuration
 nodeAgents: {}
 #  - name: win-agent
 #    profile: windows
@@ -67,26 +95,8 @@ nodeAgents: {}
 #      tls:
 #        enabled: false
 
-# -- Whether to skip invalid Flow and ClusterFlow resources
-skipInvalidResources: false
-
-# -- Limit namespaces from where to read Flow and Output specs
-watchNamespaces: []
-
-# -- Cluster domain name to be used when templating URLs to services
-clusterDomain: "cluster.local"
-
-# -- Control namespace that contains ClusterOutput and ClusterFlow resources
-controlNamespace: ""
-
-# -- Allow configuration of cluster resources from any namespace
-allowClusterResourcesFromAllNamespaces: false
-
-# -- Default flow
-defaultFlow: {}
-
-# -- Global filters
-globalFilters: []
+# -- EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future) in case there is a change in an immutable field that otherwise couldn’t be managed with a simple update.
+enableRecreateWorkloadOnImmutableFieldChange: false
 
 # -- ClusterFlows to deploy
 clusterFlows: []

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -45,7 +45,7 @@ type LoggingSpec struct {
 	LoggingRef string `json:"loggingRef,omitempty"`
 	// Disable configuration check before applying new fluentd configuration.
 	FlowConfigCheckDisabled bool `json:"flowConfigCheckDisabled,omitempty"`
-	// Skip Invalid Resources
+	// Whether to skip invalid Flow and ClusterFlow resources
 	SkipInvalidResources bool `json:"skipInvalidResources,omitempty"`
 	// Override generated config. This is a *raw* configuration string for troubleshooting purposes.
 	FlowConfigOverride string `json:"flowConfigOverride,omitempty"`


### PR DESCRIPTION
add support for syslogNG and errorOutputRef

some cleanups:
- replace `if` with `with`
- replace `indent` to `nindent` (and nicer indent)
- reorder like in docs / crd-struct (and take comments from crd-struct to helm-chart)