### PR TITLE
fix: do not refer to upstream config item to avoid hiding fluentbit configuration, also use absolute path in the config

### DIFF
--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -100,7 +100,7 @@ var fluentBitConfigTemplate = `
     Name          forward
     Match         *
     {{- if .Upstream.Enabled }}
-    Upstream      upstream.conf
+    Upstream      {{ .Upstream.Config.Path }}
     {{- else }}
     Host          {{ .TargetHost }}
     Port          {{ .TargetPort }}

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -46,6 +46,7 @@ type upstreamNode struct {
 
 type upstream struct {
 	Name  string
+	Path  string
 	Nodes []upstreamNode
 }
 
@@ -323,6 +324,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 
 		if r.fluentbitSpec.EnableUpstream {
 			input.FluentForwardOutput.Upstream.Enabled = true
+			input.FluentForwardOutput.Upstream.Config.Path = fmt.Sprintf("%s/%s", OperatorConfigPath, UpstreamConfigName)
 			input.FluentForwardOutput.Upstream.Config.Name = "fluentd-upstream"
 			for i := int32(0); i < utils.PointerToInt32(aggregatorReplicas); i++ {
 				input.FluentForwardOutput.Upstream.Config.Nodes = append(input.FluentForwardOutput.Upstream.Config.Nodes, r.generateUpstreamNode(i))

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -221,12 +221,6 @@ func (r *Reconciler) generateVolume() (v []corev1.Volume) {
 				},
 			},
 		}
-		if r.fluentbitSpec.EnableUpstream {
-			volume.VolumeSource.Secret.Items = append(volume.VolumeSource.Secret.Items, corev1.KeyToPath{
-				Key:  UpstreamConfigName,
-				Path: UpstreamConfigName,
-			})
-		}
 		v = append(v, volume)
 	} else {
 		v = append(v, corev1.Volume{


### PR DESCRIPTION
Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>
