### PR TITLE
fluentbit: enable annotation based exclude by default (fluentbit.io/exclude: true)

### DIFF
--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -181,6 +181,9 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		} else if r.fluentbitSpec.FilterKubernetes.BufferSize != "0" {
 			r.logger.Info("Notice: If the kubernetes filter buffer_size parameter is underestimated it can cause log loss. For more information: https://github.com/fluent/fluent-bit/issues/2111")
 		}
+		if r.fluentbitSpec.FilterKubernetes.K8SLoggingExclude == "" {
+			r.fluentbitSpec.FilterKubernetes.K8SLoggingExclude = "On"
+		}
 	}
 
 	input := fluentBitConfig{

--- a/pkg/resources/nodeagent/configsecret.go
+++ b/pkg/resources/nodeagent/configsecret.go
@@ -23,11 +23,12 @@ import (
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	"github.com/cisco-open/operator-tools/pkg/utils"
-	"github.com/kube-logging/logging-operator/pkg/resources/fluentd"
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kube-logging/logging-operator/pkg/resources/fluentd"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/types"
 )
 
 type fluentbitInputConfig struct {

--- a/pkg/resources/nodeagent/nodeagent.go
+++ b/pkg/resources/nodeagent/nodeagent.go
@@ -114,6 +114,10 @@ func NodeAgentFluentbitDefaults(userDefined v1beta1.NodeAgentConfig) (*v1beta1.N
 		userDefined.FluentbitSpec = &v1beta1.NodeAgentFluentbit{}
 	}
 
+	if userDefined.FluentbitSpec.FilterKubernetes.K8SLoggingExclude == "" {
+		userDefined.FluentbitSpec.FilterKubernetes.K8SLoggingExclude = "On"
+	}
+
 	if userDefined.FluentbitSpec.FilterAws != nil {
 		programDefault.FluentbitSpec.FilterAws = &v1beta1.FilterAws{
 			ImdsVersion:     "v2",

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -297,7 +297,7 @@ type FilterKubernetes struct {
 	RegexParser string `json:"Regex_Parser,omitempty"`
 	// Allow Kubernetes Pods to suggest a pre-defined Parser (read more about it in Kubernetes Annotations section) (default:Off)
 	K8SLoggingParser string `json:"K8S-Logging.Parser,omitempty"`
-	// Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section). (default:Off)
+	// Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section). (default:On)
 	K8SLoggingExclude string `json:"K8S-Logging.Exclude,omitempty"`
 	// Include Kubernetes resource labels in the extra metadata. (default:On)
 	Labels string `json:"Labels,omitempty"`


### PR DESCRIPTION
This means that pods with specific exclude annotations will be omitted from log collection, see https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#kubernetes-annotations

Note: this is a possible breaking change, although the chance to be affected by this should be close to zero.

Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>
