### PR TITLE
chore(fix): syslog-ng persist file argument escaping

### DIFF
--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -84,9 +84,8 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 	syslogngContainer := kubetool.FindContainerByName(desired.Spec.Template.Spec.Containers, containerName)
 	if mnt := kubetool.FindVolumeMountByName(syslogngContainer.VolumeMounts, buffersVolumeName); mnt != nil {
 		if !sliceAny(syslogngContainer.Args, func(arg string) bool { return strings.Contains(arg, "--persist-file") }) {
-			persistFilePath := filepath.Join(mnt.MountPath, "/syslog-ng.persist")
-			persistFileFlag := fmt.Sprintf("--persist-file=%q", persistFilePath)
-			syslogngContainer.Args = append(syslogngContainer.Args, persistFileFlag)
+			syslogngContainer.Args = append(syslogngContainer.Args,
+				"--persist-file", filepath.Join(mnt.MountPath, "/syslog-ng.persist"))
 		}
 	}
 


### PR DESCRIPTION
Specify the persist-file path in a separate argument in order to escape special characters correctly