### PR TITLE
syslog-ng aggregator fixes

### DIFF
--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -337,7 +337,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 
 	if r.Logging.Spec.SyslogNGSpec != nil {
 		input.SyslogNGOutput = &syslogNGOutputConfig{}
-		input.SyslogNGOutput.Host = fmt.Sprintf("%s.%s.svc.cluster.local", r.Logging.QualifiedName(syslogng.ServiceName), r.Logging.Spec.ControlNamespace)
+		input.SyslogNGOutput.Host = fmt.Sprintf("%s.%s.svc%s", r.Logging.QualifiedName(syslogng.ServiceName), r.Logging.Spec.ControlNamespace, r.Logging.ClusterDomainAsSuffix())
 		input.SyslogNGOutput.Port = syslogng.ServicePort
 		input.SyslogNGOutput.JSONDateKey = "ts"
 		input.SyslogNGOutput.JSONDateFormat = "iso8601"

--- a/pkg/sdk/logging/model/syslogng/config/flow_test.go
+++ b/pkg/sdk/logging/model/syslogng/config/flow_test.go
@@ -18,11 +18,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/config/render"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/config/render"
 )
 
 func TestRenderClusterFlow(t *testing.T) {
@@ -65,7 +66,7 @@ source("test_input");
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
 			out := strings.Builder{}
-			require.NoError(t, renderClusterFlow("test_input", testCase.clusterFlow, nil)(render.RenderContext{
+			require.NoError(t, renderClusterFlow(nil, "test_input", testCase.clusterFlow, nil)(render.RenderContext{
 				Out: &out,
 			}))
 			assert.Equal(t, testCase.expected, out.String())

--- a/pkg/sdk/logging/model/syslogng/config/go.mod
+++ b/pkg/sdk/logging/model/syslogng/config/go.mod
@@ -3,6 +3,7 @@ module github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/c
 go 1.20
 
 require (
+	emperror.dev/errors v0.8.1
 	github.com/cisco-open/operator-tools v0.30.0
 	github.com/kube-logging/logging-operator/pkg/sdk v0.9.1
 	github.com/siliconbrain/go-seqs v0.5.0
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	emperror.dev/errors v0.8.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
- fix: lookup actual cluster output namespace, validate and bail out if invalid
- fix: make cluster.local domain configurable for fluentbit in syslog-ng aggregator mode as well
