### PR TITLE
feat: update cluster domain to force direct resolution

### DIFF
--- a/e2e/charts/logging-operator-logging/values.yaml
+++ b/e2e/charts/logging-operator-logging/values.yaml
@@ -63,7 +63,7 @@ globalFilters: []
 watchNamespaces: []
 
 # -- Cluster domain name to be used when templating URLs to services
-clusterDomain: "cluster.local"
+clusterDomain: "cluster.local."
 
 # -- Namespace for cluster wide configuration resources like ClusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well.
 controlNamespace: ""

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -65,7 +65,7 @@ type LoggingSpec struct {
 	GlobalFilters []Filter `json:"globalFilters,omitempty"`
 	// Limit namespaces to watch Flow and Output custom resources.
 	WatchNamespaces []string `json:"watchNamespaces,omitempty"`
-	// Cluster domain name to be used when templating URLs to services (default: "cluster.local").
+	// Cluster domain name to be used when templating URLs to services (default: "cluster.local.").
 	ClusterDomain *string `json:"clusterDomain,omitempty"`
 	// Namespace for cluster wide configuration resources like CLusterFlow and ClusterOutput.
 	// This should be a protected namespace from regular users.
@@ -146,7 +146,7 @@ const (
 // SetDefaults fills empty attributes
 func (l *Logging) SetDefaults() error {
 	if l.Spec.ClusterDomain == nil {
-		l.Spec.ClusterDomain = util.StringPointer("cluster.local")
+		l.Spec.ClusterDomain = util.StringPointer("cluster.local.")
 	}
 	if !l.Spec.FlowConfigCheckDisabled && l.Status.ConfigCheckResults == nil {
 		l.Status.ConfigCheckResults = make(map[string]bool)


### PR DESCRIPTION
As we generate FQDNs with this clusterDomain value, we can directly append a dot at the end to reduce dns queries in non optimal DNS configurations.

TODO: update tests