### PR TITLE
docs(configuration/plugins): fix broken links

### DIFF
--- a/docs/configuration/plugins/outputs/kafka.md
+++ b/docs/configuration/plugins/outputs/kafka.md
@@ -7,7 +7,7 @@ generated_file: true
 # Kafka output plugin for Fluentd
 ## Overview
   More info at https://github.com/fluent/fluent-plugin-kafka
->Example Deployment: [Transport Nginx Access Logs into Kafka with Logging Operator](../../../../quickstarts/kafka-nginx/)
+>Example Deployment: [Transport Nginx Access Logs into Kafka with Logging Operator](../../../../examples/kafka-nginx/)
 
  #### Example output configurations
  ```yaml

--- a/docs/configuration/plugins/outputs/loki.md
+++ b/docs/configuration/plugins/outputs/loki.md
@@ -8,7 +8,7 @@ generated_file: true
 ## Overview
 Fluentd output plugin to ship logs to a Loki server.
 More info at https://github.com/kube-logging/fluent-plugin-kubernetes-loki
->Example: [Store Nginx Access Logs in Grafana Loki with Logging Operator](../../../../quickstarts/loki-nginx/)
+>Example: [Store Nginx Access Logs in Grafana Loki with Logging Operator](../../../../examples/loki-nginx/)
 
  #### Example output configurations
  ```yaml


### PR DESCRIPTION
This PR fixes broken links in the documentation, for the outputs:
* Loki
* Kafka

which are now under the `examples` section and no longer the `quickstarts` one.