### PR TITLE
[docs] Order types alphabetically

### DIFF
--- a/docs/configuration/crds/extensions/v1alpha1/hosttailer_types.md
+++ b/docs/configuration/crds/extensions/v1alpha1/hosttailer_types.md
@@ -10,13 +10,13 @@ HostTailerSpec defines the desired state of HostTailer
 
 ### fileTailers ([]FileTailer, optional) {#hosttailerspec-filetailers}
 
-List of file tailers 
+List of [file tailers](#filetailer). 
 
 Default: -
 
 ### systemdTailers ([]SystemdTailer, optional) {#hosttailerspec-systemdtailers}
 
-List of systemd tailers 
+List of [systemd tailers](#systemdtailer). 
 
 Default: -
 
@@ -41,7 +41,7 @@ Default: -
 
 ## HostTailerStatus
 
-HostTailerStatus defines the observed state of HostTailer
+HostTailerStatus defines the observed state of [HostTailer](#hosttailer).
 
 
 ## HostTailer
@@ -67,7 +67,7 @@ Default: -
 
 ## HostTailerList
 
-HostTailerList contains a list of HostTailer
+HostTailerList contains a list of [HostTailers](#hosttailer).
 
 ###  (metav1.TypeMeta, required) {#hosttailerlist-}
 

--- a/docs/configuration/crds/v1beta1/_index.md
+++ b/docs/configuration/crds/v1beta1/_index.md
@@ -17,10 +17,10 @@ For more information please click on the name
 | **[Common](common_types/)** | ImageSpec Metrics Security | v1beta1 |
 | **[](conversion/)** |  | v1beta1 |
 | **[FlowSpec](flow_types/)** | FlowSpec is the Kubernetes spec for Flows | v1beta1 |
-| **[FluentbitSpec](fluentbit_types/)** | FluentbitSpec defines the desired state of Fluentbit | v1beta1 |
+| **[FluentbitSpec](fluentbit_types/)** | FluentbitSpec defines the desired state of FluentbitAgent | v1beta1 |
 | **[FluentdSpec](fluentd_types/)** | FluentdSpec defines the desired state of Fluentd | v1beta1 |
 | **[Logging](logging_types/)** | Logging system configuration | v1beta1 |
-| **[NodeAgent](node_agent_types/)** |  | v1beta1 |
+| **[_hugoNodeAgent](node_agent_types/)** |  | v1beta1 |
 | **[OutputSpec](output_types/)** | OutputSpec defines the desired state of Output | v1beta1 |
 | **[SyslogNGClusterFlow](syslogng_clusterflow_types/)** | SyslogNGClusterFlow is the Schema for the syslog-ng clusterflows API | v1beta1 |
 | **[SyslogNGClusterOutput](syslogng_clusteroutput_types/)** | SyslogNGClusterOutput is the Schema for the syslog-ng clusteroutputs API | v1beta1 |

--- a/docs/configuration/crds/v1beta1/clusterflow_types.md
+++ b/docs/configuration/crds/v1beta1/clusterflow_types.md
@@ -40,11 +40,7 @@ Default: -
 
 ## ClusterSelect
 
-### namespaces ([]string, optional) {#clusterselect-namespaces}
-
-Default: -
-
-### labels (map[string]string, optional) {#clusterselect-labels}
+### container_names ([]string, optional) {#clusterselect-container_names}
 
 Default: -
 
@@ -52,18 +48,18 @@ Default: -
 
 Default: -
 
-### container_names ([]string, optional) {#clusterselect-container_names}
+### labels (map[string]string, optional) {#clusterselect-labels}
+
+Default: -
+
+### namespaces ([]string, optional) {#clusterselect-namespaces}
 
 Default: -
 
 
 ## ClusterExclude
 
-### namespaces ([]string, optional) {#clusterexclude-namespaces}
-
-Default: -
-
-### labels (map[string]string, optional) {#clusterexclude-labels}
+### container_names ([]string, optional) {#clusterexclude-container_names}
 
 Default: -
 
@@ -71,7 +67,11 @@ Default: -
 
 Default: -
 
-### container_names ([]string, optional) {#clusterexclude-container_names}
+### labels (map[string]string, optional) {#clusterexclude-labels}
+
+Default: -
+
+### namespaces ([]string, optional) {#clusterexclude-namespaces}
 
 Default: -
 
@@ -80,21 +80,27 @@ Default: -
 
 ClusterFlowSpec is the Kubernetes spec for ClusterFlows
 
-### selectors (map[string]string, optional) {#clusterflowspec-selectors}
-
-Deprecated 
-
-Default: -
-
-### match ([]ClusterMatch, optional) {#clusterflowspec-match}
-
-Default: -
-
 ### filters ([]Filter, optional) {#clusterflowspec-filters}
 
 Default: -
 
+### flowLabel (string, optional) {#clusterflowspec-flowlabel}
+
+Default: -
+
+### globalOutputRefs ([]string, optional) {#clusterflowspec-globaloutputrefs}
+
+Default: -
+
+### includeLabelInRouter (*bool, optional) {#clusterflowspec-includelabelinrouter}
+
+Default: -
+
 ### loggingRef (string, optional) {#clusterflowspec-loggingref}
+
+Default: -
+
+### match ([]ClusterMatch, optional) {#clusterflowspec-match}
 
 Default: -
 
@@ -104,7 +110,9 @@ Deprecated
 
 Default: -
 
-### globalOutputRefs ([]string, optional) {#clusterflowspec-globaloutputrefs}
+### selectors (map[string]string, optional) {#clusterflowspec-selectors}
+
+Deprecated 
 
 Default: -
 
@@ -113,15 +121,15 @@ Default: -
 
 ClusterFlowList contains a list of ClusterFlow
 
+### items ([]ClusterFlow, required) {#clusterflowlist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#clusterflowlist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#clusterflowlist-metadata}
-
-Default: -
-
-### items ([]ClusterFlow, required) {#clusterflowlist-items}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/clusteroutput_types.md
+++ b/docs/configuration/crds/v1beta1/clusteroutput_types.md
@@ -29,11 +29,11 @@ Default: -
 
 ClusterOutputSpec contains Kubernetes spec for ClusterOutput
 
-###  (OutputSpec, required) {#clusteroutputspec-}
+### enabledNamespaces ([]string, optional) {#clusteroutputspec-enablednamespaces}
 
 Default: -
 
-### enabledNamespaces ([]string, optional) {#clusteroutputspec-enablednamespaces}
+###  (OutputSpec, required) {#clusteroutputspec-}
 
 Default: -
 
@@ -42,15 +42,15 @@ Default: -
 
 ClusterOutputList contains a list of ClusterOutput
 
+### items ([]ClusterOutput, required) {#clusteroutputlist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#clusteroutputlist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#clusteroutputlist-metadata}
-
-Default: -
-
-### items ([]ClusterOutput, required) {#clusteroutputlist-items}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/common_types.md
+++ b/docs/configuration/crds/v1beta1/common_types.md
@@ -33,7 +33,7 @@ Metrics defines the service monitor endpoints
 
 Default: -
 
-### timeout (string, optional) {#metrics-timeout}
+### path (string, optional) {#metrics-path}
 
 Default: -
 
@@ -41,7 +41,11 @@ Default: -
 
 Default: -
 
-### path (string, optional) {#metrics-path}
+### prometheusAnnotations (bool, optional) {#metrics-prometheusannotations}
+
+Default: -
+
+### prometheusRules (bool, optional) {#metrics-prometheusrules}
 
 Default: -
 
@@ -53,11 +57,7 @@ Default: -
 
 Default: -
 
-### prometheusAnnotations (bool, optional) {#metrics-prometheusannotations}
-
-Default: -
-
-### prometheusRules (bool, optional) {#metrics-prometheusrules}
+### timeout (string, optional) {#metrics-timeout}
 
 Default: -
 
@@ -87,11 +87,11 @@ Default: -
 
 Default: -
 
-### relabelings ([]*v1.RelabelConfig, optional) {#servicemonitorconfig-relabelings}
+### metricRelabelings ([]*v1.RelabelConfig, optional) {#servicemonitorconfig-metricrelabelings}
 
 Default: -
 
-### metricRelabelings ([]*v1.RelabelConfig, optional) {#servicemonitorconfig-metricrelabelings}
+### relabelings ([]*v1.RelabelConfig, optional) {#servicemonitorconfig-relabelings}
 
 Default: -
 
@@ -106,13 +106,9 @@ Default: -
 
 ## Security
 
-Security defines Fluentd, Fluentbit deployment security properties
+Security defines Fluentd, FluentbitAgent deployment security properties
 
-### serviceAccount (string, optional) {#security-serviceaccount}
-
-Default: -
-
-### roleBasedAccessControlCreate (*bool, optional) {#security-rolebasedaccesscontrolcreate}
+### podSecurityContext (*corev1.PodSecurityContext, optional) {#security-podsecuritycontext}
 
 Default: -
 
@@ -120,11 +116,15 @@ Default: -
 
 Default: -
 
+### roleBasedAccessControlCreate (*bool, optional) {#security-rolebasedaccesscontrolcreate}
+
+Default: -
+
 ### securityContext (*corev1.SecurityContext, optional) {#security-securitycontext}
 
 Default: -
 
-### podSecurityContext (*corev1.PodSecurityContext, optional) {#security-podsecuritycontext}
+### serviceAccount (string, optional) {#security-serviceaccount}
 
 Default: -
 
@@ -151,11 +151,11 @@ Default: -
 
 Default: -
 
-### initialDelaySeconds (int32, optional) {#readinessdefaultcheck-initialdelayseconds}
+### failureThreshold (int32, optional) {#readinessdefaultcheck-failurethreshold}
 
 Default: -
 
-### timeoutSeconds (int32, optional) {#readinessdefaultcheck-timeoutseconds}
+### initialDelaySeconds (int32, optional) {#readinessdefaultcheck-initialdelayseconds}
 
 Default: -
 
@@ -167,7 +167,7 @@ Default: -
 
 Default: -
 
-### failureThreshold (int32, optional) {#readinessdefaultcheck-failurethreshold}
+### timeoutSeconds (int32, optional) {#readinessdefaultcheck-timeoutseconds}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/flow_types.md
+++ b/docs/configuration/crds/v1beta1/flow_types.md
@@ -8,21 +8,31 @@ generated_file: true
 
 FlowSpec is the Kubernetes spec for Flows
 
-### selectors (map[string]string, optional) {#flowspec-selectors}
-
-Deprecated 
-
-Default: -
-
-### match ([]Match, optional) {#flowspec-match}
-
-Default: -
-
 ### filters ([]Filter, optional) {#flowspec-filters}
 
 Default: -
 
+### flowLabel (string, optional) {#flowspec-flowlabel}
+
+Default: -
+
+### globalOutputRefs ([]string, optional) {#flowspec-globaloutputrefs}
+
+Default: -
+
+### includeLabelInRouter (*bool, optional) {#flowspec-includelabelinrouter}
+
+Default: -
+
+### localOutputRefs ([]string, optional) {#flowspec-localoutputrefs}
+
+Default: -
+
 ### loggingRef (string, optional) {#flowspec-loggingref}
+
+Default: -
+
+### match ([]Match, optional) {#flowspec-match}
 
 Default: -
 
@@ -32,29 +42,27 @@ Deprecated
 
 Default: -
 
-### globalOutputRefs ([]string, optional) {#flowspec-globaloutputrefs}
+### selectors (map[string]string, optional) {#flowspec-selectors}
 
-Default: -
-
-### localOutputRefs ([]string, optional) {#flowspec-localoutputrefs}
+Deprecated 
 
 Default: -
 
 
 ## Match
 
-### select (*Select, optional) {#match-select}
+### exclude (*Exclude, optional) {#match-exclude}
 
 Default: -
 
-### exclude (*Exclude, optional) {#match-exclude}
+### select (*Select, optional) {#match-select}
 
 Default: -
 
 
 ## Select
 
-### labels (map[string]string, optional) {#select-labels}
+### container_names ([]string, optional) {#select-container_names}
 
 Default: -
 
@@ -62,14 +70,14 @@ Default: -
 
 Default: -
 
-### container_names ([]string, optional) {#select-container_names}
+### labels (map[string]string, optional) {#select-labels}
 
 Default: -
 
 
 ## Exclude
 
-### labels (map[string]string, optional) {#exclude-labels}
+### container_names ([]string, optional) {#exclude-container_names}
 
 Default: -
 
@@ -77,7 +85,7 @@ Default: -
 
 Default: -
 
-### container_names ([]string, optional) {#exclude-container_names}
+### labels (map[string]string, optional) {#exclude-labels}
 
 Default: -
 
@@ -86,15 +94,7 @@ Default: -
 
 Filter definition for FlowSpec
 
-### stdout (*filter.StdOutFilterConfig, optional) {#filter-stdout}
-
-Default: -
-
-### parser (*filter.ParserConfig, optional) {#filter-parser}
-
-Default: -
-
-### tag_normaliser (*filter.TagNormaliser, optional) {#filter-tag_normaliser}
+### concat (*filter.Concat, optional) {#filter-concat}
 
 Default: -
 
@@ -102,43 +102,11 @@ Default: -
 
 Default: -
 
-### elasticsearch_genid (*filter.ElasticsearchGenId, optional) {#filter-elasticsearch_genid}
-
-Default: -
-
-### record_transformer (*filter.RecordTransformer, optional) {#filter-record_transformer}
-
-Default: -
-
-### record_modifier (*filter.RecordModifier, optional) {#filter-record_modifier}
-
-Default: -
-
-### geoip (*filter.GeoIP, optional) {#filter-geoip}
-
-Default: -
-
-### concat (*filter.Concat, optional) {#filter-concat}
-
-Default: -
-
 ### detectExceptions (*filter.DetectExceptions, optional) {#filter-detectexceptions}
 
 Default: -
 
-### grep (*filter.GrepConfig, optional) {#filter-grep}
-
-Default: -
-
-### prometheus (*filter.PrometheusConfig, optional) {#filter-prometheus}
-
-Default: -
-
-### throttle (*filter.Throttle, optional) {#filter-throttle}
-
-Default: -
-
-### sumologic (*filter.SumoLogic, optional) {#filter-sumologic}
+### elasticsearch_genid (*filter.ElasticsearchGenId, optional) {#filter-elasticsearch_genid}
 
 Default: -
 
@@ -146,7 +114,47 @@ Default: -
 
 Default: -
 
+### geoip (*filter.GeoIP, optional) {#filter-geoip}
+
+Default: -
+
+### grep (*filter.GrepConfig, optional) {#filter-grep}
+
+Default: -
+
 ### kube_events_timestamp (*filter.KubeEventsTimestampConfig, optional) {#filter-kube_events_timestamp}
+
+Default: -
+
+### parser (*filter.ParserConfig, optional) {#filter-parser}
+
+Default: -
+
+### prometheus (*filter.PrometheusConfig, optional) {#filter-prometheus}
+
+Default: -
+
+### record_modifier (*filter.RecordModifier, optional) {#filter-record_modifier}
+
+Default: -
+
+### record_transformer (*filter.RecordTransformer, optional) {#filter-record_transformer}
+
+Default: -
+
+### sumologic (*filter.SumoLogic, optional) {#filter-sumologic}
+
+Default: -
+
+### stdout (*filter.StdOutFilterConfig, optional) {#filter-stdout}
+
+Default: -
+
+### tag_normaliser (*filter.TagNormaliser, optional) {#filter-tag_normaliser}
+
+Default: -
+
+### throttle (*filter.Throttle, optional) {#filter-throttle}
 
 Default: -
 
@@ -193,15 +201,15 @@ Default: -
 
 FlowList contains a list of Flow
 
+### items ([]Flow, required) {#flowlist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#flowlist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#flowlist-metadata}
-
-Default: -
-
-### items ([]Flow, required) {#flowlist-items}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/fluentbit_types.md
+++ b/docs/configuration/crds/v1beta1/fluentbit_types.md
@@ -4,11 +4,49 @@ weight: 200
 generated_file: true
 ---
 
+## FluentbitAgent
+
+FluentbitAgent is the Schema for the loggings API
+
+###  (metav1.TypeMeta, required) {#fluentbitagent-}
+
+Default: -
+
+### metadata (metav1.ObjectMeta, optional) {#fluentbitagent-metadata}
+
+Default: -
+
+### spec (FluentbitSpec, optional) {#fluentbitagent-spec}
+
+Default: -
+
+### status (FluentbitStatus, optional) {#fluentbitagent-status}
+
+Default: -
+
+
+## FluentbitAgentList
+
+FluentbitAgentList contains a list of FluentbitAgent
+
+###  (metav1.TypeMeta, required) {#fluentbitagentlist-}
+
+Default: -
+
+### metadata (metav1.ListMeta, optional) {#fluentbitagentlist-metadata}
+
+Default: -
+
+### items ([]FluentbitAgent, required) {#fluentbitagentlist-items}
+
+Default: -
+
+
 ## FluentbitSpec
 
-FluentbitSpec defines the desired state of Fluentbit
+FluentbitSpec defines the desired state of FluentbitAgent
 
-### daemonsetAnnotations (map[string]string, optional) {#fluentbitspec-daemonsetannotations}
+### affinity (*corev1.Affinity, optional) {#fluentbitspec-affinity}
 
 Default: -
 
@@ -16,7 +54,63 @@ Default: -
 
 Default: -
 
-### labels (map[string]string, optional) {#fluentbitspec-labels}
+### bufferStorage (BufferStorage, optional) {#fluentbitspec-bufferstorage}
+
+Default: -
+
+### bufferStorageVolume (volume.KubernetesVolume, optional) {#fluentbitspec-bufferstoragevolume}
+
+[volume.KubernetesVolume](https://github.com/cisco-open/operator-tools/tree/master/docs/types) 
+
+Default: -
+
+### bufferVolumeArgs ([]string, optional) {#fluentbitspec-buffervolumeargs}
+
+Default: -
+
+### bufferVolumeImage (ImageSpec, optional) {#fluentbitspec-buffervolumeimage}
+
+Default: -
+
+### bufferVolumeMetrics (*Metrics, optional) {#fluentbitspec-buffervolumemetrics}
+
+Default: -
+
+### customParsers (string, optional) {#fluentbitspec-customparsers}
+
+Specify a custom parser file to load in addition to the default parsers file. It must be a valid key in the configmap specified by customConfig 
+
+Default: -
+
+### coroStackSize (int32, optional) {#fluentbitspec-corostacksize}
+
+Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer. Do not change the default value of this parameter unless you know what you are doing. (default: 24576) 
+
+Default: 24576
+
+### customConfigSecret (string, optional) {#fluentbitspec-customconfigsecret}
+
+Default: -
+
+### daemonsetAnnotations (map[string]string, optional) {#fluentbitspec-daemonsetannotations}
+
+Default: -
+
+### disableKubernetesFilter (*bool, optional) {#fluentbitspec-disablekubernetesfilter}
+
+Disable Kubernetes metadata filter 
+
+Default: -
+
+### dnsPolicy (corev1.DNSPolicy, optional) {#fluentbitspec-dnspolicy}
+
+Default: -
+
+### dnsConfig (*corev1.PodDNSConfig, optional) {#fluentbitspec-dnsconfig}
+
+Default: -
+
+### enableUpstream (bool, optional) {#fluentbitspec-enableupstream}
 
 Default: -
 
@@ -24,19 +118,21 @@ Default: -
 
 Default: -
 
-### image (ImageSpec, optional) {#fluentbitspec-image}
+### extraVolumeMounts ([]*VolumeMount, optional) {#fluentbitspec-extravolumemounts}
 
 Default: -
 
-### tls (*FluentbitTLS, optional) {#fluentbitspec-tls}
+### filterAws (*FilterAws, optional) {#fluentbitspec-filteraws}
 
 Default: -
 
-### targetHost (string, optional) {#fluentbitspec-targethost}
+### filterKubernetes (FilterKubernetes, optional) {#fluentbitspec-filterkubernetes}
+
+Parameters for Kubernetes metadata filter 
 
 Default: -
 
-### targetPort (int32, optional) {#fluentbitspec-targetport}
+### filterModify ([]FilterModify, optional) {#fluentbitspec-filtermodify}
 
 Default: -
 
@@ -46,11 +142,45 @@ Set the flush time in seconds.nanoseconds. The engine loop uses a Flush timeout 
 
 Default: 1
 
+### forwardOptions (*ForwardOptions, optional) {#fluentbitspec-forwardoptions}
+
+Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit  
+
+Default:  5
+
 ### grace (int32, optional) {#fluentbitspec-grace}
 
-Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit (default: 5) 
-
 Default: 5
+
+### HostNetwork (bool, optional) {#fluentbitspec-hostnetwork}
+
+Default: -
+
+### image (ImageSpec, optional) {#fluentbitspec-image}
+
+Default: -
+
+### inputTail (InputTail, optional) {#fluentbitspec-inputtail}
+
+Default: -
+
+### labels (map[string]string, optional) {#fluentbitspec-labels}
+
+Deprecated, use inputTail.parser 
+
+Default: -
+
+### livenessProbe (*corev1.Probe, optional) {#fluentbitspec-livenessprobe}
+
+Default: -
+
+### livenessDefaultCheck (bool, optional) {#fluentbitspec-livenessdefaultcheck}
+
+Default: -
+
+### loggingRef (string, optional) {#fluentbitspec-loggingref}
+
+Default: -
 
 ### logLevel (string, optional) {#fluentbitspec-loglevel}
 
@@ -58,17 +188,15 @@ Set the logging verbosity level. Allowed values are: error, warn, info, debug an
 
 Default: info
 
-### coroStackSize (int32, optional) {#fluentbitspec-corostacksize}
-
-Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer. Do not change the default value of this parameter unless you know what you are doing. (default: 24576) 
-
-Default: 24576
-
-### resources (corev1.ResourceRequirements, optional) {#fluentbitspec-resources}
+### metrics (*Metrics, optional) {#fluentbitspec-metrics}
 
 Default: -
 
-### tolerations ([]corev1.Toleration, optional) {#fluentbitspec-tolerations}
+### mountPath (string, optional) {#fluentbitspec-mountpath}
+
+Default: -
+
+### network (*FluentbitNetwork, optional) {#fluentbitspec-network}
 
 Default: -
 
@@ -76,15 +204,7 @@ Default: -
 
 Default: -
 
-### affinity (*corev1.Affinity, optional) {#fluentbitspec-affinity}
-
-Default: -
-
-### metrics (*Metrics, optional) {#fluentbitspec-metrics}
-
-Default: -
-
-### security (*Security, optional) {#fluentbitspec-security}
+### parser (string, optional) {#fluentbitspec-parser}
 
 Default: -
 
@@ -100,79 +220,7 @@ Deprecated, use positiondb
 
 Default: -
 
-### mountPath (string, optional) {#fluentbitspec-mountpath}
-
-Default: -
-
-### extraVolumeMounts ([]*VolumeMount, optional) {#fluentbitspec-extravolumemounts}
-
-Default: -
-
-### inputTail (InputTail, optional) {#fluentbitspec-inputtail}
-
-Default: -
-
-### filterAws (*FilterAws, optional) {#fluentbitspec-filteraws}
-
-Default: -
-
-### filterModify ([]FilterModify, optional) {#fluentbitspec-filtermodify}
-
-Default: -
-
-### parser (string, optional) {#fluentbitspec-parser}
-
-Deprecated, use inputTail.parser 
-
-Default: -
-
-### filterKubernetes (FilterKubernetes, optional) {#fluentbitspec-filterkubernetes}
-
-Parameters for Kubernetes metadata filter 
-
-Default: -
-
-### disableKubernetesFilter (*bool, optional) {#fluentbitspec-disablekubernetesfilter}
-
-Disable Kubernetes metadata filter 
-
-Default: -
-
-### bufferStorage (BufferStorage, optional) {#fluentbitspec-bufferstorage}
-
-Default: -
-
-### bufferStorageVolume (volume.KubernetesVolume, optional) {#fluentbitspec-bufferstoragevolume}
-
-[volume.KubernetesVolume](https://github.com/cisco-open/operator-tools/tree/master/docs/types) 
-
-Default: -
-
-### bufferVolumeMetrics (*Metrics, optional) {#fluentbitspec-buffervolumemetrics}
-
-Default: -
-
-### bufferVolumeImage (ImageSpec, optional) {#fluentbitspec-buffervolumeimage}
-
-Default: -
-
-### bufferVolumeArgs ([]string, optional) {#fluentbitspec-buffervolumeargs}
-
-Default: -
-
-### customConfigSecret (string, optional) {#fluentbitspec-customconfigsecret}
-
-Default: -
-
 ### podPriorityClassName (string, optional) {#fluentbitspec-podpriorityclassname}
-
-Default: -
-
-### livenessProbe (*corev1.Probe, optional) {#fluentbitspec-livenessprobe}
-
-Default: -
-
-### livenessDefaultCheck (bool, optional) {#fluentbitspec-livenessdefaultcheck}
 
 Default: -
 
@@ -180,15 +228,11 @@ Default: -
 
 Default: -
 
-### network (*FluentbitNetwork, optional) {#fluentbitspec-network}
+### resources (corev1.ResourceRequirements, optional) {#fluentbitspec-resources}
 
 Default: -
 
-### forwardOptions (*ForwardOptions, optional) {#fluentbitspec-forwardoptions}
-
-Default: -
-
-### enableUpstream (bool, optional) {#fluentbitspec-enableupstream}
+### security (*Security, optional) {#fluentbitspec-security}
 
 Default: -
 
@@ -196,21 +240,34 @@ Default: -
 
 Default: -
 
-### dnsPolicy (corev1.DNSPolicy, optional) {#fluentbitspec-dnspolicy}
-
-Default: -
-
-### dnsConfig (*corev1.PodDNSConfig, optional) {#fluentbitspec-dnsconfig}
-
-Default: -
-
-### HostNetwork (bool, optional) {#fluentbitspec-hostnetwork}
-
-Default: -
-
 ### syslogng_output (*FluentbitTCPOutput, optional) {#fluentbitspec-syslogng_output}
 
 Default: -
+
+### targetHost (string, optional) {#fluentbitspec-targethost}
+
+Default: -
+
+### targetPort (int32, optional) {#fluentbitspec-targetport}
+
+Default: -
+
+### tls (*FluentbitTLS, optional) {#fluentbitspec-tls}
+
+Default: -
+
+### tolerations ([]corev1.Toleration, optional) {#fluentbitspec-tolerations}
+
+Default: -
+
+### updateStrategy (appsv1.DaemonSetUpdateStrategy, optional) {#fluentbitspec-updatestrategy}
+
+Default: -
+
+
+## FluentbitStatus
+
+FluentbitStatus defines the resource status for FluentbitAgent
 
 
 ## FluentbitTLS
@@ -333,13 +390,7 @@ Default: 5M
 
 ## InputTail
 
-InputTail defines Fluentbit tail input configuration The tail input plugin allows to monitor one or several text files. It has a similar behavior like tail -f shell command.
-
-### storage.type (string, optional) {#inputtail-storage.type}
-
-Specify the buffering mechanism to use. It can be memory or filesystem.  
-
-Default: memory
+InputTail defines FluentbitAgent tail input configuration The tail input plugin allows to monitor one or several text files. It has a similar behavior like tail -f shell command.
 
 ### Buffer_Chunk_Size (string, optional) {#inputtail-buffer_chunk_size}
 
@@ -352,54 +403,6 @@ Default: 32k
 Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines), this value is used to restrict how much the memory buffer can grow. If reading a file exceed this limit, the file is removed from the monitored file list. The value must be according to the Unit Size specification.  
 
 Default: Buffer_Chunk_Size
-
-### Path (string, optional) {#inputtail-path}
-
-Pattern specifying a specific log files or multiple ones through the use of common wildcards. 
-
-Default: -
-
-### Path_Key (string, optional) {#inputtail-path_key}
-
-If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map. 
-
-Default: -
-
-### Exclude_Path (string, optional) {#inputtail-exclude_path}
-
-Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip 
-
-Default: -
-
-### Read_From_Head (bool, optional) {#inputtail-read_from_head}
-
-For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail. 
-
-Default: -
-
-### Refresh_Interval (string, optional) {#inputtail-refresh_interval}
-
-The interval of refreshing the list of watched files in seconds.  
-
-Default: 60
-
-### Rotate_Wait (string, optional) {#inputtail-rotate_wait}
-
-Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed.  
-
-Default: 5
-
-### Ignore_Older (string, optional) {#inputtail-ignore_older}
-
-Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax. Default behavior is to read all specified files. 
-
-Default: -
-
-### Skip_Long_Lines (string, optional) {#inputtail-skip_long_lines}
-
-When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file. Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.  
-
-Default: Off
 
 ### DB (*string, optional) {#inputtail-db}
 
@@ -425,15 +428,33 @@ sets the journal mode for databases (WAL). Enabling WAL provides higher performa
 
 Default:  WAL
 
-### Mem_Buf_Limit (string, optional) {#inputtail-mem_buf_limit}
+### Docker_Mode (string, optional) {#inputtail-docker_mode}
 
-Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes. 
+If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline.  
+
+Default: Off
+
+### Docker_Mode_Flush (string, optional) {#inputtail-docker_mode_flush}
+
+Wait period time in seconds to flush queued unfinished split lines.  
+
+Default: 4
+
+### Docker_Mode_Parser (string, optional) {#inputtail-docker_mode_parser}
+
+Specify an optional parser for the first line of the docker multiline mode. 
 
 Default: -
 
-### Parser (string, optional) {#inputtail-parser}
+### Exclude_Path (string, optional) {#inputtail-exclude_path}
 
-Specify the name of a parser to interpret the entry as a structured message. 
+Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip 
+
+Default: -
+
+### Ignore_Older (string, optional) {#inputtail-ignore_older}
+
+Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax. Default behavior is to read all specified files. 
 
 Default: -
 
@@ -443,15 +464,9 @@ When a message is unstructured (no parser applied), it's appended as a string un
 
 Default: log
 
-### Tag (string, optional) {#inputtail-tag}
+### Mem_Buf_Limit (string, optional) {#inputtail-mem_buf_limit}
 
-Set a tag (with regex-extract fields) that will be placed on lines read. 
-
-Default: -
-
-### Tag_Regex (string, optional) {#inputtail-tag_regex}
-
-Set a regex to extract fields from the file. 
+Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes. 
 
 Default: -
 
@@ -467,6 +482,18 @@ Wait period time in seconds to process queued multiline messages
 
 Default: 4
 
+### multiline.parser ([]string, optional) {#inputtail-multiline.parser}
+
+Specify one or multiple parser definitions to apply to the content. Part of the new Multiline Core support in 1.8  
+
+Default:  ""
+
+### Parser (string, optional) {#inputtail-parser}
+
+Specify the name of a parser to interpret the entry as a structured message. 
+
+Default: -
+
 ### Parser_Firstline (string, optional) {#inputtail-parser_firstline}
 
 Name of the parser that machs the beginning of a multiline message. Note that the regular expression defined in the parser must include a group name (named capture) 
@@ -479,46 +506,118 @@ Optional-extra parser to interpret and structure multiline entries. This option 
 
 Default: -
 
-### Docker_Mode (string, optional) {#inputtail-docker_mode}
+### Path (string, optional) {#inputtail-path}
 
-If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline.  
-
-Default: Off
-
-### Docker_Mode_Parser (string, optional) {#inputtail-docker_mode_parser}
-
-Specify an optional parser for the first line of the docker multiline mode. 
+Pattern specifying a specific log files or multiple ones through the use of common wildcards. 
 
 Default: -
 
-### Docker_Mode_Flush (string, optional) {#inputtail-docker_mode_flush}
+### Path_Key (string, optional) {#inputtail-path_key}
 
-Wait period time in seconds to flush queued unfinished split lines.  
+If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map. 
 
-Default: 4
+Default: -
 
-### multiline.parser ([]string, optional) {#inputtail-multiline.parser}
+### Read_From_Head (bool, optional) {#inputtail-read_from_head}
 
-Specify one or multiple parser definitions to apply to the content. Part of the new Multiline Core support in 1.8  
+For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail. 
 
-Default:  ""
+Default: -
+
+### Refresh_Interval (string, optional) {#inputtail-refresh_interval}
+
+The interval of refreshing the list of watched files in seconds.  
+
+Default: 60
+
+### Rotate_Wait (string, optional) {#inputtail-rotate_wait}
+
+Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed.  
+
+Default: 5
+
+### Skip_Long_Lines (string, optional) {#inputtail-skip_long_lines}
+
+When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file. Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size.  
+
+Default: Off
+
+### storage.type (string, optional) {#inputtail-storage.type}
+
+Specify the buffering mechanism to use. It can be memory or filesystem.  
+
+Default: memory
+
+### Tag (string, optional) {#inputtail-tag}
+
+Set a tag (with regex-extract fields) that will be placed on lines read. 
+
+Default: -
+
+### Tag_Regex (string, optional) {#inputtail-tag_regex}
+
+Set a regex to extract fields from the file. 
+
+Default: -
 
 
 ## FilterKubernetes
 
 FilterKubernetes Fluent Bit Kubernetes Filter allows to enrich your log files with Kubernetes metadata.
 
-### Match (string, optional) {#filterkubernetes-match}
+### Annotations (string, optional) {#filterkubernetes-annotations}
 
-Match filtered records (default:kube.*) 
+Include Kubernetes resource annotations in the extra metadata.  
 
-Default: kubernetes.*
+Default: On
 
 ### Buffer_Size (string, optional) {#filterkubernetes-buffer_size}
 
 Set the buffer size for HTTP client when reading responses from Kubernetes API server. The value must be according to the Unit Size specification. A value of 0 results in no limit, and the buffer will expand as-needed. Note that if pod specifications exceed the buffer limit, the API response will be discarded when retrieving metadata, and some kubernetes metadata will fail to be injected to the logs. If this value is empty we will set it "0".  
 
 Default: "0"
+
+### Cache_Use_Docker_Id (string, optional) {#filterkubernetes-cache_use_docker_id}
+
+When enabled, metadata will be fetched from K8s when docker_id is changed.  
+
+Default: Off
+
+### DNS_Retries (string, optional) {#filterkubernetes-dns_retries}
+
+DNS lookup retries N times until the network start working  
+
+Default: 6
+
+### DNS_Wait_Time (string, optional) {#filterkubernetes-dns_wait_time}
+
+DNS lookup interval between network status checks  
+
+Default: 30
+
+### Dummy_Meta (string, optional) {#filterkubernetes-dummy_meta}
+
+If set, use dummy-meta data (for test/dev purposes)  
+
+Default: Off
+
+### K8S-Logging.Parser (string, optional) {#filterkubernetes-k8s-logging.parser}
+
+Allow Kubernetes Pods to suggest a pre-defined Parser (read more about it in Kubernetes Annotations section)  
+
+Default: Off
+
+### K8S-Logging.Exclude (string, optional) {#filterkubernetes-k8s-logging.exclude}
+
+Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section).  
+
+Default: On
+
+### Keep_Log (string, optional) {#filterkubernetes-keep_log}
+
+When Keep_Log is disabled, the log field is removed from the incoming message once it has been successfully merged (Merge_Log must be enabled as well).  
+
+Default: On
 
 ### Kube_URL (string, optional) {#filterkubernetes-kube_url}
 
@@ -538,17 +637,53 @@ Absolute path to scan for certificate files
 
 Default: -
 
-### Kube_Token_File (string, optional) {#filterkubernetes-kube_token_file}
+### Kubelet_Port (string, optional) {#filterkubernetes-kubelet_port}
 
-Token file  (default:/var/run/secrets/kubernetes.io/serviceaccount/token) 
+kubelet port using for HTTP request, this only works when Use_Kubelet  set to On  
 
-Default: /var/run/secrets/kubernetes.io/serviceaccount/token
+Default: 10250
+
+### Kube_Meta_Cache_TTL (string, optional) {#filterkubernetes-kube_meta_cache_ttl}
+
+Configurable TTL for K8s cached metadata. By default, it is set to 0 which means TTL for cache entries is disabled and cache entries are evicted at random when capacity is reached. In order to enable this option, you should set the number to a time interval. For example, set this value to 60 or 60s and cache entries which have been created more than 60s will be evicted.  
+
+Default: 0
 
 ### Kube_Tag_Prefix (string, optional) {#filterkubernetes-kube_tag_prefix}
 
 When the source records comes from Tail input plugin, this option allows to specify what's the prefix used in Tail configuration. (default:kube.var.log.containers.) 
 
 Default: kubernetes.var.log.containers
+
+### Kube_meta_preload_cache_dir (string, optional) {#filterkubernetes-kube_meta_preload_cache_dir}
+
+If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory, named as namespace-pod.meta 
+
+Default: -
+
+### Kube_Token_File (string, optional) {#filterkubernetes-kube_token_file}
+
+Token file  (default:/var/run/secrets/kubernetes.io/serviceaccount/token) 
+
+Default: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+### Kube_Token_TTL (string, optional) {#filterkubernetes-kube_token_ttl}
+
+Token TTL configurable 'time to live' for the K8s token. By default, it is set to 600 seconds. After this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.  (default:"600") 
+
+Default: 600
+
+### Labels (string, optional) {#filterkubernetes-labels}
+
+Include Kubernetes resource labels in the extra metadata.  
+
+Default: On
+
+### Match (string, optional) {#filterkubernetes-match}
+
+Match filtered records (default:kube.*) 
+
+Default: kubernetes.*
 
 ### Merge_Log (string, optional) {#filterkubernetes-merge_log}
 
@@ -574,11 +709,11 @@ Optional parser name to specify how to parse the data contained in the log key. 
 
 Default: -
 
-### Keep_Log (string, optional) {#filterkubernetes-keep_log}
+### Regex_Parser (string, optional) {#filterkubernetes-regex_parser}
 
-When Keep_Log is disabled, the log field is removed from the incoming message once it has been successfully merged (Merge_Log must be enabled as well).  
+Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id. The parser must be registered in a parsers file (refer to parser filter-kube-test as an example). 
 
-Default: On
+Default: -
 
 ### tls.debug (string, optional) {#filterkubernetes-tls.debug}
 
@@ -598,88 +733,28 @@ When enabled, the filter reads logs coming in Journald format.
 
 Default: Off
 
-### Cache_Use_Docker_Id (string, optional) {#filterkubernetes-cache_use_docker_id}
-
-When enabled, metadata will be fetched from K8s when docker_id is changed.  
-
-Default: Off
-
-### Regex_Parser (string, optional) {#filterkubernetes-regex_parser}
-
-Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id. The parser must be registered in a parsers file (refer to parser filter-kube-test as an example). 
-
-Default: -
-
-### K8S-Logging.Parser (string, optional) {#filterkubernetes-k8s-logging.parser}
-
-Allow Kubernetes Pods to suggest a pre-defined Parser (read more about it in Kubernetes Annotations section)  
-
-Default: Off
-
-### K8S-Logging.Exclude (string, optional) {#filterkubernetes-k8s-logging.exclude}
-
-Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section).  
-
-Default: Off
-
-### Labels (string, optional) {#filterkubernetes-labels}
-
-Include Kubernetes resource labels in the extra metadata.  
-
-Default: On
-
-### Annotations (string, optional) {#filterkubernetes-annotations}
-
-Include Kubernetes resource annotations in the extra metadata.  
-
-Default: On
-
-### Kube_meta_preload_cache_dir (string, optional) {#filterkubernetes-kube_meta_preload_cache_dir}
-
-If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory, named as namespace-pod.meta 
-
-Default: -
-
-### Dummy_Meta (string, optional) {#filterkubernetes-dummy_meta}
-
-If set, use dummy-meta data (for test/dev purposes)  
-
-Default: Off
-
-### DNS_Retries (string, optional) {#filterkubernetes-dns_retries}
-
-DNS lookup retries N times until the network start working  
-
-Default: 6
-
-### DNS_Wait_Time (string, optional) {#filterkubernetes-dns_wait_time}
-
-DNS lookup interval between network status checks  
-
-Default: 30
-
 ### Use_Kubelet (string, optional) {#filterkubernetes-use_kubelet}
 
 This is an optional feature flag to get metadata information from kubelet instead of calling Kube Server API to enhance the log.  
 
 Default: Off
 
-### Kubelet_Port (string, optional) {#filterkubernetes-kubelet_port}
-
-kubelet port using for HTTP request, this only works when Use_Kubelet  set to On  
-
-Default: 10250
-
 
 ## FilterAws
 
 FilterAws The AWS Filter Enriches logs with AWS Metadata.
 
-### imds_version (string, optional) {#filteraws-imds_version}
+### account_id (*bool, optional) {#filteraws-account_id}
 
-Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2' (default). 
+The account ID for current EC2 instance. (default:false) 
 
-Default: v2
+Default: false
+
+### ami_id (*bool, optional) {#filteraws-ami_id}
+
+The EC2 instance image id. (default:false) 
+
+Default: false
 
 ### az (*bool, optional) {#filteraws-az}
 
@@ -699,27 +774,27 @@ The EC2 instance type. (default:false)
 
 Default: false
 
-### private_ip (*bool, optional) {#filteraws-private_ip}
-
-The EC2 instance private ip. (default:false) 
-
-Default: false
-
-### ami_id (*bool, optional) {#filteraws-ami_id}
-
-The EC2 instance image id. (default:false) 
-
-Default: false
-
-### account_id (*bool, optional) {#filteraws-account_id}
-
-The account ID for current EC2 instance. (default:false) 
-
-Default: false
-
 ### hostname (*bool, optional) {#filteraws-hostname}
 
 The hostname for current EC2 instance. (default:false) 
+
+Default: false
+
+### imds_version (string, optional) {#filteraws-imds_version}
+
+Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2' (default). 
+
+Default: v2
+
+### Match (string, optional) {#filteraws-match}
+
+Match filtered records (default:*) 
+
+Default: *
+
+### private_ip (*bool, optional) {#filteraws-private_ip}
+
+The EC2 instance private ip. (default:false) 
 
 Default: false
 
@@ -729,26 +804,20 @@ The VPC ID for current EC2 instance. (default:false)
 
 Default: false
 
-### Match (string, optional) {#filteraws-match}
-
-Match filtered records (default:*) 
-
-Default: *
-
 
 ## FilterModify
 
 FilterModify The Modify Filter plugin allows you to change records using rules and conditions.
 
-### rules ([]FilterModifyRule, optional) {#filtermodify-rules}
+### conditions ([]FilterModifyCondition, optional) {#filtermodify-conditions}
 
-Fluentbit Filter Modification Rule 
+FluentbitAgent Filter Modification Condition 
 
 Default: -
 
-### conditions ([]FilterModifyCondition, optional) {#filtermodify-conditions}
+### rules ([]FilterModifyRule, optional) {#filtermodify-rules}
 
-Fluentbit Filter Modification Condition 
+FluentbitAgent Filter Modification Rule 
 
 Default: -
 
@@ -757,45 +826,9 @@ Default: -
 
 FilterModifyRule The Modify Filter plugin allows you to change records using rules and conditions.
 
-### Set (*FilterKeyValue, optional) {#filtermodifyrule-set}
-
-Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten 
-
-Default: -
-
 ### Add (*FilterKeyValue, optional) {#filtermodifyrule-add}
 
 Add a key/value pair with key KEY and value VALUE if KEY does not exist 
-
-Default: -
-
-### Remove (*FilterKey, optional) {#filtermodifyrule-remove}
-
-Remove a key/value pair with key KEY if it exists 
-
-Default: -
-
-### Remove_wildcard (*FilterKey, optional) {#filtermodifyrule-remove_wildcard}
-
-Remove all key/value pairs with key matching wildcard KEY 
-
-Default: -
-
-### Remove_regex (*FilterKey, optional) {#filtermodifyrule-remove_regex}
-
-Remove all key/value pairs with key matching regexp KEY 
-
-Default: -
-
-### Rename (*FilterKeyValue, optional) {#filtermodifyrule-rename}
-
-Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist 
-
-Default: -
-
-### Hard_rename (*FilterKeyValue, optional) {#filtermodifyrule-hard_rename}
-
-Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists. If RENAMED_KEY already exists, this field is overwritten 
 
 Default: -
 
@@ -811,14 +844,50 @@ Copy a key/value pair with key KEY to COPIED_KEY if KEY exists. If COPIED_KEY al
 
 Default: -
 
+### Hard_rename (*FilterKeyValue, optional) {#filtermodifyrule-hard_rename}
+
+Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists. If RENAMED_KEY already exists, this field is overwritten 
+
+Default: -
+
+### Rename (*FilterKeyValue, optional) {#filtermodifyrule-rename}
+
+Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist 
+
+Default: -
+
+### Remove (*FilterKey, optional) {#filtermodifyrule-remove}
+
+Remove a key/value pair with key KEY if it exists 
+
+Default: -
+
+### Remove_regex (*FilterKey, optional) {#filtermodifyrule-remove_regex}
+
+Remove all key/value pairs with key matching regexp KEY 
+
+Default: -
+
+### Remove_wildcard (*FilterKey, optional) {#filtermodifyrule-remove_wildcard}
+
+Remove all key/value pairs with key matching wildcard KEY 
+
+Default: -
+
+### Set (*FilterKeyValue, optional) {#filtermodifyrule-set}
+
+Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten 
+
+Default: -
+
 
 ## FilterModifyCondition
 
 FilterModifyCondition The Modify Filter plugin allows you to change records using rules and conditions.
 
-### Key_exists (*FilterKey, optional) {#filtermodifycondition-key_exists}
+### A_key_matches (*FilterKey, optional) {#filtermodifycondition-a_key_matches}
 
-Is true if KEY exists 
+Is true if a key matches regex KEY 
 
 Default: -
 
@@ -828,21 +897,9 @@ Is true if KEY does not exist
 
 Default: -
 
-### A_key_matches (*FilterKey, optional) {#filtermodifycondition-a_key_matches}
+### Key_exists (*FilterKey, optional) {#filtermodifycondition-key_exists}
 
-Is true if a key matches regex KEY 
-
-Default: -
-
-### No_key_matches (*FilterKey, optional) {#filtermodifycondition-no_key_matches}
-
-Is true if no key matches regex KEY 
-
-Default: -
-
-### Key_value_equals (*FilterKeyValue, optional) {#filtermodifycondition-key_value_equals}
-
-Is true if KEY exists and its value is VALUE 
+Is true if KEY exists 
 
 Default: -
 
@@ -852,9 +909,9 @@ Is true if KEY exists and its value is not VALUE
 
 Default: -
 
-### Key_value_matches (*FilterKeyValue, optional) {#filtermodifycondition-key_value_matches}
+### Key_value_equals (*FilterKeyValue, optional) {#filtermodifycondition-key_value_equals}
 
-Is true if key KEY exists and its value matches VALUE 
+Is true if KEY exists and its value is VALUE 
 
 Default: -
 
@@ -864,15 +921,27 @@ Is true if key KEY exists and its value does not match VALUE
 
 Default: -
 
-### Matching_keys_have_matching_values (*FilterKeyValue, optional) {#filtermodifycondition-matching_keys_have_matching_values}
+### Key_value_matches (*FilterKeyValue, optional) {#filtermodifycondition-key_value_matches}
 
-Is true if all keys matching KEY have values that match VALUE 
+Is true if key KEY exists and its value matches VALUE 
 
 Default: -
 
 ### Matching_keys_do_not_have_matching_values (*FilterKeyValue, optional) {#filtermodifycondition-matching_keys_do_not_have_matching_values}
 
 Is true if all keys matching KEY have values that do not match VALUE 
+
+Default: -
+
+### Matching_keys_have_matching_values (*FilterKeyValue, optional) {#filtermodifycondition-matching_keys_have_matching_values}
+
+Is true if all keys matching KEY have values that match VALUE 
+
+Default: -
+
+### No_key_matches (*FilterKey, optional) {#filtermodifycondition-no_key_matches}
+
+Is true if no key matches regex KEY 
 
 Default: -
 
@@ -939,19 +1008,7 @@ Default: -
 
 ForwardOptions defines custom forward output plugin options, see https://docs.fluentbit.io/manual/pipeline/outputs/forward
 
-### Time_as_Integer (bool, optional) {#forwardoptions-time_as_integer}
-
-Default: -
-
-### Send_options (bool, optional) {#forwardoptions-send_options}
-
-Default: -
-
 ### Require_ack_response (bool, optional) {#forwardoptions-require_ack_response}
-
-Default: -
-
-### Tag (string, optional) {#forwardoptions-tag}
 
 Default: -
 
@@ -959,9 +1016,32 @@ Default: -
 
 Default: -
 
+### Send_options (bool, optional) {#forwardoptions-send_options}
+
+Default: -
+
 ### storage.total_limit_size (string, optional) {#forwardoptions-storage.total_limit_size}
 
 `storage.total_limit_size` Limit the maximum number of Chunks in the filesystem for the current output logical destination. 
+
+Default: -
+
+### Tag (string, optional) {#forwardoptions-tag}
+
+Default: -
+
+### Time_as_Integer (bool, optional) {#forwardoptions-time_as_integer}
+
+Default: -
+
+
+## FluentbitNameProvider
+
+### fluentbit (*FluentbitAgent, optional) {#fluentbitnameprovider-fluentbit}
+
+Default: -
+
+### logging (*Logging, optional) {#fluentbitnameprovider-logging}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/fluentd_types.md
+++ b/docs/configuration/crds/v1beta1/fluentd_types.md
@@ -8,7 +8,7 @@ generated_file: true
 
 FluentdSpec defines the desired state of Fluentd
 
-### statefulsetAnnotations (map[string]string, optional) {#fluentdspec-statefulsetannotations}
+### affinity (*corev1.Affinity, optional) {#fluentdspec-affinity}
 
 Default: -
 
@@ -16,107 +16,9 @@ Default: -
 
 Default: -
 
-### configCheckAnnotations (map[string]string, optional) {#fluentdspec-configcheckannotations}
-
-Default: -
-
-### labels (map[string]string, optional) {#fluentdspec-labels}
-
-Default: -
-
-### envVars ([]corev1.EnvVar, optional) {#fluentdspec-envvars}
-
-Default: -
-
-### tls (FluentdTLS, optional) {#fluentdspec-tls}
-
-Default: -
-
-### image (ImageSpec, optional) {#fluentdspec-image}
-
-Default: -
-
-### disablePvc (bool, optional) {#fluentdspec-disablepvc}
-
-Default: -
-
 ### bufferStorageVolume (volume.KubernetesVolume, optional) {#fluentdspec-bufferstoragevolume}
 
 BufferStorageVolume is by default configured as PVC using FluentdPvcSpec [volume.KubernetesVolume](https://github.com/cisco-open/operator-tools/tree/master/docs/types) 
-
-Default: -
-
-### extraVolumes ([]ExtraVolume, optional) {#fluentdspec-extravolumes}
-
-Default: -
-
-### fluentdPvcSpec (*volume.KubernetesVolume, optional) {#fluentdspec-fluentdpvcspec}
-
-Deprecated, use bufferStorageVolume 
-
-Default: -
-
-### volumeMountChmod (bool, optional) {#fluentdspec-volumemountchmod}
-
-Default: -
-
-### volumeModImage (ImageSpec, optional) {#fluentdspec-volumemodimage}
-
-Default: -
-
-### configReloaderImage (ImageSpec, optional) {#fluentdspec-configreloaderimage}
-
-Default: -
-
-### resources (corev1.ResourceRequirements, optional) {#fluentdspec-resources}
-
-Default: -
-
-### configCheckResources (corev1.ResourceRequirements, optional) {#fluentdspec-configcheckresources}
-
-Default: -
-
-### configReloaderResources (corev1.ResourceRequirements, optional) {#fluentdspec-configreloaderresources}
-
-Default: -
-
-### livenessProbe (*corev1.Probe, optional) {#fluentdspec-livenessprobe}
-
-Default: -
-
-### livenessDefaultCheck (bool, optional) {#fluentdspec-livenessdefaultcheck}
-
-Default: -
-
-### readinessProbe (*corev1.Probe, optional) {#fluentdspec-readinessprobe}
-
-Default: -
-
-### readinessDefaultCheck (ReadinessDefaultCheck, optional) {#fluentdspec-readinessdefaultcheck}
-
-Default: -
-
-### port (int32, optional) {#fluentdspec-port}
-
-Default: -
-
-### tolerations ([]corev1.Toleration, optional) {#fluentdspec-tolerations}
-
-Default: -
-
-### nodeSelector (map[string]string, optional) {#fluentdspec-nodeselector}
-
-Default: -
-
-### affinity (*corev1.Affinity, optional) {#fluentdspec-affinity}
-
-Default: -
-
-### topologySpreadConstraints ([]corev1.TopologySpreadConstraint, optional) {#fluentdspec-topologyspreadconstraints}
-
-Default: -
-
-### metrics (*Metrics, optional) {#fluentdspec-metrics}
 
 Default: -
 
@@ -132,35 +34,35 @@ Default: -
 
 Default: -
 
-### security (*Security, optional) {#fluentdspec-security}
+### configCheckAnnotations (map[string]string, optional) {#fluentdspec-configcheckannotations}
 
 Default: -
 
-### scaling (*FluentdScaling, optional) {#fluentdspec-scaling}
+### configReloaderImage (ImageSpec, optional) {#fluentdspec-configreloaderimage}
 
 Default: -
 
-### workers (int32, optional) {#fluentdspec-workers}
+### configCheckResources (corev1.ResourceRequirements, optional) {#fluentdspec-configcheckresources}
 
 Default: -
 
-### rootDir (string, optional) {#fluentdspec-rootdir}
+### configReloaderResources (corev1.ResourceRequirements, optional) {#fluentdspec-configreloaderresources}
 
 Default: -
 
-### logLevel (string, optional) {#fluentdspec-loglevel}
+### compressConfigFile (bool, optional) {#fluentdspec-compressconfigfile}
 
 Default: -
 
-### ignoreSameLogInterval (string, optional) {#fluentdspec-ignoresameloginterval}
-
-Ignore same log lines [more info]( https://docs.fluentd.org/deployment/logging#ignore_same_log_interval) 
+### disablePvc (bool, optional) {#fluentdspec-disablepvc}
 
 Default: -
 
-### ignoreRepeatedLogInterval (string, optional) {#fluentdspec-ignorerepeatedloginterval}
+### dnsPolicy (corev1.DNSPolicy, optional) {#fluentdspec-dnspolicy}
 
-Ignore repeated log lines [more info]( https://docs.fluentd.org/deployment/logging#ignore_repeated_log_interval) 
+Default: -
+
+### dnsConfig (*corev1.PodDNSConfig, optional) {#fluentdspec-dnsconfig}
 
 Default: -
 
@@ -170,7 +72,21 @@ Allows Time object in buffer's MessagePack serde [more info]( https://docs.fluen
 
 Default: -
 
-### podPriorityClassName (string, optional) {#fluentdspec-podpriorityclassname}
+### envVars ([]corev1.EnvVar, optional) {#fluentdspec-envvars}
+
+Default: -
+
+### extraArgs ([]string, optional) {#fluentdspec-extraargs}
+
+Default: -
+
+### extraVolumes ([]ExtraVolume, optional) {#fluentdspec-extravolumes}
+
+Default: -
+
+### fluentdPvcSpec (*volume.KubernetesVolume, optional) {#fluentdspec-fluentdpvcspec}
+
+Deprecated, use bufferStorageVolume 
 
 Default: -
 
@@ -188,34 +104,122 @@ Default: -
 
 Default: -
 
+### ignoreSameLogInterval (string, optional) {#fluentdspec-ignoresameloginterval}
+
+Ignore same log lines [more info]( https://docs.fluentd.org/deployment/logging#ignore_same_log_interval) 
+
+Default: -
+
+### ignoreRepeatedLogInterval (string, optional) {#fluentdspec-ignorerepeatedloginterval}
+
+Ignore repeated log lines [more info]( https://docs.fluentd.org/deployment/logging#ignore_repeated_log_interval) 
+
+Default: -
+
+### image (ImageSpec, optional) {#fluentdspec-image}
+
+Default: -
+
+### labels (map[string]string, optional) {#fluentdspec-labels}
+
+Default: -
+
+### livenessProbe (*corev1.Probe, optional) {#fluentdspec-livenessprobe}
+
+Default: -
+
+### livenessDefaultCheck (bool, optional) {#fluentdspec-livenessdefaultcheck}
+
+Default: -
+
+### logLevel (string, optional) {#fluentdspec-loglevel}
+
+Default: -
+
+### metrics (*Metrics, optional) {#fluentdspec-metrics}
+
+Default: -
+
+### nodeSelector (map[string]string, optional) {#fluentdspec-nodeselector}
+
+Default: -
+
+### podPriorityClassName (string, optional) {#fluentdspec-podpriorityclassname}
+
+Default: -
+
+### port (int32, optional) {#fluentdspec-port}
+
+Default: -
+
+### readinessProbe (*corev1.Probe, optional) {#fluentdspec-readinessprobe}
+
+Default: -
+
+### readinessDefaultCheck (ReadinessDefaultCheck, optional) {#fluentdspec-readinessdefaultcheck}
+
+Default: -
+
+### resources (corev1.ResourceRequirements, optional) {#fluentdspec-resources}
+
+Default: -
+
+### rootDir (string, optional) {#fluentdspec-rootdir}
+
+Default: -
+
+### scaling (*FluentdScaling, optional) {#fluentdspec-scaling}
+
+Default: -
+
+### security (*Security, optional) {#fluentdspec-security}
+
+Default: -
+
 ### serviceAccount (*typeoverride.ServiceAccount, optional) {#fluentdspec-serviceaccount}
 
 Default: -
 
-### dnsPolicy (corev1.DNSPolicy, optional) {#fluentdspec-dnspolicy}
+### statefulsetAnnotations (map[string]string, optional) {#fluentdspec-statefulsetannotations}
 
 Default: -
 
-### dnsConfig (*corev1.PodDNSConfig, optional) {#fluentdspec-dnsconfig}
+### tls (FluentdTLS, optional) {#fluentdspec-tls}
 
 Default: -
 
-### extraArgs ([]string, optional) {#fluentdspec-extraargs}
+### tolerations ([]corev1.Toleration, optional) {#fluentdspec-tolerations}
+
+Default: -
+
+### topologySpreadConstraints ([]corev1.TopologySpreadConstraint, optional) {#fluentdspec-topologyspreadconstraints}
+
+Default: -
+
+### volumeMountChmod (bool, optional) {#fluentdspec-volumemountchmod}
+
+Default: -
+
+### volumeModImage (ImageSpec, optional) {#fluentdspec-volumemodimage}
+
+Default: -
+
+### workers (int32, optional) {#fluentdspec-workers}
 
 Default: -
 
 
 ## FluentOutLogrotate
 
+### age (string, optional) {#fluentoutlogrotate-age}
+
+Default: -
+
 ### enabled (bool, required) {#fluentoutlogrotate-enabled}
 
 Default: -
 
 ### path (string, optional) {#fluentoutlogrotate-path}
-
-Default: -
-
-### age (string, optional) {#fluentoutlogrotate-age}
 
 Default: -
 
@@ -228,7 +232,7 @@ Default: -
 
 ExtraVolume defines the fluentd extra volumes
 
-### volumeName (string, optional) {#extravolume-volumename}
+### containerName (string, optional) {#extravolume-containername}
 
 Default: -
 
@@ -236,11 +240,11 @@ Default: -
 
 Default: -
 
-### containerName (string, optional) {#extravolume-containername}
+### volume (*volume.KubernetesVolume, optional) {#extravolume-volume}
 
 Default: -
 
-### volume (*volume.KubernetesVolume, optional) {#extravolume-volume}
+### volumeName (string, optional) {#extravolume-volumename}
 
 Default: -
 
@@ -249,7 +253,7 @@ Default: -
 
 FluentdScaling enables configuring the scaling behaviour of the fluentd statefulset
 
-### replicas (int, optional) {#fluentdscaling-replicas}
+### drain (FluentdDrainConfig, optional) {#fluentdscaling-drain}
 
 Default: -
 
@@ -257,7 +261,7 @@ Default: -
 
 Default: -
 
-### drain (FluentdDrainConfig, optional) {#fluentdscaling-drain}
+### replicas (int, optional) {#fluentdscaling-replicas}
 
 Default: -
 
@@ -283,15 +287,21 @@ Default: -
 
 FluentdDrainConfig enables configuring the drain behavior when scaling down the fluentd statefulset
 
+### annotations (map[string]string, optional) {#fluentddrainconfig-annotations}
+
+Container image to use for the drain watch sidecar 
+
+Default: -
+
 ### enabled (bool, optional) {#fluentddrainconfig-enabled}
 
 Should buffers on persistent volumes left after scaling down the statefulset be drained 
 
 Default: -
 
-### annotations (map[string]string, optional) {#fluentddrainconfig-annotations}
+### deleteVolume (bool, optional) {#fluentddrainconfig-deletevolume}
 
-Container image to use for the drain watch sidecar 
+Should persistent volume claims be deleted after draining is done 
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/logging_types.md
+++ b/docs/configuration/crds/v1beta1/logging_types.md
@@ -8,21 +8,45 @@ generated_file: true
 
 LoggingSpec defines the desired state of Logging
 
-### loggingRef (string, optional) {#loggingspec-loggingref}
+### allowClusterResourcesFromAllNamespaces (bool, optional) {#loggingspec-allowclusterresourcesfromallnamespaces}
 
-Reference to the logging system. Each of the `loggingRef`s can manage a fluentbit daemonset and a fluentd statefulset. 
+Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources 
+
+Default: -
+
+### clusterDomain (*string, optional) {#loggingspec-clusterdomain}
+
+Cluster domain name to be used when templating URLs to services . 
+
+Default:  "cluster.local"
+
+### controlNamespace (string, required) {#loggingspec-controlnamespace}
+
+Namespace for cluster wide configuration resources like CLusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well. 
+
+Default: -
+
+### defaultFlow (*DefaultFlowSpec, optional) {#loggingspec-defaultflow}
+
+Default flow for unmatched logs. This Flow configuration collects all logs that didn't matched any other Flow. 
+
+Default: -
+
+### enableRecreateWorkloadOnImmutableFieldChange (bool, optional) {#loggingspec-enablerecreateworkloadonimmutablefieldchange}
+
+Reference to the logging system. Each of the `loggingRef`s can manage a fluentbit daemonset and a fluentd statefulset. EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future) in case there is a change in an immutable field that otherwise couldn't be managed with a simple update. 
+
+Default: -
+
+### errorOutputRef (string, optional) {#loggingspec-erroroutputref}
+
+GlobalOutput name to flush ERROR events to 
 
 Default: -
 
 ### flowConfigCheckDisabled (bool, optional) {#loggingspec-flowconfigcheckdisabled}
 
 Disable configuration check before applying new fluentd configuration. 
-
-Default: -
-
-### skipInvalidResources (bool, optional) {#loggingspec-skipinvalidresources}
-
-Whether to skip invalid Flow and ClusterFlow resources 
 
 Default: -
 
@@ -34,7 +58,7 @@ Default: -
 
 ### fluentbit (*FluentbitSpec, optional) {#loggingspec-fluentbit}
 
-Fluentbit daemonset configuration. 
+FluentbitAgent daemonset configuration. Deprecated, will be removed with next major version Migrate to the standalone NodeAgent resource 
 
 Default: -
 
@@ -44,27 +68,31 @@ Fluentd statefulset configuration
 
 Default: -
 
-### syslogNG (*SyslogNGSpec, optional) {#loggingspec-syslogng}
-
-Syslog-NG statefulset configuration 
-
-Default: -
-
-### defaultFlow (*DefaultFlowSpec, optional) {#loggingspec-defaultflow}
-
-Default flow for unmatched logs. This Flow configuration collects all logs that didn't matched any other Flow. 
-
-Default: -
-
-### errorOutputRef (string, optional) {#loggingspec-erroroutputref}
-
-GlobalOutput name to flush ERROR events to 
-
-Default: -
-
 ### globalFilters ([]Filter, optional) {#loggingspec-globalfilters}
 
 Global filters to apply on logs before any match or filter mechanism. 
+
+Default: -
+
+### loggingRef (string, optional) {#loggingspec-loggingref}
+
+Default: -
+
+### nodeAgents ([]*InlineNodeAgent, optional) {#loggingspec-nodeagents}
+
+InlineNodeAgent Configuration Deprecated, will be removed with next major version 
+
+Default: -
+
+### skipInvalidResources (bool, optional) {#loggingspec-skipinvalidresources}
+
+Whether to skip invalid Flow and ClusterFlow resources 
+
+Default: -
+
+### syslogNG (*SyslogNGSpec, optional) {#loggingspec-syslogng}
+
+Syslog-NG statefulset configuration 
 
 Default: -
 
@@ -76,33 +104,7 @@ Default: -
 
 ### watchNamespaceSelector (*metav1.LabelSelector, optional) {#loggingspec-watchnamespaceselector}
 
-WatchNamespaceSelector is a LabelSelector to find matching namespaces to watch as in WatchNamespaceses.
-
-Note: This setting is mutually exclusive with watchNamespaces
-
-Default: -
-
-### controlNamespace (string, required) {#loggingspec-controlnamespace}
-
-Namespace for cluster wide configuration resources like ClusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well. 
-
-Default: -
-
-### allowClusterResourcesFromAllNamespaces (bool, optional) {#loggingspec-allowclusterresourcesfromallnamespaces}
-
-Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources 
-
-Default: -
-
-### nodeAgents ([]*NodeAgent, optional) {#loggingspec-nodeagents}
-
-NodeAgent Configuration 
-
-Default: -
-
-### enableRecreateWorkloadOnImmutableFieldChange (bool, optional) {#loggingspec-enablerecreateworkloadonimmutablefieldchange}
-
-EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future) in case there is a change in an immutable field that otherwise couldn't be managed with a simple update. 
+WatchNamespaceSelector is a LabelSelector to find matching namespaces to watch as in WatchNamespaces 
 
 Default: -
 
@@ -112,6 +114,10 @@ Default: -
 LoggingStatus defines the observed state of Logging
 
 ### configCheckResults (map[string]bool, optional) {#loggingstatus-configcheckresults}
+
+Default: -
+
+### problems ([]string, optional) {#loggingstatus-problems}
 
 Default: -
 
@@ -141,15 +147,15 @@ Default: -
 
 LoggingList contains a list of Logging
 
+### items ([]Logging, required) {#logginglist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#logginglist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#logginglist-metadata}
-
-Default: -
-
-### items ([]Logging, required) {#logginglist-items}
 
 Default: -
 
@@ -162,13 +168,21 @@ DefaultFlowSpec is a Flow for logs that did not match any other Flow
 
 Default: -
 
-### outputRefs ([]string, optional) {#defaultflowspec-outputrefs}
-
-Deprecated 
+### flowLabel (string, optional) {#defaultflowspec-flowlabel}
 
 Default: -
 
 ### globalOutputRefs ([]string, optional) {#defaultflowspec-globaloutputrefs}
+
+Default: -
+
+### includeLabelInRouter (*bool, optional) {#defaultflowspec-includelabelinrouter}
+
+Default: -
+
+### outputRefs ([]string, optional) {#defaultflowspec-outputrefs}
+
+Deprecated 
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/node_agent_types.md
+++ b/docs/configuration/crds/v1beta1/node_agent_types.md
@@ -1,33 +1,205 @@
+---
+title: NodeAgent
+weight: 200
+generated_file: true
+---
+
 ## NodeAgent
 
-### name (string, optional) {#nodeagent-name}
+NodeAgent
 
-NodeAgent unique name. 
-
-Default: -
-
-### profile (string, optional) {#nodeagent-profile}
-
-Specify the Logging-Operator nodeAgents profile. It can be linux or windows .  
-
-Default: linux
-
-### metadata (types.MetaBase, optional) {#nodeagent-metadata}
+###  (metav1.TypeMeta, required) {#nodeagent-}
 
 Default: -
 
-### nodeAgentFluentbit (*NodeAgentFluentbit, optional) {#nodeagent-nodeagentfluentbit}
+### metadata (metav1.ObjectMeta, optional) {#nodeagent-metadata}
+
+Default: -
+
+### spec (NodeAgentSpec, optional) {#nodeagent-spec}
+
+Default: -
+
+### status (NodeAgentStatus, optional) {#nodeagent-status}
+
+Default: -
+
+
+## NodeAgentSpec
+
+NodeAgentSpec
+
+### loggingRef (string, optional) {#nodeagentspec-loggingref}
+
+Default: -
+
+###  (NodeAgentConfig, required) {#nodeagentspec-}
+
+InlineNodeAgent 
+
+Default: -
+
+
+## NodeAgentConfig
+
+### profile (string, optional) {#nodeagentconfig-profile}
+
+Default: -
+
+### metadata (types.MetaBase, optional) {#nodeagentconfig-metadata}
+
+Default: -
+
+### nodeAgentFluentbit (*NodeAgentFluentbit, optional) {#nodeagentconfig-nodeagentfluentbit}
+
+Default: -
+
+
+## NodeAgentStatus
+
+NodeAgentStatus
+
+
+## NodeAgentList
+
+NodeAgentList
+
+###  (metav1.TypeMeta, required) {#nodeagentlist-}
+
+Default: -
+
+### metadata (metav1.ListMeta, optional) {#nodeagentlist-metadata}
+
+Default: -
+
+### items ([]NodeAgent, required) {#nodeagentlist-items}
+
+Default: -
+
+
+## InlineNodeAgent
+
+InlineNodeAgent
+@deprecated, replaced by NodeAgent
+
+### name (string, optional) {#inlinenodeagent-name}
+
+InlineNodeAgent unique name. 
+
+Default: -
+
+###  (NodeAgentConfig, required) {#inlinenodeagent-}
 
 Default: -
 
 
 ## NodeAgentFluentbit
 
+### bufferStorage (BufferStorage, optional) {#nodeagentfluentbit-bufferstorage}
+
+Default: -
+
+### bufferStorageVolume (volume.KubernetesVolume, optional) {#nodeagentfluentbit-bufferstoragevolume}
+
+[volume.KubernetesVolume](https://github.com/cisco-open/operator-tools/tree/master/docs/types) 
+
+Default: -
+
+### customConfigSecret (string, optional) {#nodeagentfluentbit-customconfigsecret}
+
+Default: -
+
+### containersPath (string, optional) {#nodeagentfluentbit-containerspath}
+
+Default: -
+
+### coroStackSize (int32, optional) {#nodeagentfluentbit-corostacksize}
+
+Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer. Do not change the default value of this parameter unless you know what you are doing. (default: 24576) 
+
+Default: 24576
+
+### daemonSet (*typeoverride.DaemonSet, optional) {#nodeagentfluentbit-daemonset}
+
+Default: -
+
+### disableKubernetesFilter (*bool, optional) {#nodeagentfluentbit-disablekubernetesfilter}
+
+Default: -
+
 ### enabled (*bool, optional) {#nodeagentfluentbit-enabled}
 
 Default: -
 
-### daemonSet (*typeoverride.DaemonSet, optional) {#nodeagentfluentbit-daemonset}
+### enableUpstream (*bool, optional) {#nodeagentfluentbit-enableupstream}
+
+Default: -
+
+### extraVolumeMounts ([]*VolumeMount, optional) {#nodeagentfluentbit-extravolumemounts}
+
+Default: -
+
+### filterAws (*FilterAws, optional) {#nodeagentfluentbit-filteraws}
+
+Default: -
+
+### filterKubernetes (FilterKubernetes, optional) {#nodeagentfluentbit-filterkubernetes}
+
+Default: -
+
+### flush (int32, optional) {#nodeagentfluentbit-flush}
+
+Set the flush time in seconds.nanoseconds. The engine loop uses a Flush timeout to define when is required to flush the records ingested by input plugins through the defined output plugins. (default: 1) 
+
+Default: 1
+
+### forwardOptions (*ForwardOptions, optional) {#nodeagentfluentbit-forwardoptions}
+
+Default: -
+
+### grace (int32, optional) {#nodeagentfluentbit-grace}
+
+Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit (default: 5) 
+
+Default: 5
+
+### inputTail (InputTail, optional) {#nodeagentfluentbit-inputtail}
+
+Default: -
+
+### livenessDefaultCheck (*bool, optional) {#nodeagentfluentbit-livenessdefaultcheck}
+
+Default: true
+
+### logLevel (string, optional) {#nodeagentfluentbit-loglevel}
+
+Set the logging verbosity level. Allowed values are: error, warn, info, debug and trace. Values are accumulative, e.g: if 'debug' is set, it will include error, warning, info and debug.  Note that trace mode is only available if Fluent Bit was built with the WITH_TRACE option enabled. (default: info) 
+
+Default: info
+
+### metrics (*Metrics, optional) {#nodeagentfluentbit-metrics}
+
+Default: -
+
+### metricsService (*typeoverride.Service, optional) {#nodeagentfluentbit-metricsservice}
+
+Default: -
+
+### network (*FluentbitNetwork, optional) {#nodeagentfluentbit-network}
+
+Default: -
+
+### positiondb (volume.KubernetesVolume, optional) {#nodeagentfluentbit-positiondb}
+
+[volume.KubernetesVolume](https://github.com/cisco-open/operator-tools/tree/master/docs/types) 
+
+Default: -
+
+### podPriorityClassName (string, optional) {#nodeagentfluentbit-podpriorityclassname}
+
+Default: -
+
+### security (*Security, optional) {#nodeagentfluentbit-security}
 
 Default: -
 
@@ -47,107 +219,7 @@ Default: -
 
 Default: -
 
-### flush (int32, optional) {#nodeagentfluentbit-flush}
-
-Set the flush time in seconds.nanoseconds. The engine loop uses a Flush timeout to define when is required to flush the records ingested by input plugins through the defined output plugins. (default: 1) 
-
-Default: 1
-
-### grace (int32, optional) {#nodeagentfluentbit-grace}
-
-Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit (default: 5) 
-
-Default: 5
-
-### logLevel (string, optional) {#nodeagentfluentbit-loglevel}
-
-Set the logging verbosity level. Allowed values are: error, warn, info, debug and trace. Values are accumulative, e.g: if 'debug' is set, it will include error, warning, info and debug.  Note that trace mode is only available if Fluent Bit was built with the WITH_TRACE option enabled. (default: info) 
-
-Default: info
-
-### coroStackSize (int32, optional) {#nodeagentfluentbit-corostacksize}
-
-Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer. Do not change the default value of this parameter unless you know what you are doing. (default: 24576) 
-
-Default: 24576
-
-### metrics (*Metrics, optional) {#nodeagentfluentbit-metrics}
-
-Default: -
-
-### metricsService (*typeoverride.Service, optional) {#nodeagentfluentbit-metricsservice}
-
-Default: -
-
-### security (*Security, optional) {#nodeagentfluentbit-security}
-
-Default: -
-
-### positiondb (volume.KubernetesVolume, optional) {#nodeagentfluentbit-positiondb}
-
-[volume.KubernetesVolume](https://github.com/cisco-open/operator-tools/tree/master/docs/types) 
-
-Default: -
-
-### containersPath (string, optional) {#nodeagentfluentbit-containerspath}
-
-Default: -
-
 ### varLogsPath (string, optional) {#nodeagentfluentbit-varlogspath}
-
-Default: -
-
-### extraVolumeMounts ([]*VolumeMount, optional) {#nodeagentfluentbit-extravolumemounts}
-
-Default: -
-
-### inputTail (InputTail, optional) {#nodeagentfluentbit-inputtail}
-
-Default: -
-
-### filterAws (*FilterAws, optional) {#nodeagentfluentbit-filteraws}
-
-Default: -
-
-### filterKubernetes (FilterKubernetes, optional) {#nodeagentfluentbit-filterkubernetes}
-
-Default: -
-
-### disableKubernetesFilter (*bool, optional) {#nodeagentfluentbit-disablekubernetesfilter}
-
-Default: -
-
-### bufferStorage (BufferStorage, optional) {#nodeagentfluentbit-bufferstorage}
-
-Default: -
-
-### bufferStorageVolume (volume.KubernetesVolume, optional) {#nodeagentfluentbit-bufferstoragevolume}
-
-[volume.KubernetesVolume](https://github.com/cisco-open/operator-tools/tree/master/docs/types) 
-
-Default: -
-
-### customConfigSecret (string, optional) {#nodeagentfluentbit-customconfigsecret}
-
-Default: -
-
-### podPriorityClassName (string, optional) {#nodeagentfluentbit-podpriorityclassname}
-
-Default: -
-
-### livenessDefaultCheck (*bool, optional) {#nodeagentfluentbit-livenessdefaultcheck}
-
-Default: true
-
-### network (*FluentbitNetwork, optional) {#nodeagentfluentbit-network}
-
-Default: -
-
-### forwardOptions (*ForwardOptions, optional) {#nodeagentfluentbit-forwardoptions}
-
-Default: -
-
-### enableUpstream (*bool, optional) {#nodeagentfluentbit-enableupstream}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/output_types.md
+++ b/docs/configuration/crds/v1beta1/output_types.md
@@ -8,11 +8,7 @@ generated_file: true
 
 OutputSpec defines the desired state of Output
 
-### loggingRef (string, optional) {#outputspec-loggingref}
-
-Default: -
-
-### s3 (*output.S3OutputConfig, optional) {#outputspec-s3}
+### awsElasticsearch (*output.AwsElasticsearchOutputConfig, optional) {#outputspec-awselasticsearch}
 
 Default: -
 
@@ -20,31 +16,7 @@ Default: -
 
 Default: -
 
-### gcs (*output.GCSOutput, optional) {#outputspec-gcs}
-
-Default: -
-
-### oss (*output.OSSOutput, optional) {#outputspec-oss}
-
-Default: -
-
-### elasticsearch (*output.ElasticsearchOutput, optional) {#outputspec-elasticsearch}
-
-Default: -
-
-### opensearch (*output.OpenSearchOutput, optional) {#outputspec-opensearch}
-
-Default: -
-
-### logz (*output.LogZOutput, optional) {#outputspec-logz}
-
-Default: -
-
-### loki (*output.LokiOutput, optional) {#outputspec-loki}
-
-Default: -
-
-### sumologic (*output.SumologicOutput, optional) {#outputspec-sumologic}
+### cloudwatch (*output.CloudWatchOutput, optional) {#outputspec-cloudwatch}
 
 Default: -
 
@@ -52,7 +24,7 @@ Default: -
 
 Default: -
 
-### forward (*output.ForwardOutput, optional) {#outputspec-forward}
+### elasticsearch (*output.ElasticsearchOutput, optional) {#outputspec-elasticsearch}
 
 Default: -
 
@@ -60,15 +32,23 @@ Default: -
 
 Default: -
 
-### nullout (*output.NullOutputConfig, optional) {#outputspec-nullout}
+### forward (*output.ForwardOutput, optional) {#outputspec-forward}
+
+Default: -
+
+### gelf (*output.GELFOutputConfig, optional) {#outputspec-gelf}
+
+Default: -
+
+### gcs (*output.GCSOutput, optional) {#outputspec-gcs}
+
+Default: -
+
+### http (*output.HTTPOutputConfig, optional) {#outputspec-http}
 
 Default: -
 
 ### kafka (*output.KafkaOutputConfig, optional) {#outputspec-kafka}
-
-Default: -
-
-### cloudwatch (*output.CloudWatchOutput, optional) {#outputspec-cloudwatch}
 
 Default: -
 
@@ -80,19 +60,35 @@ Default: -
 
 Default: -
 
+### loggingRef (string, optional) {#outputspec-loggingref}
+
+Default: -
+
+### logz (*output.LogZOutput, optional) {#outputspec-logz}
+
+Default: -
+
+### loki (*output.LokiOutput, optional) {#outputspec-loki}
+
+Default: -
+
+### mattermost (*output.MattermostOutputConfig, optional) {#outputspec-mattermost}
+
+Default: -
+
 ### newrelic (*output.NewRelicOutputConfig, optional) {#outputspec-newrelic}
 
 Default: -
 
-### splunkHec (*output.SplunkHecOutput, optional) {#outputspec-splunkhec}
+### nullout (*output.NullOutputConfig, optional) {#outputspec-nullout}
 
 Default: -
 
-### http (*output.HTTPOutputConfig, optional) {#outputspec-http}
+### oss (*output.OSSOutput, optional) {#outputspec-oss}
 
 Default: -
 
-### awsElasticsearch (*output.AwsElasticsearchOutputConfig, optional) {#outputspec-awselasticsearch}
+### opensearch (*output.OpenSearchOutput, optional) {#outputspec-opensearch}
 
 Default: -
 
@@ -100,11 +96,15 @@ Default: -
 
 Default: -
 
-### syslog (*output.SyslogOutputConfig, optional) {#outputspec-syslog}
+### relabel (*output.RelabelOutputConfig, optional) {#outputspec-relabel}
 
 Default: -
 
-### gelf (*output.GELFOutputConfig, optional) {#outputspec-gelf}
+### s3 (*output.S3OutputConfig, optional) {#outputspec-s3}
+
+Default: -
+
+### splunkHec (*output.SplunkHecOutput, optional) {#outputspec-splunkhec}
 
 Default: -
 
@@ -112,7 +112,11 @@ Default: -
 
 Default: -
 
-### mattermost (*output.MattermostOutputConfig, optional) {#outputspec-mattermost}
+### sumologic (*output.SumologicOutput, optional) {#outputspec-sumologic}
+
+Default: -
+
+### syslog (*output.SyslogOutputConfig, optional) {#outputspec-syslog}
 
 Default: -
 
@@ -159,15 +163,15 @@ Default: -
 
 OutputList contains a list of Output
 
+### items ([]Output, required) {#outputlist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#outputlist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#outputlist-metadata}
-
-Default: -
-
-### items ([]Output, required) {#outputlist-items}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/syslogng_clusterflow_types.md
+++ b/docs/configuration/crds/v1beta1/syslogng_clusterflow_types.md
@@ -29,11 +29,11 @@ Default: -
 
 SyslogNGClusterFlowSpec is the Kubernetes spec for Flows
 
-### match (*SyslogNGMatch, optional) {#syslogngclusterflowspec-match}
+### filters ([]SyslogNGFilter, optional) {#syslogngclusterflowspec-filters}
 
 Default: -
 
-### filters ([]SyslogNGFilter, optional) {#syslogngclusterflowspec-filters}
+### globalOutputRefs ([]string, optional) {#syslogngclusterflowspec-globaloutputrefs}
 
 Default: -
 
@@ -41,7 +41,7 @@ Default: -
 
 Default: -
 
-### globalOutputRefs ([]string, optional) {#syslogngclusterflowspec-globaloutputrefs}
+### match (*SyslogNGMatch, optional) {#syslogngclusterflowspec-match}
 
 Default: -
 
@@ -50,15 +50,15 @@ Default: -
 
 SyslogNGClusterFlowList contains a list of SyslogNGClusterFlow
 
+### items ([]SyslogNGClusterFlow, required) {#syslogngclusterflowlist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#syslogngclusterflowlist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#syslogngclusterflowlist-metadata}
-
-Default: -
-
-### items ([]SyslogNGClusterFlow, required) {#syslogngclusterflowlist-items}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/syslogng_clusteroutput_types.md
+++ b/docs/configuration/crds/v1beta1/syslogng_clusteroutput_types.md
@@ -29,11 +29,11 @@ Default: -
 
 SyslogNGClusterOutputSpec contains Kubernetes spec for SyslogNGClusterOutput
 
-###  (SyslogNGOutputSpec, required) {#syslogngclusteroutputspec-}
+### enabledNamespaces ([]string, optional) {#syslogngclusteroutputspec-enablednamespaces}
 
 Default: -
 
-### enabledNamespaces ([]string, optional) {#syslogngclusteroutputspec-enablednamespaces}
+###  (SyslogNGOutputSpec, required) {#syslogngclusteroutputspec-}
 
 Default: -
 
@@ -42,15 +42,15 @@ Default: -
 
 SyslogNGClusterOutputList contains a list of SyslogNGClusterOutput
 
+### items ([]SyslogNGClusterOutput, required) {#syslogngclusteroutputlist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#syslogngclusteroutputlist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#syslogngclusteroutputlist-metadata}
-
-Default: -
-
-### items ([]SyslogNGClusterOutput, required) {#syslogngclusteroutputlist-items}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/syslogng_flow_types.md
+++ b/docs/configuration/crds/v1beta1/syslogng_flow_types.md
@@ -8,15 +8,7 @@ generated_file: true
 
 SyslogNGFlowSpec is the Kubernetes spec for SyslogNGFlows
 
-### match (*SyslogNGMatch, optional) {#syslogngflowspec-match}
-
-Default: -
-
 ### filters ([]SyslogNGFilter, optional) {#syslogngflowspec-filters}
-
-Default: -
-
-### loggingRef (string, optional) {#syslogngflowspec-loggingref}
 
 Default: -
 
@@ -25,6 +17,14 @@ Default: -
 Default: -
 
 ### localOutputRefs ([]string, optional) {#syslogngflowspec-localoutputrefs}
+
+Default: -
+
+### loggingRef (string, optional) {#syslogngflowspec-loggingref}
+
+Default: -
+
+### match (*SyslogNGMatch, optional) {#syslogngflowspec-match}
 
 Default: -
 
@@ -75,15 +75,15 @@ Default: -
 
 FlowList contains a list of Flow
 
+### items ([]SyslogNGFlow, required) {#syslogngflowlist-items}
+
+Default: -
+
 ###  (metav1.TypeMeta, required) {#syslogngflowlist-}
 
 Default: -
 
 ### metadata (metav1.ListMeta, optional) {#syslogngflowlist-metadata}
-
-Default: -
-
-### items ([]SyslogNGFlow, required) {#syslogngflowlist-items}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/syslogng_output_types.md
+++ b/docs/configuration/crds/v1beta1/syslogng_output_types.md
@@ -24,11 +24,23 @@ Default: -
 
 Default: -
 
+### mqtt (*output.MQTT, optional) {#syslogngoutputspec-mqtt}
+
+Default: -
+
 ### sumologic-http (*output.SumologicHTTPOutput, optional) {#syslogngoutputspec-sumologic-http}
 
 Default: -
 
 ### sumologic-syslog (*output.SumologicSyslogOutput, optional) {#syslogngoutputspec-sumologic-syslog}
+
+Default: -
+
+### http (*output.HTTPOutput, optional) {#syslogngoutputspec-http}
+
+Default: -
+
+### logscale (*output.LogScaleOutput, optional) {#syslogngoutputspec-logscale}
 
 Default: -
 

--- a/docs/configuration/crds/v1beta1/syslogng_types.md
+++ b/docs/configuration/crds/v1beta1/syslogng_types.md
@@ -8,7 +8,43 @@ generated_file: true
 
 SyslogNGSpec defines the desired state of SyslogNG
 
-### tls (SyslogNGTLS, optional) {#syslogngspec-tls}
+### bufferVolumeMetrics (*BufferMetrics, optional) {#syslogngspec-buffervolumemetrics}
+
+Default: -
+
+### bufferVolumeMetricsService (*typeoverride.Service, optional) {#syslogngspec-buffervolumemetricsservice}
+
+Default: -
+
+### configCheckPod (*typeoverride.PodSpec, optional) {#syslogngspec-configcheckpod}
+
+Default: -
+
+### globalOptions (*GlobalOptions, optional) {#syslogngspec-globaloptions}
+
+Default: -
+
+### jsonKeyPrefix (string, optional) {#syslogngspec-jsonkeyprefix}
+
+Default: -
+
+### jsonKeyDelim (string, optional) {#syslogngspec-jsonkeydelim}
+
+Default: -
+
+### logIWSize (int, optional) {#syslogngspec-logiwsize}
+
+Default: -
+
+### maxConnections (int, optional) {#syslogngspec-maxconnections}
+
+Default: -
+
+### metrics (*Metrics, optional) {#syslogngspec-metrics}
+
+Default: -
+
+### metricsService (*typeoverride.Service, optional) {#syslogngspec-metricsservice}
 
 Default: -
 
@@ -32,27 +68,7 @@ Default: -
 
 Default: -
 
-### configCheckPod (*typeoverride.PodSpec, optional) {#syslogngspec-configcheckpod}
-
-Default: -
-
-### metrics (*Metrics, optional) {#syslogngspec-metrics}
-
-Default: -
-
-### metricsService (*typeoverride.Service, optional) {#syslogngspec-metricsservice}
-
-Default: -
-
-### bufferVolumeMetrics (*BufferMetrics, optional) {#syslogngspec-buffervolumemetrics}
-
-Default: -
-
-### bufferVolumeMetricsService (*typeoverride.Service, optional) {#syslogngspec-buffervolumemetricsservice}
-
-Default: -
-
-### globalOptions (*GlobalOptions, optional) {#syslogngspec-globaloptions}
+### tls (SyslogNGTLS, optional) {#syslogngspec-tls}
 
 Default: -
 
@@ -76,11 +92,32 @@ Default: -
 
 ## GlobalOptions
 
-### stats_level (*int, optional) {#globaloptions-stats_level}
+### stats (*Stats, optional) {#globaloptions-stats}
+
+TODO switch to this by default 
 
 Default: -
 
 ### stats_freq (*int, optional) {#globaloptions-stats_freq}
+
+deprecated use stats/freq from 4.1+ 
+
+Default: -
+
+### stats_level (*int, optional) {#globaloptions-stats_level}
+
+deprecated use stats/level from 4.1+ 
+
+Default: -
+
+
+## Stats
+
+### freq (*int, optional) {#stats-freq}
+
+Default: -
+
+### level (*int, optional) {#stats-level}
 
 Default: -
 

--- a/docs/configuration/plugins/_index.md
+++ b/docs/configuration/plugins/_index.md
@@ -3,68 +3,71 @@ title: Supported Plugins
 generated_file: true
 ---
 
-# Supported Plugins
-
 For more information please click on the plugin name
 <center>
 
-| Name | Profile | Description | Status |                                                                                                                                 Version |
-|:---|---|:---|:---:|----------------------------------------------------------------------------------------------------------------------------------------:|
-| **[Security](common/security/)** | common |  |  |                                                                                                                                    []() |
-| **[Transport](common/transport/)** | common |  |  |                                                                                                                                    []() |
-| **[Concat](filters/concat/)** | filters | Fluentd Filter plugin to concatenate multiline log separated in multiple events. | GA |                                                                 [2.5.0](https://github.com/fluent-plugins-nursery/fluent-plugin-concat) |
-| **[Dedot](filters/dedot/)** | filters | Concatenate multiline log separated in multiple events | GA |                                                                        [1.0.0](https://github.com/lunardial/fluent-plugin-dedot_filter) |
-| **[Exception Detector](filters/detect_exceptions/)** | filters | Exception Detector | GA |                                                        [0.0.14](https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions) |
-| **[ElasticsearchGenId](filters/elasticsearch_genid/)** | filters |  |  |                                                                                                                                    []() |
-| **[Enhance K8s Metadata](filters/enhance_k8s/)** | filters | Fluentd output plugin to add extra Kubernetes metadata to the events. | GA |                      [2.0.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/main/fluent-plugin-enhance-k8s-metadata) |
-| **[Geo IP](filters/geoip/)** | filters | Fluentd GeoIP filter | GA |                                                                                   [1.3.2](https://github.com/y-ken/fluent-plugin-geoip) |
-| **[Grep](filters/grep/)** | filters | Grep events by the values | GA |                                                                                       [more info](https://docs.fluentd.org/filter/grep) |
-| **[Kubernetes Events Timestamp](filters/kube_events_timestamp/)** | filters | Fluentd Filter plugin to select particular timestamp into an additional field | GA |                                                           [0.1.4](https://github.com/kube-logging/fluentd-filter-kube-events-timestamp) |
-| **[Parser](filters/parser/)** | filters | Parses a string field in event records and mutates its event record with the parsed result. | GA |                                                                                     [more info](https://docs.fluentd.org/filter/parser) |
-| **[Prometheus](filters/prometheus/)** | filters | Prometheus Filter Plugin to count Incoming Records | GA |                                              [2.0.2](https://github.com/fluent/fluent-plugin-prometheus#prometheus-outputfilter-plugin) |
-| **[Record Modifier](filters/record_modifier/)** | filters | Modify each event record. | GA |                                                                    [2.1.0](https://github.com/repeatedly/fluent-plugin-record-modifier) |
-| **[Record Transformer](filters/record_transformer/)** | filters | Mutates/transforms incoming event streams. | GA |                                                                         [more info](https://docs.fluentd.org/filter/record_transformer) |
-| **[Stdout](filters/stdout/)** | filters | Prints events to stdout | GA |                                                                                     [more info](https://docs.fluentd.org/filter/stdout) |
-| **[SumoLogic](filters/sumologic/)** | filters | Sumo Logic collection solution for Kubernetes | GA |                                                                   [2.3.1](https://github.com/SumoLogic/sumologic-kubernetes-collection) |
-| **[Tag Normaliser](filters/tagnormaliser/)** | filters | Re-tag based on log metadata | GA |                                                                   [0.1.1](https://github.com/kube-logging/fluent-plugin-tag-normaliser) |
-| **[Throttle](filters/throttle/)** | filters | A sentry plugin to throttle logs. Logs are grouped by a configurable key. When a group exceeds a configuration rate, logs are dropped for this group. | GA |                                                                            [0.0.5](https://github.com/rubrikinc/fluent-plugin-throttle) |
-| **[Amazon Elasticsearch](outputs/aws_elasticsearch/)** | outputs | Fluent plugin for Amazon Elasticsearch | Testing |                                                             [2.4.1](https://github.com/atomita/fluent-plugin-aws-elasticsearch-service) |
-| **[Azure Storage](outputs/azurestore/)** | outputs | Store logs in Azure Storage | GA |                                                           [0.2.1](https://github.com/microsoft/fluent-plugin-azure-storage-append-blob) |
-| **[Buffer](outputs/buffer/)** | outputs | Fluentd event buffer | GA |                                                                      [mode info](https://docs.fluentd.org/configuration/buffer-section) |
-| **[Amazon CloudWatch](outputs/cloudwatch/)** | outputs | Send your logs to AWS CloudWatch | GA |                                  [0.14.2](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/releases/tag/v0.14.2) |
-| **[Datadog](outputs/datadog/)** | outputs | Send your logs to Datadog | Testing |                                                         [0.14.1](https://github.com/DataDog/fluent-plugin-datadog/releases/tag/v0.14.1) |
-| **[Elasticsearch](outputs/elasticsearch/)** | outputs | Send your logs to Elasticsearch | GA |                                                        [5.1.1](https://github.com/uken/fluent-plugin-elasticsearch/releases/tag/v5.1.4) |
-| **[File](outputs/file/)** | outputs | Output plugin writes events to files | GA |                                                                                       [more info](https://docs.fluentd.org/output/file) |
-| **[Format](outputs/format/)** | outputs | Specify how to format output record. | GA |                                                                      [more info](https://docs.fluentd.org/configuration/format-section) |
-| **[Format rfc5424](outputs/format_rfc5424/)** | outputs | Specify how to format output record. | GA |                                                [more info](https://github.com/cloudfoundry/fluent-plugin-syslog_rfc5424#format-section) |
-| **[Forward](outputs/forward/)** | outputs | Forwards events to other fluentd nodes. | GA |                                                                                    [more info](https://docs.fluentd.org/output/forward) |
-| **[Google Cloud Storage](outputs/gcs/)** | outputs | Store logs in Google Cloud Storage | GA |                                                                              [0.4.0](https://github.com/kube-logging/fluent-plugin-gcs) |
-| **[Gelf](outputs/gelf/)** | outputs | Output plugin writes events to GELF | Testing |                                                                          [1.0.8](https://github.com/hotschedules/fluent-plugin-gelf-hs) |
-| **[Http](outputs/http/)** | outputs | Sends logs to HTTP/HTTPS endpoints. | GA |                                                                                       [more info](https://docs.fluentd.org/output/http) |
-| **[Kafka](outputs/kafka/)** | outputs | Send your logs to Kafka | GA |                                                            [0.17.5](https://github.com/fluent/fluent-plugin-kafka/releases/tag/v0.17.5) |
-| **[Amazon Kinesis Firehose](outputs/kinesis_firehose/)** | outputs | Fluent plugin for Amazon Kinesis | Testing |                                                       [3.4.2](https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.4.2) |
-| **[Amazon Kinesis Stream](outputs/kinesis_stream/)** | outputs | Fluent plugin for Amazon Kinesis | GA |                                                       [3.4.2](https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.4.2) |
-| **[LogDNA](outputs/logdna/)** | outputs | Send your logs to LogDNA | GA |                                                             [0.4.0](https://github.com/logdna/fluent-plugin-logdna/releases/tag/v0.4.0) |
-| **[LogZ](outputs/logz/)** | outputs | Store logs in LogZ.io | GA |                                                           [0.0.21](https://github.com/logzio/fluent-plugin-logzio/releases/tag/v0.0.21) |
+| Name | Profile | Description | Status |Version |
+|:---|---|:---|:---:|---:|
+| **[Security](common/security/)** | common |  |  | []() |
+| **[Transport](common/transport/)** | common |  |  | []() |
+| **[Concat](filters/concat/)** | filters | Fluentd Filter plugin to concatenate multiline log separated in multiple events. | GA | [2.5.0](https://github.com/fluent-plugins-nursery/fluent-plugin-concat) |
+| **[Dedot](filters/dedot/)** | filters | Concatenate multiline log separated in multiple events | GA | [1.0.0](https://github.com/lunardial/fluent-plugin-dedot_filter) |
+| **[Exception Detector](filters/detect_exceptions/)** | filters | Exception Detector | GA | [0.0.14](https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions) |
+| **[ElasticsearchGenId](filters/elasticsearch_genid/)** | filters |  |  | []() |
+| **[Enhance K8s Metadata](filters/enhance_k8s/)** | filters | Fluentd output plugin to add extra Kubernetes metadata to the events. | GA | [2.0.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/main/fluent-plugin-enhance-k8s-metadata) |
+| **[Geo IP](filters/geoip/)** | filters | Fluentd GeoIP filter | GA | [1.3.2](https://github.com/y-ken/fluent-plugin-geoip) |
+| **[Grep](filters/grep/)** | filters | Grep events by the values | GA | [more info](https://docs.fluentd.org/filter/grep) |
+| **[Kubernetes Events Timestamp](filters/kube_events_timestamp/)** | filters | Fluentd Filter plugin to select particular timestamp into an additional field | GA | [0.1.4](https://github.com/kube-logging/fluentd-filter-kube-events-timestamp) |
+| **[Parser](filters/parser/)** | filters | Parses a string field in event records and mutates its event record with the parsed result. | GA | [more info](https://docs.fluentd.org/filter/parser) |
+| **[Prometheus](filters/prometheus/)** | filters | Prometheus Filter Plugin to count Incoming Records | GA | [2.0.2](https://github.com/fluent/fluent-plugin-prometheus#prometheus-outputfilter-plugin) |
+| **[Record Modifier](filters/record_modifier/)** | filters | Modify each event record. | GA | [2.1.0](https://github.com/repeatedly/fluent-plugin-record-modifier) |
+| **[Record Transformer](filters/record_transformer/)** | filters | Mutates/transforms incoming event streams. | GA | [more info](https://docs.fluentd.org/filter/record_transformer) |
+| **[Stdout](filters/stdout/)** | filters | Prints events to stdout | GA | [more info](https://docs.fluentd.org/filter/stdout) |
+| **[SumoLogic](filters/sumologic/)** | filters | Sumo Logic collection solution for Kubernetes | GA | [2.3.1](https://github.com/SumoLogic/sumologic-kubernetes-collection) |
+| **[Tag Normaliser](filters/tagnormaliser/)** | filters | Re-tag based on log metadata | GA | [0.1.1](https://github.com/kube-logging/fluent-plugin-tag-normaliser) |
+| **[Throttle](filters/throttle/)** | filters | A sentry plugin to throttle logs. Logs are grouped by a configurable key. When a group exceeds a configuration rate, logs are dropped for this group. | GA | [0.0.5](https://github.com/rubrikinc/fluent-plugin-throttle) |
+| **[Amazon Elasticsearch](outputs/aws_elasticsearch/)** | outputs | Fluent plugin for Amazon Elasticsearch | Testing | [2.4.1](https://github.com/atomita/fluent-plugin-aws-elasticsearch-service) |
+| **[Azure Storage](outputs/azurestore/)** | outputs | Store logs in Azure Storage | GA | [0.2.1](https://github.com/microsoft/fluent-plugin-azure-storage-append-blob) |
+| **[Buffer](outputs/buffer/)** | outputs | Fluentd event buffer | GA | [mode info](https://docs.fluentd.org/configuration/buffer-section) |
+| **[Amazon CloudWatch](outputs/cloudwatch/)** | outputs | Send your logs to AWS CloudWatch | GA | [0.14.2](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/releases/tag/v0.14.2) |
+| **[Datadog](outputs/datadog/)** | outputs | Send your logs to Datadog | Testing | [0.14.1](https://github.com/DataDog/fluent-plugin-datadog/releases/tag/v0.14.1) |
+| **[Elasticsearch](outputs/elasticsearch/)** | outputs | Send your logs to Elasticsearch | GA | [5.1.1](https://github.com/uken/fluent-plugin-elasticsearch/releases/tag/v5.1.4) |
+| **[File](outputs/file/)** | outputs | Output plugin writes events to files | GA | [more info](https://docs.fluentd.org/output/file) |
+| **[Format](outputs/format/)** | outputs | Specify how to format output record. | GA | [more info](https://docs.fluentd.org/configuration/format-section) |
+| **[Format rfc5424](outputs/format_rfc5424/)** | outputs | Specify how to format output record. | GA | [more info](https://github.com/cloudfoundry/fluent-plugin-syslog_rfc5424#format-section) |
+| **[Forward](outputs/forward/)** | outputs | Forwards events to other fluentd nodes. | GA | [more info](https://docs.fluentd.org/output/forward) |
+| **[Google Cloud Storage](outputs/gcs/)** | outputs | Store logs in Google Cloud Storage | GA | [0.4.0](https://github.com/kube-logging/fluent-plugin-gcs) |
+| **[Gelf](outputs/gelf/)** | outputs | Output plugin writes events to GELF | Testing | [1.0.8](https://github.com/hotschedules/fluent-plugin-gelf-hs) |
+| **[Http](outputs/http/)** | outputs | Sends logs to HTTP/HTTPS endpoints. | GA | [more info](https://docs.fluentd.org/output/http) |
+| **[Kafka](outputs/kafka/)** | outputs | Send your logs to Kafka | GA | [0.17.5](https://github.com/fluent/fluent-plugin-kafka/releases/tag/v0.17.5) |
+| **[Amazon Kinesis Firehose](outputs/kinesis_firehose/)** | outputs | Fluent plugin for Amazon Kinesis | Testing | [3.4.2](https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.4.2) |
+| **[Amazon Kinesis Stream](outputs/kinesis_stream/)** | outputs | Fluent plugin for Amazon Kinesis | GA | [3.4.2](https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.4.2) |
+| **[LogDNA](outputs/logdna/)** | outputs | Send your logs to LogDNA | GA | [0.4.0](https://github.com/logdna/fluent-plugin-logdna/releases/tag/v0.4.0) |
+| **[LogZ](outputs/logz/)** | outputs | Store logs in LogZ.io | GA | [0.0.21](https://github.com/logzio/fluent-plugin-logzio/releases/tag/v0.0.21) |
+| **[Grafana Loki](outputs/loki/)** | outputs | Transfer logs to Loki | GA | [1.2.19](https://github.com/grafana/loki/tree/master/fluentd/fluent-plugin-grafana-loki) |
 | **[Mattermost](outputs/mattermost/)** | outputs | Sends logs to Mattermost via webhooks. | GA | [0.2.2](https://github.com/levigo-systems/fluent-plugin-mattermost) |
-| **[Grafana Loki](outputs/loki/)** | outputs | Transfer logs to Loki | GA |                                                [1.2.17](https://github.com/grafana/loki/tree/master/fluentd/fluent-plugin-grafana-loki) |
-| **[NewRelic Logs](outputs/newrelic/)** | outputs | Send logs to New Relic Logs | GA |                                                                            [1.2.1](https://github.com/newrelic/newrelic-fluentd-output) |
-| **[OpenSearch](outputs/opensearch/)** | outputs | Send your logs to OpenSearch | GA |                                                         [1.0.5](https://github.com/fluent/fluent-plugin-opensearch/releases/tag/v1.0.5) |
-| **[Alibaba Cloud Storage](outputs/oss/)** | outputs | Store logs the Alibaba Cloud Object Storage Service | GA |                                                                                    [0.0.2](https://github.com/aliyun/fluent-plugin-oss) |
-| **[Redis](outputs/redis/)** | outputs | Sends logs to Redis endpoints. | GA |                                                                  [0.3.5](https://github.com/fluent-plugins-nursery/fluent-plugin-redis) |
-| **[Amazon S3](outputs/s3/)** | outputs | Store logs in Amazon S3 | GA |                                                                 [1.6.1](https://github.com/fluent/fluent-plugin-s3/releases/tag/v1.6.1) |
-| **[Splunk Hec](outputs/splunk_hec/)** | outputs | Fluent Plugin Splunk Hec Release | GA |                                                                                                                               [1.2.9]() |
-| **[SQS](outputs/sqs/)** | outputs | Output plugin writes fluent-events as queue messages to Amazon SQS | Testing |                                                                                    [v2.1.0](https://github.com/ixixi/fluent-plugin-sqs) |
-| **[SumoLogic](outputs/sumologic/)** | outputs | Send your logs to Sumologic | GA |                                                       [1.8.0](https://github.com/SumoLogic/fluentd-output-sumologic/releases/tag/1.8.0) |
-| **[Syslog](outputs/syslog/)** | outputs | Output plugin writes events to syslog | GA |                                                              [0.9.0.rc.8](https://github.com/cloudfoundry/fluent-plugin-syslog_rfc5424) |
-| **[Syslog-NG Match](syslogng/filters/match/)** | syslogng-filters | Selectively keep records | GA | [more info](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/65#TOPIC-1829159) |
-| **[Syslog-NG Parser](syslogng/filters/parser/)** | syslogng-filters | Parse data from records | GA |               [more info](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/90) |
-| **[Syslog-NG Rewrite](syslogng/filters/rewrite/)** | syslogng-filters | Rewrite parts of the message | GA |               [more info](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/77) |
-| **[disk-buffer configuration](syslogng/outputs/disk_buffer/)** | syslogng-outputs | disk-buffer configuration | Testing |            [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338) |
-| **[File](syslogng/outputs/file/)** | syslogng-outputs | SStoring messages in plain-text files | Testing |                        [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.17/administration-guide/32) |
-| **[Loggly](syslogng/outputs/loggly/)** | syslogng-outputs | Send your logs to loggly | Testing |          [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/43#TOPIC-1829072) |
-| **[Sumo Logic HTTP](syslogng/outputs/sumologic_http/)** | syslogng-outputs | Storing messages in Sumo Logic over http | Testing |                        [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/55) |
-| **[Sumo Logic Syslog](syslogng/outputs/sumologic_syslog/)** | syslogng-outputs | Storing messages in Sumo Logic over http | Testing |          [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#TOPIC-1829122) |
-| **[Syslog output configuration](syslogng/outputs/syslog/)** | syslogng-outputs | Syslog output configuration | Testing |            [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338) |
-| **[TLS config for syslog-ng outputs](syslogng/outputs/tls/)** | syslogng-outputs | TLS config for syslog-ng outputs | Testing |            [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338) |
+| **[NewRelic Logs](outputs/newrelic/)** | outputs | Send logs to New Relic Logs | GA | [1.2.1](https://github.com/newrelic/newrelic-fluentd-output) |
+| **[OpenSearch](outputs/opensearch/)** | outputs | Send your logs to OpenSearch | GA | [1.0.5](https://github.com/fluent/fluent-plugin-opensearch/releases/tag/v1.0.5) |
+| **[Alibaba Cloud Storage](outputs/oss/)** | outputs | Store logs the Alibaba Cloud Object Storage Service | GA | [0.0.2](https://github.com/aliyun/fluent-plugin-oss) |
+| **[Redis](outputs/redis/)** | outputs | Sends logs to Redis endpoints. | GA | [0.3.5](https://github.com/fluent-plugins-nursery/fluent-plugin-redis) |
+| **[Relabel](outputs/relabel/)** | outputs | Relabel output plugin re-labels events. | GA | [more info](https://docs.fluentd.org/output/relabel) |
+| **[Amazon S3](outputs/s3/)** | outputs | Store logs in Amazon S3 | GA | [1.6.1](https://github.com/fluent/fluent-plugin-s3/releases/tag/v1.6.1) |
+| **[Splunk Hec](outputs/splunk_hec/)** | outputs | Fluent Plugin Splunk Hec Release | GA | [1.2.9]() |
+| **[SQS](outputs/sqs/)** | outputs | Output plugin writes fluent-events as queue messages to Amazon SQS | Testing | [v2.1.0](https://github.com/ixixi/fluent-plugin-sqs) |
+| **[SumoLogic](outputs/sumologic/)** | outputs | Send your logs to Sumologic | GA | [1.8.0](https://github.com/SumoLogic/fluentd-output-sumologic/releases/tag/1.8.0) |
+| **[Syslog](outputs/syslog/)** | outputs | Output plugin writes events to syslog | GA | [0.9.0.rc.8](https://github.com/cloudfoundry/fluent-plugin-syslog_rfc5424) |
+| **[Syslog-NG Match](syslogng-filters/match/)** | syslogng-filters | Selectively keep records | GA | [more info](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/65#TOPIC-1829159) |
+| **[Syslog-NG Parser](syslogng-filters/parser/)** | syslogng-filters | Parse data from records | GA | [more info](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/90) |
+| **[Syslog-NG Rewrite](syslogng-filters/rewrite/)** | syslogng-filters | Rewrite parts of the message | GA | [more info](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/77) |
+| **[disk-buffer configuration](syslogng-outputs/disk_buffer/)** | syslogng-outputs | disk-buffer configuration | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338) |
+| **[File](syslogng-outputs/file/)** | syslogng-outputs | SStoring messages in plain-text files | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.17/administration-guide/32) |
+| **[HTTP](syslogng-outputs/http/)** | syslogng-outputs | Sending messages over HTTP | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/40#TOPIC-1829058) |
+| **[Loggly](syslogng-outputs/loggly/)** | syslogng-outputs | Send your logs to loggly | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/43#TOPIC-1829072) |
+| **[Falcon LogScale](syslogng-outputs/logscale/)** | syslogng-outputs | Storing messages in Falcon's LogScale over http | Testing | [](https://library.humio.com/falcon-logscale/api-ingest.html#api-ingest-structured-data) |
+| **[MQTT Destination](syslogng-outputs/mqtt/)** | syslogng-outputs | Sending messages over MQTT Protocol | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/45#TOPIC-1829079) |
+| **[Sumo Logic HTTP](syslogng-outputs/sumologic_http/)** | syslogng-outputs | Storing messages in Sumo Logic over http | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/55) |
+| **[Sumo Logic Syslog](syslogng-outputs/sumologic_syslog/)** | syslogng-outputs | Storing messages in Sumo Logic over syslog | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#TOPIC-1829122) |
+| **[Syslog output configuration](syslogng-outputs/syslog/)** | syslogng-outputs | Syslog output configuration | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338) |
+| **[TLS config for syslog-ng outputs](syslogng-outputs/tls/)** | syslogng-outputs | TLS config for syslog-ng outputs | Testing | [](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338) |
 </center>
+

--- a/docs/configuration/plugins/filters/concat.md
+++ b/docs/configuration/plugins/filters/concat.md
@@ -17,11 +17,11 @@ Specify field name in the record to parse. If you leave empty the Container Runt
 
 Default: -
 
-### separator (string, optional) {#concat-separator}
+### separator (*string, optional) {#concat-separator}
 
-The separator of lines.  
+The separator of lines. (default: "\n") 
 
-Default:  "\n"
+Default: \"\\n\"
 
 ### n_lines (int, optional) {#concat-n_lines}
 
@@ -101,33 +101,63 @@ If true, keep partial metadata
 
 Default: -
 
+### partial_metadata_format (string, optional) {#concat-partial_metadata_format}
 
- #### Example `Concat` filter configurations
+Input format of the partial metadata (fluentd or journald docker log driver)( docker-fluentd, docker-journald, docker-journald-lowercase) 
+
+Default: -
+
+### use_partial_cri_logtag (bool, optional) {#concat-use_partial_cri_logtag}
+
+Use cri log tag to concatenate multiple records 
+
+Default: -
+
+### partial_cri_logtag_key (string, optional) {#concat-partial_cri_logtag_key}
+
+The key name that is referred to concatenate records on cri log 
+
+Default: -
+
+### partial_cri_stream_key (string, optional) {#concat-partial_cri_stream_key}
+
+The key name that is referred to detect stream name on cri log 
+
+Default: -
+
+
+ ## Example `Concat` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - concat:
-        partial_key: "partial_message"
-        separator: ""
-        n_lines: 10
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - concat:
+	      partial_key: "partial_message"
+	      separator: ""
+	      n_lines: 10
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type concat
-  @id test_concat
-  key message
-  n_lines 10
-  partial_key partial_message
-</filter>
+ <filter **>
+
+	@type concat
+	@id test_concat
+	key message
+	n_lines 10
+	partial_key partial_message
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/dedot.md
+++ b/docs/configuration/plugins/filters/dedot.md
@@ -24,30 +24,36 @@ Separator
 Default: _
 
 
- #### Example `Dedot` filter configurations
+ ## Example `Dedot` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - dedot:
-        de_dot_separator: "-"
-        de_dot_nested: true
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - dedot:
+	      de_dot_separator: "-"
+	      de_dot_nested: true
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type dedot
-  @id test_dedot
-  de_dot_nested true
-  de_dot_separator -
-</filter>
+ <filter **>
+
+	@type dedot
+	@id test_dedot
+	de_dot_nested true
+	de_dot_separator -
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/detect_exceptions.md
+++ b/docs/configuration/plugins/filters/detect_exceptions.md
@@ -6,17 +6,18 @@ generated_file: true
 
 # Exception Detector
 ## Overview
-This filter plugin consumes a log stream of JSON objects which contain single-line log messages. If a consecutive sequence of log messages form an exception stack trace, they forwarded as a single, combined JSON object. Otherwise, the input log data is forwarded as is.
-More info at https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions
+ This filter plugin consumes a log stream of JSON objects which contain single-line log messages. If a consecutive sequence of log messages form an exception stack trace, they forwarded as a single, combined JSON object. Otherwise, the input log data is forwarded as is.
+ More info at https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions
 
  > Note: As Tag management is not supported yet, this Plugin is **mutually exclusive** with [Tag normaliser](../tagnormaliser)
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
-filters:
-  - detectExceptions:
-      languages: java, python
-      multiline_flush_interval: 0.1
+ filters:
+   - detectExceptions:
+     languages: java, python
+     multiline_flush_interval: 0.1
+
  ```
 
 ## Configuration
@@ -32,7 +33,7 @@ Default:  ""
 
 The prefix to be removed from the input tag when outputting a record.  
 
-Default:  ""
+Default:  kubernetes
 
 ### multiline_flush_interval (string, optional) {#detectexceptions-multiline_flush_interval}
 
@@ -70,34 +71,46 @@ Force line breaks between each lines when comibining exception stacks.
 
 Default:  false
 
+### match_tag (string, optional) {#detectexceptions-match_tag}
 
- #### Example `Exception Detector` filter configurations
+Tag used in match directive.  
+
+Default:  kubernetes.**
+
+
+ ## Example `Exception Detector` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - detectExceptions:
-        multiline_flush_interval: 0.1
-        languages:
-          - java
-          - python
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - detectExceptions:
+	      multiline_flush_interval: 0.1
+	      languages:
+	        - java
+	        - python
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<match kubernetes.**>
-  @type detect_exceptions
-  @id test_detect_exceptions
-  languages ["java","python"]
-  multiline_flush_interval 0.1
-  remove_tag_prefix kubernetes
-</match>
+ <match kubernetes.**>
+
+	@type detect_exceptions
+	@id test_detect_exceptions
+	languages ["java","python"]
+	multiline_flush_interval 0.1
+	remove_tag_prefix kubernetes
+
+ </match>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/enhance_k8s.md
+++ b/docs/configuration/plugins/filters/enhance_k8s.md
@@ -114,23 +114,29 @@ Cache refresh variation
 Default:  60*15
 
 
- #### Example `EnhanceK8s` filter configurations
+ ## Example `EnhanceK8s` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Logging
-metadata:
-  name: demo-flow
-spec:
-  globalFilters:
-    - enhanceK8s: {}
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Logging
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	globalFilters:
+	  - enhanceK8s: {}
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type enhance_k8s_metadata
-  @id test_enhanceK8s
-</filter>
+ <filter **>
+
+	@type enhance_k8s_metadata
+	@id test_enhanceK8s
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/geoip.md
+++ b/docs/configuration/plugins/filters/geoip.md
@@ -36,7 +36,7 @@ Specify backend library (geoip2_c, geoip, geoip2_compat)
 
 Default: -
 
-### skip_adding_null_record (bool, optional) {#geoip-skip_adding_null_record}
+### skip_adding_null_record (*bool, optional) {#geoip-skip_adding_null_record}
 
 To avoid get stacktrace error with `[null, null]` array for elasticsearch. 
 
@@ -49,42 +49,48 @@ Records are represented as maps: `key: value`
 Default: -
 
 
- #### Example `GeoIP` filter configurations
+ ## Example `GeoIP` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - geoip:
-        geoip_lookup_keys: remote_addr
-        records:
-          - city: ${city.names.en["remote_addr"]}
-            location_array: '''[${location.longitude["remote"]},${location.latitude["remote"]}]'''
-            country: ${country.iso_code["remote_addr"]}
-            country_name: ${country.names.en["remote_addr"]}
-            postal_code:  ${postal.code["remote_addr"]}
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - geoip:
+	      geoip_lookup_keys: remote_addr
+	      records:
+	        - city: ${city.names.en["remote_addr"]}
+	          location_array: '''[${location.longitude["remote"]},${location.latitude["remote"]}]'''
+	          country: ${country.iso_code["remote_addr"]}
+	          country_name: ${country.names.en["remote_addr"]}
+	          postal_code:  ${postal.code["remote_addr"]}
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type geoip
-  @id test_geoip
-  geoip_lookup_keys remote_addr
-  skip_adding_null_record true
-  <record>
-    city ${city.names.en["remote_addr"]}
-    country ${country.iso_code["remote_addr"]}
-    country_name ${country.names.en["remote_addr"]}
-    location_array '[${location.longitude["remote"]},${location.latitude["remote"]}]'
-    postal_code ${postal.code["remote_addr"]}
-  </record>
-</filter>
+ <filter **>
+
+	@type geoip
+	@id test_geoip
+	geoip_lookup_keys remote_addr
+	skip_adding_null_record true
+	<record>
+	  city ${city.names.en["remote_addr"]}
+	  country ${country.iso_code["remote_addr"]}
+	  country_name ${country.names.en["remote_addr"]}
+	  location_array '[${location.longitude["remote"]},${location.latitude["remote"]}]'
+	  postal_code ${postal.code["remote_addr"]}
+	</record>
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/grep.md
+++ b/docs/configuration/plugins/filters/grep.md
@@ -36,203 +36,227 @@ Default: -
 Default: -
 
 
-## [Regexp Directive](https://docs.fluentd.org/filter/grep#less-than-regexp-greater-than-directive) {#Regexp-Directive}
+## Regexp Directive
 
-Specify filtering rule. This directive contains two parameters.
+Specify filtering rule (as described in the [Fluentd documentation](https://docs.fluentd.org/filter/grep#less-than-regexp-greater-than-directive)). This directive contains two parameters.
 
-### key (string, required) {#[regexp directive](https://docs.fluentd.org/filter/grep#less-than-regexp-greater-than-directive) {#regexp-directive}-key}
+### key (string, required) {#regexp directive-key}
 
 Specify field name in the record to parse. 
 
 Default: -
 
-### pattern (string, required) {#[regexp directive](https://docs.fluentd.org/filter/grep#less-than-regexp-greater-than-directive) {#regexp-directive}-pattern}
+### pattern (string, required) {#regexp directive-pattern}
 
 Pattern expression to evaluate 
 
 Default: -
 
 
- #### Example `Regexp` filter configurations
+ ## Example `Regexp` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - grep:
-        regexp:
-        - key: first
-          pattern: /^5\d\d$/
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - grep:
+	      regexp:
+	      - key: first
+	        pattern: /^5\d\d$/
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-  <filter **>
-    @type grep
-    @id demo-flow_1_grep
-    <regexp>
-      key first
-      pattern /^5\d\d$/
-    </regexp>
-  </filter>
+
+	<filter **>
+	  @type grep
+	  @id demo-flow_1_grep
+	  <regexp>
+	    key first
+	    pattern /^5\d\d$/
+	  </regexp>
+	</filter>
+
  ```
 
 ---
-## [Exclude Directive](https://docs.fluentd.org/filter/grep#less-than-exclude-greater-than-directive) {#Exclude-Directive}
+## Exclude Directive
 
-Specify filtering rule to reject events. This directive contains two parameters.
+Specify filtering rule to reject events (as described in the [Fluentd documentation](https://docs.fluentd.org/filter/grep#less-than-exclude-greater-than-directive)). This directive contains two parameters.
 
-### key (string, required) {#[exclude directive](https://docs.fluentd.org/filter/grep#less-than-exclude-greater-than-directive) {#exclude-directive}-key}
+### key (string, required) {#exclude directive-key}
 
 Specify field name in the record to parse. 
 
 Default: -
 
-### pattern (string, required) {#[exclude directive](https://docs.fluentd.org/filter/grep#less-than-exclude-greater-than-directive) {#exclude-directive}-pattern}
+### pattern (string, required) {#exclude directive-pattern}
 
 Pattern expression to evaluate 
 
 Default: -
 
 
- #### Example `Exclude` filter configurations
+ ## Example `Exclude` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - grep:
-        exclude:
-        - key: first
-          pattern: /^5\d\d$/
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - grep:
+	      exclude:
+	      - key: first
+	        pattern: /^5\d\d$/
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-  <filter **>
-    @type grep
-    @id demo-flow_0_grep
-    <exclude>
-      key first
-      pattern /^5\d\d$/
-    </exclude>
-  </filter>
+
+	<filter **>
+	  @type grep
+	  @id demo-flow_0_grep
+	  <exclude>
+	    key first
+	    pattern /^5\d\d$/
+	  </exclude>
+	</filter>
+
  ```
 
 ---
-## [Or Directive](https://docs.fluentd.org/filter/grep#less-than-or-greater-than-directive) {#Or-Directive}
+## Or Directive
 
-Specify filtering rule. This directive contains either `regexp` or `exclude` directive.
+Specify filtering rule (as described in the [Fluentd documentation](https://docs.fluentd.org/filter/grep#less-than-or-greater-than-directive). This directive contains either `regexp` or `exclude` directive.
 
-### regexp ([]RegexpSection, optional) {#[or directive](https://docs.fluentd.org/filter/grep#less-than-or-greater-than-directive) {#or-directive}-regexp}
+### regexp ([]RegexpSection, optional) {#or directive-regexp}
 
 [Regexp Directive](#Regexp-Directive) 
 
 Default: -
 
-### exclude ([]ExcludeSection, optional) {#[or directive](https://docs.fluentd.org/filter/grep#less-than-or-greater-than-directive) {#or-directive}-exclude}
+### exclude ([]ExcludeSection, optional) {#or directive-exclude}
 
 [Exclude Directive](#Exclude-Directive) 
 
 Default: -
 
 
- #### Example `Or` filter configurations
+ ## Example `Or` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - grep:
-        or:
-          - exclude:
-            - key: first
-              pattern: /^5\d\d$/
-            - key: second
-              pattern: /\.css$/
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
 
-  selectors: {}
-  localOutputRefs:
-    - demo-output
-```
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - grep:
+	      or:
+	        - exclude:
+	          - key: first
+	            pattern: /^5\d\d$/
+	          - key: second
+	            pattern: /\.css$/
+
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
+ ```
 
  #### Fluentd Config Result
  ```yaml
-    <or>
-      <exclude>
-        key first
-        pattern /^5\d\d$/
-      </exclude>
-      <exclude>
-        key second
-        pattern /\.css$/
-      </exclude>
-    </or>
+
+	<or>
+	  <exclude>
+	    key first
+	    pattern /^5\d\d$/
+	  </exclude>
+	  <exclude>
+	    key second
+	    pattern /\.css$/
+	  </exclude>
+	</or>
+
  ```
 
 ---
-## [And Directive](https://docs.fluentd.org/filter/grep#less-than-and-greater-than-directive) {#And-Directive}
+## And Directive
 
-Specify filtering rule. This directive contains either `regexp` or `exclude` directive.
+Specify filtering rule (as described in the [Fluentd documentation](https://docs.fluentd.org/filter/grep#less-than-and-greater-than-directive). This directive contains either `regexp` or `exclude` directive.
 
-### regexp ([]RegexpSection, optional) {#[and directive](https://docs.fluentd.org/filter/grep#less-than-and-greater-than-directive) {#and-directive}-regexp}
+### regexp ([]RegexpSection, optional) {#and directive-regexp}
 
 [Regexp Directive](#Regexp-Directive) 
 
 Default: -
 
-### exclude ([]ExcludeSection, optional) {#[and directive](https://docs.fluentd.org/filter/grep#less-than-and-greater-than-directive) {#and-directive}-exclude}
+### exclude ([]ExcludeSection, optional) {#and directive-exclude}
 
 [Exclude Directive](#Exclude-Directive) 
 
 Default: -
 
 
- #### Example `And` filter configurations
+ ## Example `And` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - grep:
-        and:
-          - regexp:
-            - key: first
-              pattern: /^5\d\d$/
-            - key: second
-              pattern: /\.css$/
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
 
-  selectors: {}
-  localOutputRefs:
-    - demo-output
-```
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - grep:
+	      and:
+	        - regexp:
+	          - key: first
+	            pattern: /^5\d\d$/
+	          - key: second
+	            pattern: /\.css$/
+
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
+ ```
 
  #### Fluentd Config Result
  ```yaml
-    <and>
-      <regexp>
-        key first
-        pattern /^5\d\d$/
-      </regexp>
-      <regexp>
-        key second
-        pattern /\.css$/
-      </regexp>
-    </and>
+
+	<and>
+	  <regexp>
+	    key first
+	    pattern /^5\d\d$/
+	  </regexp>
+	  <regexp>
+	    key second
+	    pattern /\.css$/
+	  </regexp>
+	</and>
+
  ```
 
 ---

--- a/docs/configuration/plugins/filters/kube_events_timestamp.md
+++ b/docs/configuration/plugins/filters/kube_events_timestamp.md
@@ -24,23 +24,27 @@ Added time field name
 Default:  triggerts
 
 
- #### Example `Kubernetes Events Timestamp` filter configurations
+ ## Example `Kubernetes Events Timestamp` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: es-flow
-spec:
-  filters:
-    - kube_events_timestamp:
-        timestamp_fields:
-          - "event.eventTime"
-          - "event.lastTimestamp"
-          - "event.firstTimestamp"
-        mapped_time_key: mytimefield
-  selectors: {}
-  localOutputRefs:
-    - es-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: es-flow
+
+ spec:
+
+	filters:
+	  - kube_events_timestamp:
+	      timestamp_fields:
+	        - "event.eventTime"
+	        - "event.lastTimestamp"
+	        - "event.firstTimestamp"
+	      mapped_time_key: mytimefield
+	selectors: {}
+	localOutputRefs:
+	  - es-output
+
  ```
 
  #### Fluentd Config Result

--- a/docs/configuration/plugins/filters/parser.md
+++ b/docs/configuration/plugins/filters/parser.md
@@ -399,51 +399,57 @@ Use specified timezone. one can parse/format the time value in the specified tim
 Default: -
 
 
- #### Example `Parser` filter configurations
+ ## Example `Parser` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - parser:
-        remove_key_name_field: true
-        reserve_data: true
-        parse:
-          type: multi_format
-          patterns:
-          - format: nginx
-          - format: regexp
-            expression: /foo/
-          - format: none
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - parser:
+	      remove_key_name_field: true
+	      reserve_data: true
+	      parse:
+	        type: multi_format
+	        patterns:
+	        - format: nginx
+	        - format: regexp
+	          expression: /foo/
+	        - format: none
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type parser
-  @id test_parser
-  key_name message
-  remove_key_name_field true
-  reserve_data true
-  <parse>
-    @type multi_format
-    <pattern>
-      format nginx
-    </pattern>
-    <pattern>
-      expression /foo/
-      format regexp
-    </pattern>
-    <pattern>
-      format none
-    </pattern>
-  </parse>
-</filter>
+ <filter **>
+
+	@type parser
+	@id test_parser
+	key_name message
+	remove_key_name_field true
+	reserve_data true
+	<parse>
+	  @type multi_format
+	  <pattern>
+	    format nginx
+	  </pattern>
+	  <pattern>
+	    expression /foo/
+	    format regexp
+	  </pattern>
+	  <pattern>
+	    format none
+	  </pattern>
+	</parse>
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/prometheus.md
+++ b/docs/configuration/plugins/filters/prometheus.md
@@ -61,55 +61,61 @@ Additional labels for this metric
 Default: -
 
 
- #### Example `Prometheus` filter configurations
+ ## Example `Prometheus` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - tag_normaliser: {}
-    - parser:
-        remove_key_name_field: true
-        reserve_data: true
-        parse:
-          type: nginx
-    - prometheus:
-        metrics:
-        - name: total_counter
-          desc: The total number of foo in message.
-          type: counter
-          labels:
-            foo: bar
-        labels:
-          host: ${hostname}
-          tag: ${tag}
-          namespace: $.kubernetes.namespace
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - tag_normaliser: {}
+	  - parser:
+	      remove_key_name_field: true
+	      reserve_data: true
+	      parse:
+	        type: nginx
+	  - prometheus:
+	      metrics:
+	      - name: total_counter
+	        desc: The total number of foo in message.
+	        type: counter
+	        labels:
+	          foo: bar
+	      labels:
+	        host: ${hostname}
+	        tag: ${tag}
+	        namespace: $.kubernetes.namespace
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```
-  <filter **>
-    @type prometheus
-    @id logging-demo-flow_2_prometheus
-    <metric>
-      desc The total number of foo in message.
-      name total_counter
-      type counter
-      <labels>
-        foo bar
-      </labels>
-    </metric>
-    <labels>
-      host ${hostname}
-      namespace $.kubernetes.namespace
-      tag ${tag}
-    </labels>
-  </filter>
+
+	<filter **>
+	  @type prometheus
+	  @id logging-demo-flow_2_prometheus
+	  <metric>
+	    desc The total number of foo in message.
+	    name total_counter
+	    type counter
+	    <labels>
+	      foo bar
+	    </labels>
+	  </metric>
+	  <labels>
+	    host ${hostname}
+	    namespace $.kubernetes.namespace
+	    tag ${tag}
+	  </labels>
+	</filter>
+
  ```
 
 ---

--- a/docs/configuration/plugins/filters/record_modifier.md
+++ b/docs/configuration/plugins/filters/record_modifier.md
@@ -48,31 +48,37 @@ Add records docs at: https://github.com/repeatedly/fluent-plugin-record-modifier
 Default: -
 
 
- #### Example `Record Modifier` filter configurations
+ ## Example `Record Modifier` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - record_modifier:
-        records:
-        - foo: "bar"
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - record_modifier:
+	      records:
+	      - foo: "bar"
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type record_modifier
-  @id test_record_modifier
-  <record>
-    foo bar
-  </record>
-</filter>
+ <filter **>
+
+	@type record_modifier
+	@id test_record_modifier
+	<record>
+	  foo bar
+	</record>
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/record_transformer.md
+++ b/docs/configuration/plugins/filters/record_transformer.md
@@ -54,31 +54,37 @@ Add records docs at: https://docs.fluentd.org/filter/record_transformer Records 
 Default: -
 
 
- #### Example `Record Transformer` filter configurations
+ ## Example `Record Transformer` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - record_transformer:
-        records:
-        - foo: "bar"
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - record_transformer:
+	      records:
+	      - foo: "bar"
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type record_transformer
-  @id test_record_transformer
-  <record>
-    foo bar
-  </record>
-</filter>
+ <filter **>
+
+	@type record_transformer
+	@id test_record_transformer
+	<record>
+	  foo bar
+	</record>
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/stdout.md
+++ b/docs/configuration/plugins/filters/stdout.md
@@ -18,28 +18,34 @@ This is the option of stdout format.
 Default: -
 
 
- #### Example `StdOut` filter configurations
+ ## Example `StdOut` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - stdout:
-        output_type: json
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - stdout:
+	      output_type: json
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type stdout
-  @id test_stdout
-  output_type json
-</filter>
+ <filter **>
+
+	@type stdout
+	@id test_stdout
+	output_type json
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/sumologic.md
+++ b/docs/configuration/plugins/filters/sumologic.md
@@ -6,7 +6,7 @@ generated_file: true
 
 # Sumo Logic collection solution for Kubernetes
 ## Overview
-More info at https://github.com/SumoLogic/sumologic-kubernetes-collection
+ More info at https://github.com/SumoLogic/sumologic-kubernetes-collection
 
 ## Configuration
 ## SumoLogic
@@ -168,28 +168,34 @@ Collector Value
 Default:  "undefined"
 
 
- #### Example `Parser` filter configurations
+ ## Example `Parser` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - sumologic:
-        source_name: "elso"
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - sumologic:
+	      source_name: "elso"
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type kubernetes_sumologic
-  @id test_sumologic
-  source_name elso
-</filter>
+ <filter **>
+
+	@type kubernetes_sumologic
+	@id test_sumologic
+	source_name elso
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/tagnormaliser.md
+++ b/docs/configuration/plugins/filters/tagnormaliser.md
@@ -6,19 +6,19 @@ generated_file: true
 
 # Fluentd Plugin to re-tag based on log metadata
 ## Overview
-More info at https://github.com/kube-logging/fluent-plugin-tag-normaliser
+ More info at https://github.com/kube-logging/fluent-plugin-tag-normaliser
 
-Available kubernetes metadata
+ # Available kubernetes metadata
 
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| ${pod_name} | Pod name | understood-butterfly-logging-demo-7dcdcfdcd7-h7p9n |
-| ${container_name} | Container name inside the Pod | logging-demo |
-| ${namespace_name} | Namespace name | default |
-| ${pod_id} | Kubernetes UUID for Pod | 1f50d309-45a6-11e9-b795-025000000001  |
-| ${labels} | Kubernetes Pod labels. This is a nested map. You can access nested attributes via `.`  | {"app":"logging-demo", "pod-template-hash":"7dcdcfdcd7" }  |
-| ${host} | Node hostname the Pod runs on | docker-desktop |
-| ${docker_id} | Docker UUID of the container | 3a38148aa37aa3... |
+ | Parameter | Description | Example |
+ |-----------|-------------|---------|
+ | ${pod_name} | Pod name | understood-butterfly-logging-demo-7dcdcfdcd7-h7p9n |
+ | ${container_name} | Container name inside the Pod | logging-demo |
+ | ${namespace_name} | Namespace name | default |
+ | ${pod_id} | Kubernetes UUID for Pod | 1f50d309-45a6-11e9-b795-025000000001  |
+ | ${labels} | Kubernetes Pod labels. This is a nested map. You can access nested attributes via `.`  | {"app":"logging-demo", "pod-template-hash":"7dcdcfdcd7" }  |
+ | ${host} | Node hostname the Pod runs on | docker-desktop |
+ | ${docker_id} | Docker UUID of the container | 3a38148aa37aa3... |
 
 ## Configuration
 ## Tag Normaliser parameters
@@ -29,29 +29,41 @@ Re-Tag log messages info at [github](https://github.com/kube-logging/fluent-plug
 
 Default: ${namespace_name}.${pod_name}.${container_name}
 
+### match_tag (string, optional) {#tag normaliser parameters-match_tag}
 
- #### Example `Parser` filter configurations
+Tag used in match directive.  
+
+Default:  kubernetes.**
+
+
+ ## Example `Parser` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - tag_normaliser:
-        format: cluster1.${namespace_name}.${pod_name}.${labels.app}
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - tag_normaliser:
+	      format: cluster1.${namespace_name}.${pod_name}.${labels.app}
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<match kubernetes.**>
-  @type tag_normaliser
-  @id test_tag_normaliser
-  format cluster1.${namespace_name}.${pod_name}.${labels.app}
-</match>
+ <match kubernetes.**>
+
+	@type tag_normaliser
+	@id test_tag_normaliser
+	format cluster1.${namespace_name}.${pod_name}.${labels.app}
+
+ </match>
  ```
 
 ---

--- a/docs/configuration/plugins/filters/throttle.md
+++ b/docs/configuration/plugins/filters/throttle.md
@@ -42,28 +42,34 @@ When a group reaches its limit and as long as it is not reset, a warning message
 Default:  10 seconds
 
 
- #### Example `Throttle` filter configurations
+ ## Example `Throttle` filter configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Flow
-metadata:
-  name: demo-flow
-spec:
-  filters:
-    - throttle:
-        group_key: "$.kubernetes.container_name"
-  selectors: {}
-  localOutputRefs:
-    - demo-output
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - throttle:
+	      group_key: "$.kubernetes.container_name"
+	selectors: {}
+	localOutputRefs:
+	  - demo-output
+
  ```
 
  #### Fluentd Config Result
  ```yaml
-<filter **>
-  @type throttle
-  @id test_throttle
-  group_key $.kubernetes.container_name
-</filter>
+ <filter **>
+
+	@type throttle
+	@id test_throttle
+	group_key $.kubernetes.container_name
+
+ </filter>
  ```
 
 ---

--- a/docs/configuration/plugins/outputs/aws_elasticsearch.md
+++ b/docs/configuration/plugins/outputs/aws_elasticsearch.md
@@ -6,17 +6,27 @@ generated_file: true
 
 # Amazon Elasticsearch output plugin for Fluentd
 ## Overview
-  More info at https://github.com/atomita/fluent-plugin-aws-elasticsearch-service
 
- #### Example output configurations
- ```yaml
+	More info at https://github.com/atomita/fluent-plugin-aws-elasticsearch-service
+
+ ## Example output configurations
+ {{< highlight yaml >}}
  spec:
-   kinesisStream:
-     stream_name: example-stream-name
-     region: us-east-1
-     format:
-       type: json
- ```
+
+	awsElasticsearch:
+	  logstash_format: true
+	  include_tag_key: true
+	  tag_key: "@log_name"
+	  flush_interval: 1s
+	  endpoint:
+	    url: https://CLUSTER_ENDPOINT_URL
+	    region: eu-west-1
+	    access_key_id:
+	      value: aws-key
+	    secret_access_key:
+	      value: aws_secret
+
+ {{</ highlight >}}
 
 ## Configuration
 ## Amazon Elasticsearch

--- a/docs/configuration/plugins/outputs/azurestore.md
+++ b/docs/configuration/plugins/outputs/azurestore.md
@@ -6,8 +6,8 @@ generated_file: true
 
 # Azure Storage output plugin for Fluentd
 ## Overview
-Azure Storage output plugin buffers logs in local file and upload them to Azure Storage periodically.
-More info at https://github.com/microsoft/fluent-plugin-azure-storage-append-blob
+ Azure Storage output plugin buffers logs in local file and upload them to Azure Storage periodically.
+ More info at https://github.com/microsoft/fluent-plugin-azure-storage-append-blob
 
 ## Configuration
 ## Output Config
@@ -69,6 +69,12 @@ Default: json
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/cloudwatch.md
+++ b/docs/configuration/plugins/outputs/cloudwatch.md
@@ -6,31 +6,33 @@ generated_file: true
 
 # CloudWatch output plugin for Fluentd
 ## Overview
-This plugin has been designed to output logs or metrics to Amazon CloudWatch.
-More info at https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs
+ This plugin has been designed to output logs or metrics to Amazon CloudWatch.
+ More info at [https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs).
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-  cloudwatch:
-    aws_key_id:
-      valueFrom:
-        secretKeyRef:
-          name: logging-s3
-          key: awsAccessKeyId
-    aws_sec_key:
-      valueFrom:
-        secretKeyRef:
-          name: logging-s3
-          key: awsSecretAccessKey
-    log_group_name: operator-log-group
-    log_stream_name: operator-log-stream
-    region: us-east-1
-    auto_create_stream true
-    buffer:
-      timekey: 30s
-      timekey_wait: 30s
-      timekey_use_utc: true
+
+	cloudwatch:
+	  aws_key_id:
+	    valueFrom:
+	      secretKeyRef:
+	        name: logging-s3
+	        key: awsAccessKeyId
+	  aws_sec_key:
+	    valueFrom:
+	      secretKeyRef:
+	        name: logging-s3
+	        key: awsSecretAccessKey
+	  log_group_name: operator-log-group
+	  log_stream_name: operator-log-stream
+	  region: us-east-1
+	  auto_create_stream true
+	  buffer:
+	    timekey: 30s
+	    timekey_wait: 30s
+	    timekey_use_utc: true
+
  ```
 
 ## Configuration
@@ -249,6 +251,12 @@ Default: -
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/datadog.md
+++ b/docs/configuration/plugins/outputs/datadog.md
@@ -6,8 +6,20 @@ generated_file: true
 
 # Datadog output plugin for Fluentd
 ## Overview
-It mainly contains a proper JSON formatter and a socket handler that streams logs directly to Datadog - so no need to use a log shipper if you don't wan't to.
-More info at https://github.com/DataDog/fluent-plugin-datadog
+ It mainly contains a proper JSON formatter and a socket handler that streams logs directly to Datadog - so no need to use a log shipper if you don't wan't to.
+ More info at [https://github.com/DataDog/fluent-plugin-datadog](https://github.com/DataDog/fluent-plugin-datadog).
+
+ ## Example
+ ```yaml
+ spec:
+
+	datadog:
+	  api_key '<YOUR_API_KEY>'
+	  dd_source: '<INTEGRATION_NAME>'
+	  dd_tags: '<KEY1:VALUE1>,<KEY2:VALUE2>'
+	  dd_sourcecategory: '<YOUR_SOURCE_CATEGORY>'
+
+ ```
 
 ## Configuration
 ## Output Config
@@ -135,6 +147,12 @@ Default:  "http-intake.logs.datadoghq.com"
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/elasticsearch.md
+++ b/docs/configuration/plugins/outputs/elasticsearch.md
@@ -6,22 +6,24 @@ generated_file: true
 
 # Elasticsearch output plugin for Fluentd
 ## Overview
-More info at https://github.com/uken/fluent-plugin-elasticsearch
->Example Deployment: [Save all logs to ElasticSearch](../../../../quickstarts/es-nginx/)
+ More info at https://github.com/uken/fluent-plugin-elasticsearch
+ >Example Deployment: [Save all logs to ElasticSearch](../../../../quickstarts/es-nginx/)
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   elasticsearch:
-     host: elasticsearch-elasticsearch-cluster.default.svc.cluster.local
-     port: 9200
-     scheme: https
-     ssl_verify: false
-     ssl_version: TLSv1_2
-     buffer:
-       timekey: 1m
-       timekey_wait: 30s
-       timekey_use_utc: true
+
+	elasticsearch:
+	  host: elasticsearch-elasticsearch-cluster.default.svc.cluster.local
+	  port: 9200
+	  scheme: https
+	  ssl_verify: false
+	  ssl_version: TLSv1_2
+	  buffer:
+	    timekey: 1m
+	    timekey_wait: 30s
+	    timekey_use_utc: true
+
  ```
 
 ## Configuration
@@ -504,6 +506,12 @@ Default: -
 ### buffer (*Buffer, optional) {#elasticsearch-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#elasticsearch-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/file.md
+++ b/docs/configuration/plugins/outputs/file.md
@@ -65,40 +65,52 @@ Default: -
 
 Default: -
 
+### slow_flush_log_threshold (string, optional) {#fileoutputconfig-slow_flush_log_threshold}
 
- #### Example `File` output configurations
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
+
+Default: -
+
+
+ ## Example `File` output configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Output
-metadata:
-  name: demo-output
-spec:
-  file:
-    path: /tmp/logs/${tag}/%Y/%m/%d.%H.%M
-    append: true
-    buffer:
-      timekey: 1m
-      timekey_wait: 10s
-      timekey_use_utc: true
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Output
+ metadata:
+
+	name: demo-output
+
+ spec:
+
+	file:
+	  path: /tmp/logs/${tag}/%Y/%m/%d.%H.%M
+	  append: true
+	  buffer:
+	    timekey: 1m
+	    timekey_wait: 10s
+	    timekey_use_utc: true
+
  ```
 
  #### Fluentd Config Result
  ```
-  <match **>
-	@type file
-	@id test_file
-	add_path_suffix true
-	append true
-	path /tmp/logs/${tag}/%Y/%m/%d.%H.%M
-	<buffer tag,time>
-	  @type file
-	  path /buffers/test_file.*.buffer
-	  retry_forever true
-	  timekey 1m
-	  timekey_use_utc true
-	  timekey_wait 30s
-	</buffer>
-  </match>
+
+	 <match **>
+		@type file
+		@id test_file
+		add_path_suffix true
+		append true
+		path /tmp/logs/${tag}/%Y/%m/%d.%H.%M
+		<buffer tag,time>
+		  @type file
+		  path /buffers/test_file.*.buffer
+		  retry_forever true
+		  timekey 1m
+		  timekey_use_utc true
+		  timekey_wait 30s
+		</buffer>
+	 </match>
+
  ```
 
 ---

--- a/docs/configuration/plugins/outputs/format.md
+++ b/docs/configuration/plugins/outputs/format.md
@@ -4,6 +4,24 @@ weight: 200
 generated_file: true
 ---
 
+# Format output records
+## Overview
+ Specify how to format output records. For details, see [https://docs.fluentd.org/configuration/format-section](https://docs.fluentd.org/configuration/format-section).
+
+ ## Example
+ ```yaml
+ spec:
+
+	format:
+	  path: /tmp/logs/${tag}/%Y/%m/%d.%H.%M
+	  format:
+	    type: single_value
+	    add_newline: true
+	    message_key: msg
+
+ ```
+
+## Configuration
 ## Format
 
 ### type (string, optional) {#format-type}

--- a/docs/configuration/plugins/outputs/forward.md
+++ b/docs/configuration/plugins/outputs/forward.md
@@ -198,6 +198,12 @@ Default:  false
 
 Default: -
 
+### slow_flush_log_threshold (string, optional) {#forwardoutput-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
+
+Default: -
+
 
 ## Fluentd Server
 

--- a/docs/configuration/plugins/outputs/gcs.md
+++ b/docs/configuration/plugins/outputs/gcs.md
@@ -4,6 +4,22 @@ weight: 200
 generated_file: true
 ---
 
+# Google Cloud Storage
+## Overview
+ Store logs in Google Cloud Storage. For details, see [https://github.com/kube-logging/fluent-plugin-gcs](https://github.com/kube-logging/fluent-plugin-gcs).
+
+ ## Example
+ ```yaml
+ spec:
+
+	gcs:
+	  project: logging-example
+	  bucket: banzai-log-test
+	  path: logs/${tag}/%Y/%m/%d/
+
+ ```
+
+## Configuration
 ## GCSOutput
 
 ### project (string, required) {#gcsoutput-project}
@@ -117,6 +133,12 @@ Default: -
 ### buffer (*Buffer, optional) {#gcsoutput-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#gcsoutput-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/gelf.md
+++ b/docs/configuration/plugins/outputs/gelf.md
@@ -42,27 +42,32 @@ TLS Options  - for options see https://github.com/graylog-labs/gelf-rb/blob/7291
 Default:  {}
 
 
-
- #### Example `GELF` output configurations
+ ## Example `GELF` output configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Output
-metadata:
-  name: gelf-output-sample
-spec:
-  gelf:
-    host: gelf-host
-    port: 12201
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Output
+ metadata:
+
+	name: gelf-output-sample
+
+ spec:
+
+	gelf:
+	  host: gelf-host
+	  port: 12201
+
  ```
 
- #### Fluentd Config Result
+ ## Fluentd Config Result
  ```
-  <match **>
-	@type gelf
-	@id test_gelf
-	host gelf-host
-	port 12201
-  </match>
+
+	 <match **>
+		@type gelf
+		@id test_gelf
+		host gelf-host
+		port 12201
+	 </match>
+
  ```
 
 ---

--- a/docs/configuration/plugins/outputs/http.md
+++ b/docs/configuration/plugins/outputs/http.md
@@ -9,14 +9,16 @@ generated_file: true
  Sends logs to HTTP/HTTPS endpoints.
  More info at https://docs.fluentd.org/output/http.
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   http:
-     endpoint: http://logserver.com:9000/api
-     buffer:
-       tags: "[]"
-       flush_interval: 10s
+
+	http:
+	  endpoint: http://logserver.com:9000/api
+	  buffer:
+	    tags: "[]"
+	    flush_interval: 10s
+
  ```
 
 ## Configuration
@@ -145,6 +147,12 @@ Default: -
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/kafka.md
+++ b/docs/configuration/plugins/outputs/kafka.md
@@ -6,23 +6,27 @@ generated_file: true
 
 # Kafka output plugin for Fluentd
 ## Overview
-  More info at https://github.com/fluent/fluent-plugin-kafka
->Example Deployment: [Transport Nginx Access Logs into Kafka with Logging Operator](../../../../quickstarts/kafka-nginx/)
 
- #### Example output configurations
+	More info at https://github.com/fluent/fluent-plugin-kafka
+
+ >Example Deployment: [Transport Nginx Access Logs into Kafka with Logging Operator](../../../../quickstarts/kafka-nginx/)
+
+ ## Example output configurations
  ```yaml
  spec:
-   kafka:
-     brokers: kafka-headless.kafka.svc.cluster.local:29092
-     default_topic: topic
-     sasl_over_ssl: false
-     format:
-       type: json
-     buffer:
-       tags: topic
-       timekey: 1m
-       timekey_wait: 30s
-       timekey_use_utc: true
+
+	kafka:
+	  brokers: kafka-headless.kafka.svc.cluster.local:29092
+	  default_topic: topic
+	  sasl_over_ssl: false
+	  format:
+	    type: json
+	  buffer:
+	    tags: topic
+	    timekey: 1m
+	    timekey_wait: 30s
+	    timekey_use_utc: true
+
  ```
 
 ## Configuration
@@ -245,6 +249,12 @@ Default: -
 ### buffer (*Buffer, optional) {#kafka-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#kafka-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/kinesis_firehose.md
+++ b/docs/configuration/plugins/outputs/kinesis_firehose.md
@@ -6,16 +6,19 @@ generated_file: true
 
 # Kinesis Firehose output plugin for Fluentd
 ## Overview
-  More info at https://github.com/awslabs/aws-fluent-plugin-kinesis#configuration-kinesis_firehose
 
- #### Example output configurations
+	More info at https://github.com/awslabs/aws-fluent-plugin-kinesis#configuration-kinesis_firehose
+
+ ## Example output configurations
  ```yaml
  spec:
-   kinesisFirehose:
-     delivery_stream_name: example-stream-name
-     region: us-east-1
-     format:
-       type: json
+
+	kinesisFirehose:
+	  delivery_stream_name: example-stream-name
+	  region: us-east-1
+	  format:
+	    type: json
+
  ```
 
 ## Configuration
@@ -110,6 +113,12 @@ Default: -
 ### buffer (*Buffer, optional) {#kinesisstream-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#kinesisstream-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/kinesis_stream.md
+++ b/docs/configuration/plugins/outputs/kinesis_stream.md
@@ -6,16 +6,19 @@ generated_file: true
 
 # Kinesis Stream output plugin for Fluentd
 ## Overview
-  More info at https://github.com/awslabs/aws-fluent-plugin-kinesis#configuration-kinesis_streams
 
- #### Example output configurations
+	More info at https://github.com/awslabs/aws-fluent-plugin-kinesis#configuration-kinesis_streams
+
+ ## Example output configurations
  ```yaml
  spec:
-   kinesisStream:
-     stream_name: example-stream-name
-     region: us-east-1
-     format:
-       type: json
+
+	kinesisStream:
+	  stream_name: example-stream-name
+	  region: us-east-1
+	  format:
+	    type: json
+
  ```
 
 ## Configuration
@@ -110,6 +113,12 @@ Default: -
 ### buffer (*Buffer, optional) {#kinesisstream-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#kinesisstream-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/logdna.md
+++ b/docs/configuration/plugins/outputs/logdna.md
@@ -61,32 +61,44 @@ Default:  /logs/ingest
 
 Default: -
 
+### slow_flush_log_threshold (string, optional) {#logdna-slow_flush_log_threshold}
 
- #### Example `LogDNA` filter configurations
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
+
+Default: -
+
+
+ ## Example `LogDNA` filter configurations
  ```yaml
  apiVersion: logging.banzaicloud.io/v1beta1
  kind: Output
  metadata:
-   name: logdna-output-sample
+
+	name: logdna-output-sample
+
  spec:
-   logdna:
-     api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxx
-     hostname: logging-operator
-     app: my-app
-     tags: web,dev
-     ingester_domain https://logs.logdna.com
-     ingester_endpoint /logs/ingest
+
+	logdna:
+	  api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxx
+	  hostname: logging-operator
+	  app: my-app
+	  tags: web,dev
+	  ingester_domain https://logs.logdna.com
+	  ingester_endpoint /logs/ingest
+
  ```
 
  #### Fluentd Config Result
  ```
-<match **>
+ <match **>
+
 	@type logdna
 	@id test_logdna
 	api_key xxxxxxxxxxxxxxxxxxxxxxxxxxy
 	app my-app
 	hostname logging-operator
-</match>
+
+ </match>
  ```
 
 ---

--- a/docs/configuration/plugins/outputs/logz.md
+++ b/docs/configuration/plugins/outputs/logz.md
@@ -6,29 +6,31 @@ generated_file: true
 
 # LogZ output plugin for Fluentd
 ## Overview
-More info at https://github.com/tarokkk/fluent-plugin-logzio
+ More info at https://github.com/tarokkk/fluent-plugin-logzio
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   logz:
-     endpoint:
-       url: https://listener.logz.io
-       port: 8071
-       token:
-         valueFrom:
-          secretKeyRef:
-      	  name: logz-token
-            key: token
-     output_include_tags: true
-     output_include_time: true
-     buffer:
-       type: file
-       flush_mode: interval
-       flush_thread_count: 4
-       flush_interval: 5s
-       chunk_limit_size: 16m
-       queue_limit_length: 4096
+
+	logz:
+	  endpoint:
+	    url: https://listener.logz.io
+	    port: 8071
+	    token:
+	      valueFrom:
+	       secretKeyRef:
+	   	  name: logz-token
+	         key: token
+	  output_include_tags: true
+	  output_include_time: true
+	  buffer:
+	    type: file
+	    flush_mode: interval
+	    flush_thread_count: 4
+	    flush_interval: 5s
+	    chunk_limit_size: 16m
+	    queue_limit_length: 4096
+
  ```
 
 ## Configuration
@@ -93,6 +95,12 @@ Default: -
 ### buffer (*Buffer, optional) {#logzio-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#logzio-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/loki.md
+++ b/docs/configuration/plugins/outputs/loki.md
@@ -6,19 +6,21 @@ generated_file: true
 
 # Loki output plugin 
 ## Overview
-Fluentd output plugin to ship logs to a Loki server.
-More info at https://github.com/kube-logging/fluent-plugin-kubernetes-loki
->Example: [Store Nginx Access Logs in Grafana Loki with Logging Operator](../../../../quickstarts/loki-nginx/)
+ Fluentd output plugin to ship logs to a Loki server.
+ More info at https://grafana.com/docs/loki/latest/clients/fluentd/
+ >Example: [Store Nginx Access Logs in Grafana Loki with Logging Operator](../../../../quickstarts/loki-nginx/)
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   loki:
-     url: http://loki:3100
-     buffer:
-       timekey: 1m
-       timekey_wait: 30s
-       timekey_use_utc: true
+
+	loki:
+	  url: http://loki:3100
+	  buffer:
+	    timekey: 1m
+	    timekey_wait: 30s
+	    timekey_use_utc: true
+
  ```
 
 ## Configuration
@@ -114,9 +116,21 @@ Configure Kubernetes metadata in a Prometheus like format
 
 Default:  false
 
+### include_thread_label (*bool, optional) {#output config-include_thread_label}
+
+whether to include the fluentd_thread label when multiple threads are used for flushing.  
+
+Default:  true
+
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/mattermost.md
+++ b/docs/configuration/plugins/outputs/mattermost.md
@@ -54,7 +54,7 @@ message The message you want to send, can be a static message, which you add at 
 
 Default: -
 
-### enable_tls (bool, optional) {#output config-enable_tls}
+### enable_tls (*bool, optional) {#output config-enable_tls}
 
 enable_tls you can set the communication channel if it uses tls.  
 

--- a/docs/configuration/plugins/outputs/newrelic.md
+++ b/docs/configuration/plugins/outputs/newrelic.md
@@ -6,17 +6,19 @@ generated_file: true
 
 # New Relic Logs plugin for Fluentd
 ## Overview
-**newrelic** output plugin send log data to New Relic Logs
+ **newrelic** output plugin send log data to New Relic Logs
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   newrelic:
-     license_key:
-       valueFrom:
-         secretKeyRef:
-           name: logging-newrelic
-           key: licenseKey
+
+	newrelic:
+	  license_key:
+	    valueFrom:
+	      secretKeyRef:
+	        name: logging-newrelic
+	        key: licenseKey
+
  ```
 
 ## Configuration
@@ -39,5 +41,17 @@ Default: -
 New Relic ingestion endpoint [Secret](../secret/) 
 
 Default: https://log-api.newrelic.com/log/v1
+
+### format (*Format, optional) {#output config-format}
+
+[Format](../format/) 
+
+Default: -
+
+### buffer (*Buffer, optional) {#output config-buffer}
+
+[Buffer](../buffer/) 
+
+Default: -
 
 

--- a/docs/configuration/plugins/outputs/opensearch.md
+++ b/docs/configuration/plugins/outputs/opensearch.md
@@ -6,22 +6,24 @@ generated_file: true
 
 # OpenSearch output plugin for Fluentd
 ## Overview
-More info at https://github.com/fluent/fluent-plugin-opensearch
->Example Deployment: [Save all logs to OpenSearch](../../../../quickstarts/es-nginx/)
+ More info at https://github.com/fluent/fluent-plugin-opensearch
+ >Example Deployment: [Save all logs to OpenSearch](../../../../quickstarts/es-nginx/)
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   opensearch:
-     host: opensearch-cluster.default.svc.cluster.local
-     port: 9200
-     scheme: https
-     ssl_verify: false
-     ssl_version: TLSv1_2
-     buffer:
-       timekey: 1m
-       timekey_wait: 30s
-       timekey_use_utc: true
+
+	opensearch:
+	  host: opensearch-cluster.default.svc.cluster.local
+	  port: 9200
+	  scheme: https
+	  ssl_verify: false
+	  ssl_version: TLSv1_2
+	  buffer:
+	    timekey: 1m
+	    timekey_wait: 30s
+	    timekey_use_utc: true
+
  ```
 
 ## Configuration
@@ -233,9 +235,15 @@ CA certificate
 
 Default: -
 
+### ssl_version (string, optional) {#opensearch-ssl_version}
+
+If you want to configure SSL/TLS version, you can specify ssl_version parameter. [SSLv23, TLSv1, TLSv1_1, TLSv1_2] 
+
+Default: -
+
 ### remove_keys_on_update (string, optional) {#opensearch-remove_keys_on_update}
 
-If you want to configure SSL/TLS version, you can specify ssl_version parameter. [SSLv23, TLSv1, TLSv1_1, TLSv1_2] Remove keys on update will not update the configured keys in OpenSearch when a record is being updated. This setting only has any effect if the write operation is update or upsert. 
+Remove keys on update will not update the configured keys in OpenSearch when a record is being updated. This setting only has any effect if the write operation is update or upsert. 
 
 Default: -
 
@@ -518,5 +526,29 @@ Default:  false
 ### buffer (*Buffer, optional) {#opensearch-buffer}
 
 Default: -
+
+### slow_flush_log_threshold (string, optional) {#opensearch-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
+
+Default: -
+
+### data_stream_enable (*bool, optional) {#opensearch-data_stream_enable}
+
+Use @type opensearch_data_stream 
+
+Default: -
+
+### data_stream_name (string, optional) {#opensearch-data_stream_name}
+
+You can specify Opensearch data stream name by this parameter. This parameter is mandatory for opensearch_data_stream. 
+
+Default: -
+
+### data_stream_template_name (string, optional) {#opensearch-data_stream_template_name}
+
+Specify an existing index template for the data stream. If not present, a new template is created and named after the data stream.  
+
+Default:  data_stream_name
 
 

--- a/docs/configuration/plugins/outputs/oss.md
+++ b/docs/configuration/plugins/outputs/oss.md
@@ -6,18 +6,18 @@ generated_file: true
 
 # Aliyun OSS plugin for Fluentd
 ## Overview
-**Fluent OSS output plugin** buffers event logs in local files and uploads them to OSS periodically in background threads.
+ **Fluent OSS output plugin** buffers event logs in local files and uploads them to OSS periodically in background threads.
 
-This plugin splits events by using the timestamp of event logs. For example,  a log '2019-04-09 message Hello' is reached, and then another log '2019-04-10 message World' is reached in this order, the former is stored in "20190409.gz" file, and latter in "20190410.gz" file.
+ This plugin splits events by using the timestamp of event logs. For example,  a log '2019-04-09 message Hello' is reached, and then another log '2019-04-10 message World' is reached in this order, the former is stored in "20190409.gz" file, and latter in "20190410.gz" file.
 
-**Fluent OSS input plugin** reads data from OSS periodically.
+ **Fluent OSS input plugin** reads data from OSS periodically.
 
-This plugin uses MNS on the same region of the OSS bucket. We must setup MNS and OSS event notification before using this plugin.
+ This plugin uses MNS on the same region of the OSS bucket. We must setup MNS and OSS event notification before using this plugin.
 
-[This document](https://help.aliyun.com/document_detail/52656.html) shows how to setup MNS and OSS event notification.
+ [This document](https://help.aliyun.com/document_detail/52656.html) shows how to setup MNS and OSS event notification.
 
-This plugin will poll events from MNS queue and extract object keys from these events, and then will read those objects from OSS.
-More info at https://github.com/aliyun/fluent-plugin-oss
+ This plugin will poll events from MNS queue and extract object keys from these events, and then will read those objects from OSS.
+ More info at https://github.com/aliyun/fluent-plugin-oss
 
 ## Configuration
 ## Output Config
@@ -145,6 +145,12 @@ Default: -
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/redis.md
+++ b/docs/configuration/plugins/outputs/redis.md
@@ -9,14 +9,16 @@ generated_file: true
  Sends logs to Redis endpoints.
  More info at https://github.com/fluent-plugins-nursery/fluent-plugin-redis
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   redis:
-     host: redis-master.prod.svc.cluster.local
-     buffer:
-       tags: "[]"
-       flush_interval: 10s
+
+	redis:
+	  host: redis-master.prod.svc.cluster.local
+	  buffer:
+	    tags: "[]"
+	    flush_interval: 10s
+
  ```
 
 ## Configuration
@@ -79,6 +81,12 @@ Default: -
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/relabel.md
+++ b/docs/configuration/plugins/outputs/relabel.md
@@ -1,0 +1,15 @@
+---
+title: Relabel
+weight: 200
+generated_file: true
+---
+
+## Output Config
+
+### label (string, required) {#output config-label}
+
+Specifies new label for events 
+
+Default: -
+
+

--- a/docs/configuration/plugins/outputs/s3.md
+++ b/docs/configuration/plugins/outputs/s3.md
@@ -6,30 +6,32 @@ generated_file: true
 
 # Amazon S3 plugin for Fluentd
 ## Overview
-**s3** output plugin buffers event logs in local file and upload it to S3 periodically. This plugin splits files exactly by using the time of event logs (not the time when the logs are received). For example, a log '2011-01-02 message B' is reached, and then another log '2011-01-03 message B' is reached in this order, the former one is stored in "20110102.gz" file, and latter one in "20110103.gz" file.
->Example: [S3 Output Deployment](../../../../quickstarts/example-s3/)
+ **s3** output plugin buffers event logs in local file and upload it to S3 periodically. This plugin splits files exactly by using the time of event logs (not the time when the logs are received). For example, a log '2011-01-02 message B' is reached, and then another log '2011-01-03 message B' is reached in this order, the former one is stored in "20110102.gz" file, and latter one in "20110103.gz" file.
+ >Example: [S3 Output Deployment](../../../../quickstarts/example-s3/)
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-  s3:
-    aws_key_id:
-      valueFrom:
-        secretKeyRef:
-          name: logging-s3
-          key: awsAccessKeyId
-    aws_sec_key:
-      valueFrom:
-        secretKeyRef:
-          name: logging-s3
-          key: awsSecretAccessKey
-    s3_bucket: logging-amazon-s3
-    s3_region: eu-central-1
-    path: logs/${tag}/%Y/%m/%d/
-    buffer:
-      timekey: 10m
-      timekey_wait: 30s
-      timekey_use_utc: true
+
+	s3:
+	  aws_key_id:
+	    valueFrom:
+	      secretKeyRef:
+	        name: logging-s3
+	        key: awsAccessKeyId
+	  aws_sec_key:
+	    valueFrom:
+	      secretKeyRef:
+	        name: logging-s3
+	        key: awsSecretAccessKey
+	  s3_bucket: logging-amazon-s3
+	  s3_region: eu-central-1
+	  path: logs/${tag}/%Y/%m/%d/
+	  buffer:
+	    timekey: 10m
+	    timekey_wait: 30s
+	    timekey_use_utc: true
+
  ```
 
 ## Configuration
@@ -254,6 +256,12 @@ Default: -
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/splunk_hec.md
+++ b/docs/configuration/plugins/outputs/splunk_hec.md
@@ -6,15 +6,17 @@ generated_file: true
 
 # Splunk via Hec output plugin for Fluentd
 ## Overview
-More info at https://github.com/splunk/fluent-plugin-splunk-hec
+ More info at https://github.com/splunk/fluent-plugin-splunk-hec
 
- #### Example output configurations
+ ## Example output configurations
  ```yaml
  spec:
-   splunkHec:
-     hec_host: splunk.default.svc.cluster.local
-     hec_port: 8088
-     protocol: http
+
+	splunkHec:
+	  hec_host: splunk.default.svc.cluster.local
+	  hec_port: 8088
+	  protocol: http
+
  ```
 
 ## Configuration
@@ -205,6 +207,12 @@ Default: -
 ### buffer (*Buffer, optional) {#splunkhecoutput-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#splunkhecoutput-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/sqs.md
+++ b/docs/configuration/plugins/outputs/sqs.md
@@ -77,30 +77,41 @@ Default:  '__tag'
 
 Default: -
 
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
+
+Default: -
 
 
- #### Example `SQS` output configurations
+ ## Example `SQS` output configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Output
-metadata:
-  name: sqs-output-sample
-spec:
-  sqs:
-    queue_name: some-aws-sqs-queue
-    create_queue: false
-    region: us-east-1
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Output
+ metadata:
+
+	name: sqs-output-sample
+
+ spec:
+
+	sqs:
+	  queue_name: some-aws-sqs-queue
+	  create_queue: false
+	  region: us-east-1
+
  ```
 
  #### Fluentd Config Result
  ```
-  <match **>
-      @type sqs
-      @id test_sqs
-      queue_name some-aws-sqs-queue
-      create_queue false
-      region us-east-1
-  </match>
+
+	<match **>
+	    @type sqs
+	    @id test_sqs
+	    queue_name some-aws-sqs-queue
+	    create_queue false
+	    region us-east-1
+	</match>
+
  ```
 
 ---

--- a/docs/configuration/plugins/outputs/sumologic.md
+++ b/docs/configuration/plugins/outputs/sumologic.md
@@ -6,35 +6,40 @@ generated_file: true
 
 # SumoLogic output plugin for Fluentd
 ## Overview
-This plugin has been designed to output logs or metrics to SumoLogic via a HTTP collector endpoint
-More info at https://github.com/SumoLogic/fluentd-output-sumologic
+ This plugin has been designed to output logs or metrics to SumoLogic via a HTTP collector endpoint
+ More info at https://github.com/SumoLogic/fluentd-output-sumologic
 
  Example secret for HTTP input URL
  ```
+ kubectl create secret generic sumo-output --from-literal "endpoint=$URL"
+ ```
+
+ # Example ClusterOutput
+
+ ```yaml
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: ClusterOutput
+ metadata:
+
+	name: sumo-output
+
+ spec:
+
+	sumologic:
+	  buffer:
+	    flush_interval: 10s
+	    flush_mode: interval
+	  compress: true
+	  endpoint:
+	    valueFrom:
+	      secretKeyRef:
+	        key: endpoint
+	        name: sumo-output
+	  source_name: test1
+
+ ```
+
 export URL='https://endpoint1.collection.eu.sumologic.com/receiver/v1/http/.......'
-kubectl create secret generic sumo-output --from-literal "endpoint=$URL"
-```
-
- Example ClusterOutput
-
-```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: ClusterOutput
-metadata:
-  name: sumo-output
-spec:
-  sumologic:
-    buffer:
-      flush_interval: 10s
-      flush_mode: interval
-    compress: true
-    endpoint:
-      valueFrom:
-        secretKeyRef:
-          key: endpoint
-          name: sumo-output
-    source_name: test1
-```
 
 ## Configuration
 ## Output Config
@@ -168,6 +173,12 @@ Default: -
 ### buffer (*Buffer, optional) {#output config-buffer}
 
 [Buffer](../buffer/) 
+
+Default: -
+
+### slow_flush_log_threshold (string, optional) {#output config-slow_flush_log_threshold}
+
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 Default: -
 

--- a/docs/configuration/plugins/outputs/syslog.md
+++ b/docs/configuration/plugins/outputs/syslog.md
@@ -101,47 +101,59 @@ Default: -
 
 Default: -
 
+### slow_flush_log_threshold (string, optional) {#syslogoutputconfig-slow_flush_log_threshold}
 
- #### Example `File` output configurations
+The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
+
+Default: -
+
+
+ ## Example `File` output configurations
  ```yaml
-apiVersion: logging.banzaicloud.io/v1beta1
-kind: Output
-metadata:
-  name: demo-output
-spec:
-  syslog:
-    host: SYSLOG-HOST
-    port: 123
-    format:
-      app_name_field: example.custom_field_1
-      proc_id_field: example.custom_field_2
-    buffer:
-      timekey: 1m
-      timekey_wait: 10s
-      timekey_use_utc: true
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Output
+ metadata:
+
+	name: demo-output
+
+ spec:
+
+	syslog:
+	  host: SYSLOG-HOST
+	  port: 123
+	  format:
+	    app_name_field: example.custom_field_1
+	    proc_id_field: example.custom_field_2
+	  buffer:
+	    timekey: 1m
+	    timekey_wait: 10s
+	    timekey_use_utc: true
+
  ```
 
  #### Fluentd Config Result
  ```
-  <match **>
-	@type syslog_rfc5424
-	@id test_syslog
-	host SYSLOG-HOST
-	port 123
-  <format>
-    @type syslog_rfc5424
-    app_name_field example.custom_field_1
-    proc_id_field example.custom_field_2
-  </format>
-	<buffer tag,time>
-	  @type file
-	  path /buffers/test_file.*.buffer
-	  retry_forever true
-	  timekey 1m
-	  timekey_use_utc true
-	  timekey_wait 30s
-	</buffer>
-  </match>
+
+	 <match **>
+		@type syslog_rfc5424
+		@id test_syslog
+		host SYSLOG-HOST
+		port 123
+	 <format>
+	   @type syslog_rfc5424
+	   app_name_field example.custom_field_1
+	   proc_id_field example.custom_field_2
+	 </format>
+		<buffer tag,time>
+		  @type file
+		  path /buffers/test_file.*.buffer
+		  retry_forever true
+		  timekey 1m
+		  timekey_use_utc true
+		  timekey_wait 30s
+		</buffer>
+	 </match>
+
  ```
 
 ---

--- a/docs/configuration/plugins/syslogng-filters/match.md
+++ b/docs/configuration/plugins/syslogng-filters/match.md
@@ -1,0 +1,118 @@
+---
+title: Match
+weight: 200
+generated_file: true
+---
+
+# Match
+## Overview
+ Match filters can be used to select the log records to process. These filters have the same options and syntax as [syslog-ng flow match expressions]({{< relref "/docs/logging-operator/configuration/plugins/syslog-ng-filters/match.md" >}}).
+
+ {{< highlight yaml >}}
+
+	filters:
+	- match:
+	    or:
+	    - regexp:
+	        value: json.kubernetes.labels.app.kubernetes.io/name
+	        pattern: apache
+	        type: string
+	    - regexp:
+	        value: json.kubernetes.labels.app.kubernetes.io/name
+	        pattern: nginx
+	        type: string
+
+ {{</ highlight >}}
+
+## Configuration
+## MatchExpr
+
+### and ([]MatchExpr, optional) {#matchexpr-and}
+
+Default: -
+
+### not (*MatchExpr, optional) {#matchexpr-not}
+
+Default: -
+
+### regexp (*RegexpMatchExpr, optional) {#matchexpr-regexp}
+
+[Regexp Directive](#Regexp-Directive) 
+
+Default: -
+
+### or ([]MatchExpr, optional) {#matchexpr-or}
+
+Default: -
+
+
+## Regexp Directive
+
+Specify filtering rule. For details, see the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/68#TOPIC-1829171).
+
+### pattern (string, required) {#regexp directive-pattern}
+
+Pattern expression to evaluate 
+
+Default: -
+
+### template (string, optional) {#regexp directive-template}
+
+Specify a template of the record fields to match against. 
+
+Default: -
+
+### value (string, optional) {#regexp directive-value}
+
+Specify a field name of the record to match against the value of. 
+
+Default: -
+
+### flags ([]string, optional) {#regexp directive-flags}
+
+Pattern flags 
+
+Default: -
+
+### type (string, optional) {#regexp directive-type}
+
+Pattern type 
+
+Default: -
+
+
+ #### Example `Regexp` filter configurations
+ ```yaml
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: Flow
+ metadata:
+
+	name: demo-flow
+
+ spec:
+
+	filters:
+	  - match:
+	      regexp:
+	      - value: first
+	        pattern: ^5\d\d$
+	match: {}
+	localOutputRefs:
+	  - demo-output
+
+ ```
+
+ #### Syslog-NG Config Result
+ ```
+
+	log {
+	   source(main_input);
+	   filter {
+	       match("^5\d\d$" value("first"));
+	   };
+	   destination(output_default_demo-output);
+	};
+
+ ```
+
+---

--- a/docs/configuration/plugins/syslogng-filters/parser.md
+++ b/docs/configuration/plugins/syslogng-filters/parser.md
@@ -1,0 +1,90 @@
+---
+title: Parser
+weight: 200
+generated_file: true
+---
+
+# [Parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/82#TOPIC-1829229)
+## Overview
+ Parser filters can be used to extract key-value pairs from message data. Logging operator currently supports the following parsers:
+
+ - [regexp](#regexp)
+ - [syslog-parser](#syslog)
+
+ ## Regexp parser {#regexp}
+
+ The regexp parser can use regular expressions to parse fields from a message.
+
+ {{< highlight yaml >}}
+
+	filters:
+	- parser:
+	    regexp:
+	      patterns:
+	      - ".*test_field -> (?<test_field>.*)$"
+	      prefix: .regexp.
+
+ {{</ highlight >}}
+
+ For details, see the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/91#TOPIC-1829263).
+
+ ## Syslog parser {#syslog}
+
+ The syslog parser can parse syslog messages. For details, see the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/83#TOPIC-1829231).
+
+ {{< highlight yaml >}}
+
+	filters:
+	- parser:
+	    syslog-parser: {}
+
+ {{</ highlight >}}
+
+## Configuration
+## [Parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/82#TOPIC-1768819)
+
+### regexp (*RegexpParser, optional) {#[parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/82#topic-1768819)-regexp}
+
+Default: -
+
+### syslog-parser (*SyslogParser, optional) {#[parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/82#topic-1768819)-syslog-parser}
+
+Default: -
+
+
+## [Regexp parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/90)
+
+### patterns ([]string, required) {#[regexp parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/90)-patterns}
+
+The regular expression patterns that you want to find a match. regexp-parser() supports multiple patterns, and stops the processing at the first successful match. 
+
+Default: -
+
+### prefix (string, optional) {#[regexp parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/90)-prefix}
+
+Insert a prefix before the name part of the parsed name-value pairs to help further processing. 
+
+Default: -
+
+### template (string, optional) {#[regexp parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/90)-template}
+
+Specify a template of the record fields to match against. 
+
+Default: -
+
+### flags ([]string, optional) {#[regexp parser](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.36/administration-guide/90)-flags}
+
+Pattern flags 
+
+Default: -
+
+
+## SyslogParser
+
+### flags ([]string, optional) {#syslogparser-flags}
+
+Pattern flags 
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-filters/rewrite.md
+++ b/docs/configuration/plugins/syslogng-filters/rewrite.md
@@ -1,0 +1,204 @@
+---
+title: Rewrite
+weight: 200
+generated_file: true
+---
+
+# [Rewrite](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/76#TOPIC-1829205)
+## Overview
+ Rewrite filters can be used to modify record contents. Logging operator currently supports the following rewrite functions:
+
+ - [group_unset](#groupunset)
+ - [rename](#rename)
+ - [set](#set)
+ - [substitute](#subst)
+ - [unset](#unset)
+
+ > Note: All rewrite functions support an optional `condition` which has the same syntax as the [match filter](../match/).
+
+ ## Group unset {#groupunset}
+
+ The `group_unset` function removes from the record a group of fields matching a pattern.
+
+ {{< highlight yaml >}}
+
+	filters:
+	- rewrite:
+	  - group_unset:
+	      pattern: "json.kubernetes.annotations.*"
+
+ {{</ highlight >}}
+
+ ## Rename
+
+ The `rename` function changes the name of an existing field name.
+
+ {{< highlight yaml >}}
+
+	filters:
+	- rewrite:
+	  - rename:
+	      oldName: "json.kubernetes.labels.app"
+	      newName: "json.kubernetes.labels.app.kubernetes.io/name"
+
+ {{</ highlight >}}
+
+ ## Set
+
+ The `set` function sets the value of a field.
+
+ {{< highlight yaml >}}
+
+	filters:
+	- rewrite:
+	  - set:
+	      field: "json.kubernetes.cluster"
+	      value: "prod-us"
+
+ {{</ highlight >}}
+
+ ## Substitute (subst) {#subst}
+
+ The `subst` function replaces parts of a field with a replacement value based on a pattern.
+
+ {{< highlight yaml >}}
+
+	filters:
+	- rewrite:
+	  - subst:
+	      pattern: "\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d\d"
+	      replace: "[redacted bank card number]"
+	      field: "MESSAGE"
+
+ {{</ highlight >}}
+
+ The function also supports the `type` and `flags` fields for specifying pattern type and flags as described in the [match expression regexp function](../match/).
+
+ ## Unset
+
+ You can unset macros or fields of the message.
+
+ > Note: Unsetting a field completely deletes any previous value of the field.
+
+ {{< highlight yaml >}}
+
+	filters:
+	- rewrite:
+	  - unset:
+	      field: "json.kubernetes.cluster"
+
+ {{</ highlight >}}
+
+## Configuration
+## RewriteConfig
+
+### group_unset (*GroupUnsetConfig, optional) {#rewriteconfig-group_unset}
+
+Default: -
+
+### rename (*RenameConfig, optional) {#rewriteconfig-rename}
+
+Default: -
+
+### set (*SetConfig, optional) {#rewriteconfig-set}
+
+Default: -
+
+### subst (*SubstituteConfig, optional) {#rewriteconfig-subst}
+
+Default: -
+
+### unset (*UnsetConfig, optional) {#rewriteconfig-unset}
+
+Default: -
+
+
+## RenameConfig
+
+https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/78#TOPIC-1829213
+
+### oldName (string, required) {#renameconfig-oldname}
+
+Default: -
+
+### newName (string, required) {#renameconfig-newname}
+
+Default: -
+
+### condition (*MatchExpr, optional) {#renameconfig-condition}
+
+Default: -
+
+
+## SetConfig
+
+https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/77#TOPIC-1829207
+
+### field (string, required) {#setconfig-field}
+
+Default: -
+
+### value (string, required) {#setconfig-value}
+
+Default: -
+
+### condition (*MatchExpr, optional) {#setconfig-condition}
+
+Default: -
+
+
+## SubstituteConfig
+
+https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/77#TOPIC-1829206
+
+### pattern (string, required) {#substituteconfig-pattern}
+
+Default: -
+
+### replace (string, required) {#substituteconfig-replace}
+
+Default: -
+
+### field (string, required) {#substituteconfig-field}
+
+Default: -
+
+### flags ([]string, optional) {#substituteconfig-flags}
+
+Default: -
+
+### type (string, optional) {#substituteconfig-type}
+
+Default: -
+
+### condition (*MatchExpr, optional) {#substituteconfig-condition}
+
+Default: -
+
+
+## UnsetConfig
+
+https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/78#TOPIC-1829212
+
+### field (string, required) {#unsetconfig-field}
+
+Default: -
+
+### condition (*MatchExpr, optional) {#unsetconfig-condition}
+
+Default: -
+
+
+## GroupUnsetConfig
+
+https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/78#TOPIC-1829212
+
+### pattern (string, required) {#groupunsetconfig-pattern}
+
+Default: -
+
+### condition (*MatchExpr, optional) {#groupunsetconfig-condition}
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/disk_buffer.md
+++ b/docs/configuration/plugins/syslogng-outputs/disk_buffer.md
@@ -1,0 +1,59 @@
+---
+title: Disk buffer
+weight: 200
+generated_file: true
+---
+
+# Disk buffer configuration
+## Overview
+ The parameters of the syslog-ng disk buffer. Using a disk buffer on the output helps avoid message loss in case of a system failure on the destination side.
+ More info at https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338
+
+## Configuration
+## DiskBuffer
+
+Documentation: https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#TOPIC-1829124
+
+### disk_buf_size (int64, required) {#diskbuffer-disk_buf_size}
+
+This is a required option. The maximum size of the disk-buffer in bytes. The minimum value is 1048576 bytes. 
+
+Default: -
+
+### reliable (bool, required) {#diskbuffer-reliable}
+
+If set to yes, syslog-ng OSE cannot lose logs in case of reload/restart, unreachable destination or syslog-ng OSE crash. This solution provides a slower, but reliable disk-buffer option. 
+
+Default: -
+
+### compaction (*bool, optional) {#diskbuffer-compaction}
+
+Prunes the unused space in the LogMessage representation 
+
+Default: -
+
+### dir (string, optional) {#diskbuffer-dir}
+
+Description: Defines the folder where the disk-buffer files are stored. 
+
+Default: -
+
+### mem_buf_length (*int64, optional) {#diskbuffer-mem_buf_length}
+
+Use this option if the option reliable() is set to no. This option contains the number of messages stored in overflow queue. 
+
+Default: -
+
+### mem_buf_size (*int64, optional) {#diskbuffer-mem_buf_size}
+
+Use this option if the option reliable() is set to yes. This option contains the size of the messages in bytes that is used in the memory part of the disk buffer. 
+
+Default: -
+
+### q_out_size (*int64, optional) {#diskbuffer-q_out_size}
+
+The number of messages stored in the output buffer of the destination. 
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/file.md
+++ b/docs/configuration/plugins/syslogng-outputs/file.md
@@ -1,0 +1,71 @@
+---
+title: File
+weight: 200
+generated_file: true
+---
+
+# File output plugin for syslog-ng
+## Overview
+ The `file` output stores log records in a plain text file.
+
+ {{< highlight yaml >}}
+
+	spec:
+	  file:
+	    path: /mnt/archive/logs/${YEAR}/${MONTH}/${DAY}/app.log
+	    create_dirs: true
+
+ {{</ highlight >}}
+
+ For details on the available options of the output, see the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/36#TOPIC-1829044).
+
+## Configuration
+## FileOutput
+
+Documentation: https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/36#TOPIC-1829044
+
+### path (string, required) {#fileoutput-path}
+
+Store file path 
+
+Default: -
+
+### create_dirs (bool, optional) {#fileoutput-create_dirs}
+
+Enable creating non-existing directories.  
+
+Default:  false
+
+### dir_group (string, optional) {#fileoutput-dir_group}
+
+The group of the directories created by syslog-ng. To preserve the original properties of an existing directory, use the option without specifying an attribute: dir-group().  
+
+Default:  Use the global settings
+
+### dir_owner (string, optional) {#fileoutput-dir_owner}
+
+The owner of the directories created by syslog-ng. To preserve the original properties of an existing directory, use the option without specifying an attribute: dir-owner().  
+
+Default:  Use the global settings
+
+### dir_perm (int, optional) {#fileoutput-dir_perm}
+
+The permission mask of directories created by syslog-ng. Log directories are only created if a file after macro expansion refers to a non-existing directory, and directory creation is enabled (see also the create-dirs() option). For octal numbers prefix the number with 0, for example use 0755 for rwxr-xr-x. 
+
+Default:  Use the global settings
+
+### disk_buffer (*DiskBuffer, optional) {#fileoutput-disk_buffer}
+
+This option enables putting outgoing messages into the disk buffer of the destination to avoid message loss in case of a system failure on the destination side. For details, see the [Syslog-ng DiskBuffer options](../disk_buffer/).  
+
+Default:  false
+
+### template (string, optional) {#fileoutput-template}
+
+Default: -
+
+### persist_name (string, optional) {#fileoutput-persist_name}
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/http.md
+++ b/docs/configuration/plugins/syslogng-outputs/http.md
@@ -1,0 +1,135 @@
+---
+title: HTTP
+weight: 200
+generated_file: true
+---
+
+# Sending messages over HTTP
+## Overview
+ More info at https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/40#TOPIC-1829058
+
+## Configuration
+## HTTPOutput
+
+### url (string, optional) {#httpoutput-url}
+
+Specifies the hostname or IP address and optionally the port number of the web service that can receive log data via HTTP. Use a colon (:) after the address to specify the port number of the server. For example: http://127.0.0.1:8000 
+
+Default: -
+
+### headers ([]string, optional) {#httpoutput-headers}
+
+Custom HTTP headers to include in the request, for example, headers("HEADER1: header1", "HEADER2: header2").   
+
+Default:  empty
+
+### time_reopen (int, optional) {#httpoutput-time_reopen}
+
+The time to wait in seconds before a dead connection is reestablished.  
+
+Default:  60
+
+### tls (*TLS, optional) {#httpoutput-tls}
+
+This option sets various options related to TLS encryption, for example, key/certificate files and trusted CA locations. TLS can be used only with tcp-based transport protocols. For details, see [TLS for syslog-ng outputs](../tls/) and the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#TOPIC-1829193). 
+
+Default: -
+
+### disk_buffer (*DiskBuffer, optional) {#httpoutput-disk_buffer}
+
+This option enables putting outgoing messages into the disk buffer of the destination to avoid message loss in case of a system failure on the destination side. For details, see the [Syslog-ng DiskBuffer options](../disk_buffer/).  
+
+Default:  false
+
+###  (Batch, required) {#httpoutput-}
+
+Batching parameters 
+
+Default: -
+
+### body (string, optional) {#httpoutput-body}
+
+The body of the HTTP request, for example, body("${ISODATE} ${MESSAGE}"). You can use strings, macros, and template functions in the body. If not set, it will contain the message received from the source by default. 
+
+Default: -
+
+### body-prefix (string, optional) {#httpoutput-body-prefix}
+
+The string syslog-ng OSE puts at the beginning of the body of the HTTP request, before the log message. 
+
+Default: -
+
+### body-suffix (string, optional) {#httpoutput-body-suffix}
+
+The string syslog-ng OSE puts to the end of the body of the HTTP request, after the log message. 
+
+Default: -
+
+### delimiter (string, optional) {#httpoutput-delimiter}
+
+By default, syslog-ng OSE separates the log messages of the batch with a newline character. 
+
+Default: -
+
+### method (string, optional) {#httpoutput-method}
+
+Specifies the HTTP method to use when sending the message to the server. POST | PUT 
+
+Default: -
+
+### retries (int, optional) {#httpoutput-retries}
+
+The number of times syslog-ng OSE attempts to send a message to this destination. If syslog-ng OSE could not send a message, it will try again until the number of attempts reaches retries, then drops the message. 
+
+Default: -
+
+### user (string, optional) {#httpoutput-user}
+
+The username that syslog-ng OSE uses to authenticate on the server where it sends the messages. 
+
+Default: -
+
+### password (secret.Secret, optional) {#httpoutput-password}
+
+The password that syslog-ng OSE uses to authenticate on the server where it sends the messages. 
+
+Default: -
+
+### user-agent (string, optional) {#httpoutput-user-agent}
+
+The value of the USER-AGENT header in the messages sent to the server. 
+
+Default: -
+
+### workers (int, optional) {#httpoutput-workers}
+
+Description: Specifies the number of worker threads (at least 1) that syslog-ng OSE uses to send messages to the server. Increasing the number of worker threads can drastically improve the performance of the destination. 
+
+Default: -
+
+### persist_name (string, optional) {#httpoutput-persist_name}
+
+Default: -
+
+
+## Batch
+
+### batch-lines (int, optional) {#batch-batch-lines}
+
+Description: Specifies how many lines are flushed to a destination in one batch. The syslog-ng OSE application waits for this number of lines to accumulate and sends them off in a single batch. Increasing this number increases throughput as more messages are sent in a single batch, but also increases message latency. For example, if you set batch-lines() to 100, syslog-ng OSE waits for 100 messages. 
+
+Default: -
+
+### batch-bytes (int, optional) {#batch-batch-bytes}
+
+Description: Sets the maximum size of payload in a batch. If the size of the messages reaches this value, syslog-ng OSE sends the batch to the destination even if the number of messages is less than the value of the batch-lines() option. Note that if the batch-timeout() option is enabled and the queue becomes empty, syslog-ng OSE flushes the messages only if batch-timeout() expires, or the batch reaches the limit set in batch-bytes(). 
+
+Default: -
+
+### batch-timeout (int, optional) {#batch-batch-timeout}
+
+Description: Specifies the time syslog-ng OSE waits for lines to accumulate in the output buffer. The syslog-ng OSE application sends batches to the destinations evenly. The timer starts when the first message arrives to the buffer, so if only few messages arrive, syslog-ng OSE sends messages to the destination at most once every batch-timeout() milliseconds. 
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/loggly.md
+++ b/docs/configuration/plugins/syslogng-outputs/loggly.md
@@ -1,0 +1,42 @@
+---
+title: Loggly output
+weight: 200
+generated_file: true
+---
+
+# Loggly output plugin for syslog-ng
+## Overview
+ The `loggly()` destination sends log messages to the [Loggly](https://www.loggly.com/) Logging-as-a-Service provider. You can send log messages over TCP, or encrypted with TLS. For details, see the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/43#TOPIC-1829072).
+
+ ## Prerequisites
+
+ You need a Loggly account and your user token to use this output.
+
+## Configuration
+## Loggly
+
+### host (string, optional) {#loggly-host}
+
+Address of the destination host 
+
+Default: -
+
+### tag (string, optional) {#loggly-tag}
+
+Event tag [more information](https://documentation.solarwinds.com/en/success_center/loggly/content/admin/tags.htm) 
+
+Default: -
+
+### token (*secret.Secret, required) {#loggly-token}
+
+Your Customer Token that you received from Loggly [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/43#loggly-option-token) 
+
+Default: -
+
+###  (SyslogOutput, required) {#loggly-}
+
+syslog output configuration 
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/logscale.md
+++ b/docs/configuration/plugins/syslogng-outputs/logscale.md
@@ -1,0 +1,82 @@
+---
+title: LogScale
+weight: 200
+generated_file: true
+---
+
+# logscale
+## Overview
+ {{</ highlight >}}
+
+## Configuration
+## LogScaleOutput
+
+### url (*secret.Secret, optional) {#logscaleoutput-url}
+
+Ingester URL is the URL of the Humio cluster you want to send data to.  
+
+Default:  https://cloud.humio.com
+
+### token (*secret.Secret, optional) {#logscaleoutput-token}
+
+An Ingest Token is a unique string that identifies a repository and allows you to send data to that repository(https://library.humio.com/falcon-logscale/ingesting-data-tokens.html).  
+
+Default:  empty
+
+### rawstring (string, optional) {#logscaleoutput-rawstring}
+
+The raw string representing the Event. The default display for an Event in LogScale is the rawstring. If you do not provide the rawstring field, then the response defaults to a JSON representation of the attributes field.  
+
+Default:  empty
+
+### attributes (string, optional) {#logscaleoutput-attributes}
+
+A JSON object representing key-value pairs for the Event. These key-value pairs adds structure to Events, making it easier to search. Attributes can be nested JSON objects, however, we recommend limiting the amount of nesting.  
+
+Default:  "--scope rfc5424 --exclude MESSAGE --exclude DATE --leave-initial-dot"
+
+### timezone (string, optional) {#logscaleoutput-timezone}
+
+The timezone is only required if you specify the timestamp in milliseconds. The timezone specifies the local timezone for the event. Note that you must still specify the timestamp in UTC time. 
+
+Default: -
+
+### extra_headers (string, optional) {#logscaleoutput-extra_headers}
+
+This field represents additional headers that can be included in the HTTP request when sending log records to Falcon's LogScale.   
+
+Default:  empty
+
+### content_type (string, optional) {#logscaleoutput-content_type}
+
+This field specifies the content type of the log records being sent to Falcon's LogScale.   
+
+Default:  "application/json"
+
+### disk_buffer (*DiskBuffer, optional) {#logscaleoutput-disk_buffer}
+
+This option enables putting outgoing messages into the disk buffer of the destination to avoid message loss in case of a system failure on the destination side. For details, see the [Syslog-ng DiskBuffer options](../disk_buffer/).  
+
+Default:  false
+
+### body (string, optional) {#logscaleoutput-body}
+
+Default: -
+
+### batch_lines (int, optional) {#logscaleoutput-batch_lines}
+
+Default: -
+
+### batch_bytes (int, optional) {#logscaleoutput-batch_bytes}
+
+Default: -
+
+### batch_timeout (int, optional) {#logscaleoutput-batch_timeout}
+
+Default: -
+
+### persist_name (string, optional) {#logscaleoutput-persist_name}
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/mqtt.md
+++ b/docs/configuration/plugins/syslogng-outputs/mqtt.md
@@ -1,0 +1,65 @@
+---
+title: MQTT
+weight: 200
+generated_file: true
+---
+
+# Sending messages from a local network to an MQTT broker
+## Overview
+
+ ## Prerequisites
+
+ ## Example
+
+ {{< highlight yaml >}}
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: SyslogNGOutput
+ metadata:
+
+	name: mqtt
+	namespace: default
+
+ spec:
+
+	mqtt:
+	  address: tcp://mosquitto:1883
+	  template: |
+	    $(format-json --subkeys json~ --key-delimiter ~)
+	  topic: test/demo
+
+ {{</ highlight >}}
+
+## Configuration
+## MQTT
+
+### address (string, optional) {#mqtt-address}
+
+Address of the destination host 
+
+Default: -
+
+### topic (string, optional) {#mqtt-topic}
+
+Topic defines in which topic syslog-ng stores the log message. You can also use templates here, and use, for example, the $HOST macro in the topic name hierarchy. 
+
+Default: -
+
+### fallback-topic (string, optional) {#mqtt-fallback-topic}
+
+fallback-topic is used when syslog-ng cannot post a message to the originally defined topic (which can include invalid characters coming from templates). 
+
+Default: -
+
+### template (string, optional) {#mqtt-template}
+
+Template where you can configure the message template sent to the MQTT broker. By default, the template is: “$ISODATE $HOST $MSGHDR$MSG” 
+
+Default: -
+
+### qos (int, optional) {#mqtt-qos}
+
+qos stands for quality of service and can take three values in the MQTT world. Its default value is 0, where there is no guarantee that the message is ever delivered. 
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/sumologic_http.md
+++ b/docs/configuration/plugins/syslogng-outputs/sumologic_http.md
@@ -1,0 +1,116 @@
+---
+title: Sumo Logic HTTP
+weight: 200
+generated_file: true
+---
+
+# Storing messages in Sumo Logic over http
+## Overview
+ The `sumologic-http` output sends log records over HTTP to Sumo Logic.
+
+ ## Prerequisites
+
+ You need a Sumo Logic account to use this output. For details, see the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/55#TOPIC-1829118).
+
+ ## Example
+
+ {{< highlight yaml >}}
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: SyslogNGOutput
+ metadata:
+
+	name: test-sumo
+	namespace: default
+
+ spec:
+
+	sumologic-http:
+	  batch-lines: 1000
+	  disk_buffer:
+	    disk_buf_size: 512000000
+	    dir: /buffers
+	    reliable: true
+	  body: "$(format-json
+	              --subkeys json.
+	              --exclude json.kubernetes.annotations.*
+	              json.kubernetes.annotations=literal($(format-flat-json --subkeys json.kubernetes.annotations.))
+	              --exclude json.kubernetes.labels.*
+	              json.kubernetes.labels=literal($(format-flat-json --subkeys json.kubernetes.labels.)))"
+	  collector:
+	    valueFrom:
+	      secretKeyRef:
+	        key: token
+	        name: sumo-collector
+	  deployment: us2
+	  headers:
+	  - 'X-Sumo-Name: source-name'
+	  - 'X-Sumo-Category: source-category'
+	  tls:
+	    use-system-cert-store: true
+
+ {{</ highlight >}}
+
+## Configuration
+## SumologicHTTPOutput
+
+### collector (*secret.Secret, optional) {#sumologichttpoutput-collector}
+
+The Cloud Syslog Cloud Token that you received from the Sumo Logic service while configuring your cloud syslog source.  
+
+Default:  empty
+
+### deployment (string, optional) {#sumologichttpoutput-deployment}
+
+This option specifies your Sumo Logic deployment.https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-by-Deployment-and-Firewall-Security   
+
+Default:  empty
+
+### headers ([]string, optional) {#sumologichttpoutput-headers}
+
+Custom HTTP headers to include in the request, for example, headers("HEADER1: header1", "HEADER2: header2").   
+
+Default:  empty
+
+### time_reopen (int, optional) {#sumologichttpoutput-time_reopen}
+
+The time to wait in seconds before a dead connection is reestablished.  
+
+Default:  60
+
+### tls (*TLS, optional) {#sumologichttpoutput-tls}
+
+This option sets various options related to TLS encryption, for example, key/certificate files and trusted CA locations. TLS can be used only with tcp-based transport protocols. For details, see [TLS for syslog-ng outputs](../tls/) and the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#TOPIC-1829193). 
+
+Default: -
+
+### disk_buffer (*DiskBuffer, optional) {#sumologichttpoutput-disk_buffer}
+
+This option enables putting outgoing messages into the disk buffer of the destination to avoid message loss in case of a system failure on the destination side. For details, see the [Syslog-ng DiskBuffer options](../disk_buffer/).  
+
+Default:  false
+
+### body (string, optional) {#sumologichttpoutput-body}
+
+Default: -
+
+### url (*secret.Secret, optional) {#sumologichttpoutput-url}
+
+Default: -
+
+### batch-lines (int, optional) {#sumologichttpoutput-batch-lines}
+
+Default: -
+
+### batch-bytes (int, optional) {#sumologichttpoutput-batch-bytes}
+
+Default: -
+
+### batch-timeout (int, optional) {#sumologichttpoutput-batch-timeout}
+
+Default: -
+
+### persist_name (string, optional) {#sumologichttpoutput-persist_name}
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/sumologic_syslog.md
+++ b/docs/configuration/plugins/syslogng-outputs/sumologic_syslog.md
@@ -1,0 +1,54 @@
+---
+title: Sumo Logic Syslog
+weight: 200
+generated_file: true
+---
+
+# Storing messages in Sumo Logic over syslog
+## Overview
+ More info at https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#TOPIC-1829122
+
+## Configuration
+## SumologicSyslogOutput
+
+### port (int, optional) {#sumologicsyslogoutput-port}
+
+This option sets the port number of the Sumo Logic server to connect to.  
+
+Default:  6514
+
+### deployment (string, optional) {#sumologicsyslogoutput-deployment}
+
+This option specifies your Sumo Logic deployment.https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-by-Deployment-and-Firewall-Security   
+
+Default:  empty
+
+### tag (string, optional) {#sumologicsyslogoutput-tag}
+
+This option specifies the list of tags to add as the tags fields of Sumo Logic messages. If not specified, syslog-ng OSE automatically adds the tags already assigned to the message. If you set the tag() option, only the tags you specify will be added to the messages.  
+
+Default:  tag
+
+### token (int, optional) {#sumologicsyslogoutput-token}
+
+The Cloud Syslog Cloud Token that you received from the Sumo Logic service while configuring your cloud syslog source. https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Cloud-Syslog-Source#configure-a-cloud%C2%A0syslog%C2%A0source 
+
+Default: -
+
+### tls (*TLS, optional) {#sumologicsyslogoutput-tls}
+
+This option sets various options related to TLS encryption, for example, key/certificate files and trusted CA locations. TLS can be used only with tcp-based transport protocols. For details, see [TLS for syslog-ng outputs](../tls/) and the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#TOPIC-1829193). 
+
+Default: -
+
+### disk_buffer (*DiskBuffer, optional) {#sumologicsyslogoutput-disk_buffer}
+
+This option enables putting outgoing messages into the disk buffer of the destination to avoid message loss in case of a system failure on the destination side. For details, see the [Syslog-ng DiskBuffer options](../disk_buffer/).  
+
+Default:  false
+
+### persist_name (string, optional) {#sumologicsyslogoutput-persist_name}
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/syslog.md
+++ b/docs/configuration/plugins/syslogng-outputs/syslog.md
@@ -1,0 +1,170 @@
+---
+title: Syslog (RFC5424) output
+weight: 200
+generated_file: true
+---
+
+# Syslog output configuration
+## Overview
+ The `syslog` output sends log records over a socket using the Syslog protocol (RFC 5424).
+
+ {{< highlight yaml >}}
+
+	spec:
+	  syslog:
+	    host: 10.12.34.56
+	    transport: tls
+	    tls:
+	      ca_file:
+	        mountFrom:
+	          secretKeyRef:
+	            name: tls-secret
+	            key: ca.crt
+	      cert_file:
+	        mountFrom:
+	          secretKeyRef:
+	            name: tls-secret
+	            key: tls.crt
+	      key_file:
+	        mountFrom:
+	          secretKeyRef:
+	            name: tls-secret
+	            key: tls.key
+
+ {{</ highlight >}}
+
+ The following example also configures disk-based buffering for the output. For details, see the [Syslog-ng DiskBuffer options](../disk_buffer/).
+
+ {{< highlight yaml >}}
+ apiVersion: logging.banzaicloud.io/v1beta1
+ kind: SyslogNGOutput
+ metadata:
+
+	name: test
+	namespace: default
+
+ spec:
+
+	syslog:
+	  host: 10.20.9.89
+	  port: 601
+	  disk_buffer:
+	    disk_buf_size: 512000000
+	    dir: /buffer
+	    reliable: true
+	  template: "$(format-json
+	              --subkeys json.
+	              --exclude json.kubernetes.labels.*
+	              json.kubernetes.labels=literal($(format-flat-json --subkeys json.kubernetes.labels.)))\n"
+	  tls:
+	    ca_file:
+	      mountFrom:
+	        secretKeyRef:
+	          key: ca.crt
+	          name: syslog-tls-cert
+	    cert_file:
+	      mountFrom:
+	        secretKeyRef:
+	          key: tls.crt
+	          name: syslog-tls-cert
+	    key_file:
+	      mountFrom:
+	        secretKeyRef:
+	          key: tls.key
+	          name: syslog-tls-cert
+	  transport: tls
+
+ {{</ highlight >}}
+
+ For details on the available options of the output, see the [syslog-ng documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#TOPIC-1829124).
+
+## Configuration
+## SyslogOutput
+
+Documentation: https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#TOPIC-1829124
+
+### host (string, optional) {#syslogoutput-host}
+
+Address of the destination host 
+
+Default: -
+
+### port (int, optional) {#syslogoutput-port}
+
+The port number to connect to. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor895) 
+
+Default: -
+
+### transport (string, optional) {#syslogoutput-transport}
+
+Specifies the protocol used to send messages to the destination server. [more information]() [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor911) 
+
+Default: -
+
+### close_on_input (*bool, optional) {#syslogoutput-close_on_input}
+
+By default, syslog-ng OSE closes destination sockets if it receives any input from the socket (for example, a reply). If this option is set to no, syslog-ng OSE just ignores the input, but does not close the socket. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor859) 
+
+Default: -
+
+### flags ([]string, optional) {#syslogoutput-flags}
+
+Flags influence the behavior of the destination driver. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor877) 
+
+Default: -
+
+### flush_lines (int, optional) {#syslogoutput-flush_lines}
+
+Specifies how many lines are flushed to a destination at a time. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor880) 
+
+Default: -
+
+### so_keepalive (*bool, optional) {#syslogoutput-so_keepalive}
+
+Enables keep-alive messages, keeping the socket open. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor897) 
+
+Default: -
+
+### suppress (int, optional) {#syslogoutput-suppress}
+
+Specifies the number of seconds syslog-ng waits for identical messages. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor901) 
+
+Default: -
+
+### template (string, optional) {#syslogoutput-template}
+
+Specifies a template defining the logformat to be used in the destination. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor905)  
+
+Default:  0
+
+### template_escape (*bool, optional) {#syslogoutput-template_escape}
+
+Turns on escaping for the ', ", and backspace characters in templated output files. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor906) 
+
+Default: -
+
+### tls (*TLS, optional) {#syslogoutput-tls}
+
+Sets various options related to TLS encryption, for example, key/certificate files and trusted CA locations. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor910) 
+
+Default: -
+
+### ts_format (string, optional) {#syslogoutput-ts_format}
+
+Override the global timestamp format (set in the global ts-format() parameter) for the specific destination. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/56#kanchor912) 
+
+Default: -
+
+### disk_buffer (*DiskBuffer, optional) {#syslogoutput-disk_buffer}
+
+Enables putting outgoing messages into the disk buffer of the destination to avoid message loss in case of a system failure on the destination side. For details, see the [Syslog-ng DiskBuffer options](../disk_buffer/). 
+
+Default: -
+
+### persist_name (string, optional) {#syslogoutput-persist_name}
+
+Unique name for the syslog-ng driver [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/administration-guide/persist-name) 
+
+Default: -
+
+

--- a/docs/configuration/plugins/syslogng-outputs/tls.md
+++ b/docs/configuration/plugins/syslogng-outputs/tls.md
@@ -1,0 +1,56 @@
+---
+title: TLS config for syslog-ng outputs
+weight: 200
+generated_file: true
+---
+
+# TLS config for syslog-ng outputs
+## Overview
+ More info at https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/32#kanchor2338
+
+## Configuration
+## TLS
+
+### ca_dir (*secret.Secret, optional) {#tls-ca_dir}
+
+The name of a directory that contains a set of trusted CA certificates in PEM format. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#kanchor3142) 
+
+Default: -
+
+### ca_file (*secret.Secret, optional) {#tls-ca_file}
+
+The name of a file that contains a set of trusted CA certificates in PEM format. (Optional) [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#kanchor3144) 
+
+Default: -
+
+### key_file (*secret.Secret, optional) {#tls-key_file}
+
+The name of a file that contains an unencrypted private key in PEM format, suitable as a TLS key. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#kanchor3163) 
+
+Default: -
+
+### cert_file (*secret.Secret, optional) {#tls-cert_file}
+
+Name of a file, that contains an X.509 certificate (or a certificate chain) in PEM format, suitable as a TLS certificate, matching the private key set in the key-file() option. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#kanchor3146) 
+
+Default: -
+
+### peer_verify (string, optional) {#tls-peer_verify}
+
+Verification method of the peer. [more information](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/73#tls-options-peer-verify) 
+
+Default: -
+
+### use-system-cert-store (*bool, optional) {#tls-use-system-cert-store}
+
+Use the certificate store of the system for verifying HTTPS certificates. [more information](https://curl.se/docs/sslcerts.html) 
+
+Default: -
+
+### cipher-suite (string, optional) {#tls-cipher-suite}
+
+Description: Specifies the cipher, hash, and key-exchange algorithms used for the encryption, for example, ECDHE-ECDSA-AES256-SHA384. The list of available algorithms depends on the version of OpenSSL used to compile syslog-ng OSE 
+
+Default: -
+
+

--- a/pkg/sdk/logging/api/v1beta1/clusterflow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/clusterflow_types.go
@@ -50,40 +50,40 @@ type ClusterMatch struct {
 }
 
 type ClusterSelect struct {
-	Namespaces     []string          `json:"namespaces,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty"`
-	Hosts          []string          `json:"hosts,omitempty"`
 	ContainerNames []string          `json:"container_names,omitempty"`
+	Hosts          []string          `json:"hosts,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	Namespaces     []string          `json:"namespaces,omitempty"`
 }
 
 type ClusterExclude struct {
-	Namespaces     []string          `json:"namespaces,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty"`
-	Hosts          []string          `json:"hosts,omitempty"`
 	ContainerNames []string          `json:"container_names,omitempty"`
+	Hosts          []string          `json:"hosts,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	Namespaces     []string          `json:"namespaces,omitempty"`
 }
 
 // ClusterFlowSpec is the Kubernetes spec for ClusterFlows
 type ClusterFlowSpec struct {
+	Filters              []Filter       `json:"filters,omitempty"`
+	FlowLabel            string         `json:"flowLabel,omitempty"`
+	GlobalOutputRefs     []string       `json:"globalOutputRefs,omitempty"`
+	IncludeLabelInRouter *bool          `json:"includeLabelInRouter,omitempty"`
+	LoggingRef           string         `json:"loggingRef,omitempty"`
+	Match                []ClusterMatch `json:"match,omitempty"`
 	// Deprecated
-	Selectors  map[string]string `json:"selectors,omitempty"`
-	Match      []ClusterMatch    `json:"match,omitempty"`
-	Filters    []Filter          `json:"filters,omitempty"`
-	LoggingRef string            `json:"loggingRef,omitempty"`
+	OutputRefs []string `json:"outputRefs,omitempty"`
 	// Deprecated
-	OutputRefs           []string `json:"outputRefs,omitempty"`
-	GlobalOutputRefs     []string `json:"globalOutputRefs,omitempty"`
-	FlowLabel            string   `json:"flowLabel,omitempty"`
-	IncludeLabelInRouter *bool    `json:"includeLabelInRouter,omitempty"`
+	Selectors map[string]string `json:"selectors,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // ClusterFlowList contains a list of ClusterFlow
 type ClusterFlowList struct {
+	Items           []ClusterFlow `json:"items"`
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ClusterFlow `json:"items"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/clusteroutput_types.go
+++ b/pkg/sdk/logging/api/v1beta1/clusteroutput_types.go
@@ -47,17 +47,17 @@ type ClusterOutput struct {
 
 // ClusterOutputSpec contains Kubernetes spec for ClusterOutput
 type ClusterOutputSpec struct {
-	OutputSpec        `json:",inline"`
 	EnabledNamespaces []string `json:"enabledNamespaces,omitempty"`
+	OutputSpec        `json:",inline"`
 }
 
 // +kubebuilder:object:root=true
 
 // ClusterOutputList contains a list of ClusterOutput
 type ClusterOutputList struct {
+	Items           []ClusterOutput `json:"items"`
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ClusterOutput `json:"items"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -55,13 +55,13 @@ func RepositoryWithTag(repository, tag string) string {
 // Metrics defines the service monitor endpoints
 type Metrics struct {
 	Interval              string               `json:"interval,omitempty"`
-	Timeout               string               `json:"timeout,omitempty"`
-	Port                  int32                `json:"port,omitempty"`
 	Path                  string               `json:"path,omitempty"`
-	ServiceMonitor        bool                 `json:"serviceMonitor,omitempty"`
-	ServiceMonitorConfig  ServiceMonitorConfig `json:"serviceMonitorConfig,omitempty"`
+	Port                  int32                `json:"port,omitempty"`
 	PrometheusAnnotations bool                 `json:"prometheusAnnotations,omitempty"`
 	PrometheusRules       bool                 `json:"prometheusRules,omitempty"`
+	ServiceMonitor        bool                 `json:"serviceMonitor,omitempty"`
+	ServiceMonitorConfig  ServiceMonitorConfig `json:"serviceMonitorConfig,omitempty"`
+	Timeout               string               `json:"timeout,omitempty"`
 }
 
 // BufferMetrics defines the service monitor endpoints
@@ -74,19 +74,19 @@ type BufferMetrics struct {
 type ServiceMonitorConfig struct {
 	AdditionalLabels   map[string]string   `json:"additionalLabels,omitempty"`
 	HonorLabels        bool                `json:"honorLabels,omitempty"`
-	Relabelings        []*v1.RelabelConfig `json:"relabelings,omitempty"`
 	MetricsRelabelings []*v1.RelabelConfig `json:"metricRelabelings,omitempty"`
+	Relabelings        []*v1.RelabelConfig `json:"relabelings,omitempty"`
 	Scheme             string              `json:"scheme,omitempty"`
 	TLSConfig          *v1.TLSConfig       `json:"tlsConfig,omitempty"`
 }
 
 // Security defines Fluentd, FluentbitAgent deployment security properties
 type Security struct {
-	ServiceAccount               string                     `json:"serviceAccount,omitempty"`
-	RoleBasedAccessControlCreate *bool                      `json:"roleBasedAccessControlCreate,omitempty"`
-	PodSecurityPolicyCreate      bool                       `json:"podSecurityPolicyCreate,omitempty"`
-	SecurityContext              *corev1.SecurityContext    `json:"securityContext,omitempty"`
 	PodSecurityContext           *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+	PodSecurityPolicyCreate      bool                       `json:"podSecurityPolicyCreate,omitempty"`
+	RoleBasedAccessControlCreate *bool                      `json:"roleBasedAccessControlCreate,omitempty"`
+	SecurityContext              *corev1.SecurityContext    `json:"securityContext,omitempty"`
+	ServiceAccount               string                     `json:"serviceAccount,omitempty"`
 }
 
 // ReadinessDefaultCheck Enable default readiness checks
@@ -96,9 +96,9 @@ type ReadinessDefaultCheck struct {
 	BufferFreeSpaceThreshold int32 `json:"bufferFreeSpaceThreshold,omitempty"`
 	BufferFileNumber         bool  `json:"bufferFileNumber,omitempty"`
 	BufferFileNumberMax      int32 `json:"bufferFileNumberMax,omitempty"`
+	FailureThreshold         int32 `json:"failureThreshold,omitempty"`
 	InitialDelaySeconds      int32 `json:"initialDelaySeconds,omitempty"`
-	TimeoutSeconds           int32 `json:"timeoutSeconds,omitempty"`
 	PeriodSeconds            int32 `json:"periodSeconds,omitempty"`
 	SuccessThreshold         int32 `json:"successThreshold,omitempty"`
-	FailureThreshold         int32 `json:"failureThreshold,omitempty"`
+	TimeoutSeconds           int32 `json:"timeoutSeconds,omitempty"`
 }

--- a/pkg/sdk/logging/api/v1beta1/flow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/flow_types.go
@@ -30,54 +30,54 @@ type _metaFlowSpec interface{} //nolint:deadcode,unused
 
 // FlowSpec is the Kubernetes spec for Flows
 type FlowSpec struct {
-	// Deprecated
-	Selectors  map[string]string `json:"selectors,omitempty"`
-	Match      []Match           `json:"match,omitempty"`
-	Filters    []Filter          `json:"filters,omitempty"`
-	LoggingRef string            `json:"loggingRef,omitempty"`
-	// Deprecated
-	OutputRefs           []string `json:"outputRefs,omitempty"`
-	GlobalOutputRefs     []string `json:"globalOutputRefs,omitempty"`
-	LocalOutputRefs      []string `json:"localOutputRefs,omitempty"`
+	Filters              []Filter `json:"filters,omitempty"`
 	FlowLabel            string   `json:"flowLabel,omitempty"`
+	GlobalOutputRefs     []string `json:"globalOutputRefs,omitempty"`
 	IncludeLabelInRouter *bool    `json:"includeLabelInRouter,omitempty"`
+	LocalOutputRefs      []string `json:"localOutputRefs,omitempty"`
+	LoggingRef           string   `json:"loggingRef,omitempty"`
+	Match                []Match  `json:"match,omitempty"`
+	// Deprecated
+	OutputRefs []string `json:"outputRefs,omitempty"`
+	// Deprecated
+	Selectors map[string]string `json:"selectors,omitempty"`
 }
 
 type Match struct {
-	*Select  `json:"select,omitempty"`
 	*Exclude `json:"exclude,omitempty"`
+	*Select  `json:"select,omitempty"`
 }
 
 type Select struct {
-	Labels         map[string]string `json:"labels,omitempty"`
-	Hosts          []string          `json:"hosts,omitempty"`
 	ContainerNames []string          `json:"container_names,omitempty"`
+	Hosts          []string          `json:"hosts,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
 }
 
 type Exclude struct {
-	Labels         map[string]string `json:"labels,omitempty"`
-	Hosts          []string          `json:"hosts,omitempty"`
 	ContainerNames []string          `json:"container_names,omitempty"`
+	Hosts          []string          `json:"hosts,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
 }
 
 // Filter definition for FlowSpec
 type Filter struct {
-	StdOut              *filter.StdOutFilterConfig        `json:"stdout,omitempty"`
-	Parser              *filter.ParserConfig              `json:"parser,omitempty"`
-	TagNormaliser       *filter.TagNormaliser             `json:"tag_normaliser,omitempty"`
-	Dedot               *filter.DedotFilterConfig         `json:"dedot,omitempty"`
-	ElasticGenId        *filter.ElasticsearchGenId        `json:"elasticsearch_genid,omitempty"`
-	RecordTransformer   *filter.RecordTransformer         `json:"record_transformer,omitempty"`
-	RecordModifier      *filter.RecordModifier            `json:"record_modifier,omitempty"`
-	GeoIP               *filter.GeoIP                     `json:"geoip,omitempty"`
 	Concat              *filter.Concat                    `json:"concat,omitempty"`
+	Dedot               *filter.DedotFilterConfig         `json:"dedot,omitempty"`
 	DetectExceptions    *filter.DetectExceptions          `json:"detectExceptions,omitempty"`
-	Grep                *filter.GrepConfig                `json:"grep,omitempty"`
-	Prometheus          *filter.PrometheusConfig          `json:"prometheus,omitempty"`
-	Throttle            *filter.Throttle                  `json:"throttle,omitempty"`
-	SumoLogic           *filter.SumoLogic                 `json:"sumologic,omitempty"`
+	ElasticGenId        *filter.ElasticsearchGenId        `json:"elasticsearch_genid,omitempty"`
 	EnhanceK8s          *filter.EnhanceK8s                `json:"enhanceK8s,omitempty"`
+	GeoIP               *filter.GeoIP                     `json:"geoip,omitempty"`
+	Grep                *filter.GrepConfig                `json:"grep,omitempty"`
 	KubeEventsTimestamp *filter.KubeEventsTimestampConfig `json:"kube_events_timestamp,omitempty"`
+	Parser              *filter.ParserConfig              `json:"parser,omitempty"`
+	Prometheus          *filter.PrometheusConfig          `json:"prometheus,omitempty"`
+	RecordModifier      *filter.RecordModifier            `json:"record_modifier,omitempty"`
+	RecordTransformer   *filter.RecordTransformer         `json:"record_transformer,omitempty"`
+	SumoLogic           *filter.SumoLogic                 `json:"sumologic,omitempty"`
+	StdOut              *filter.StdOutFilterConfig        `json:"stdout,omitempty"`
+	TagNormaliser       *filter.TagNormaliser             `json:"tag_normaliser,omitempty"`
+	Throttle            *filter.Throttle                  `json:"throttle,omitempty"`
 }
 
 // FlowStatus defines the observed state of Flow
@@ -98,18 +98,17 @@ type FlowStatus struct {
 type Flow struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   FlowSpec   `json:"spec,omitempty"`
-	Status FlowStatus `json:"status,omitempty"`
+	Spec              FlowSpec   `json:"spec,omitempty"`
+	Status            FlowStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // FlowList contains a list of Flow
 type FlowList struct {
+	Items           []Flow `json:"items"`
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []Flow `json:"items"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -461,8 +461,8 @@ type ForwardOptions struct {
 }
 
 type FluentbitNameProvider struct {
-	logging   *Logging
-	fluentbit *FluentbitAgent
+	logging   *Logging		`json:"logging,omitempty"`
+	fluentbit *FluentbitAgent	`json:"fluentbit,omitempty"`
 }
 
 func (l *FluentbitNameProvider) ComponentName(name string) string {

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -64,69 +64,68 @@ type FluentbitAgentList struct {
 
 // FluentbitSpec defines the desired state of FluentbitAgent
 type FluentbitSpec struct {
-	LoggingRef string `json:"loggingRef,omitempty"`
-
-	DaemonSetAnnotations map[string]string `json:"daemonsetAnnotations,omitempty"`
-	Annotations          map[string]string `json:"annotations,omitempty"`
-	Labels               map[string]string `json:"labels,omitempty"`
-	EnvVars              []corev1.EnvVar   `json:"envVars,omitempty"`
-	Image                ImageSpec         `json:"image,omitempty"`
-	TLS                  *FluentbitTLS     `json:"tls,omitempty"`
-	TargetHost           string            `json:"targetHost,omitempty"`
-	TargetPort           int32             `json:"targetPort,omitempty"`
-	// Set the flush time in seconds.nanoseconds. The engine loop uses a Flush timeout to define when is required to flush the records ingested by input plugins through the defined output plugins. (default: 1)
-	Flush int32 `json:"flush,omitempty"  plugin:"default:1"`
-	// Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit (default: 5)
-	Grace int32 `json:"grace,omitempty" plugin:"default:5"`
-	// Set the logging verbosity level. Allowed values are: error, warn, info, debug and trace. Values are accumulative, e.g: if 'debug' is set, it will include error, warning, info and debug.  Note that trace mode is only available if Fluent Bit was built with the WITH_TRACE option enabled. (default: info)
-	LogLevel string `json:"logLevel,omitempty" plugin:"default:info"`
-	// Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer.
-	// Do not change the default value of this parameter unless you know what you are doing. (default: 24576)
-	CoroStackSize int32                       `json:"coroStackSize,omitempty" plugin:"default:24576"`
-	Resources     corev1.ResourceRequirements `json:"resources,omitempty"`
-	Tolerations   []corev1.Toleration         `json:"tolerations,omitempty"`
-	NodeSelector  map[string]string           `json:"nodeSelector,omitempty"`
-	Affinity      *corev1.Affinity            `json:"affinity,omitempty"`
-	Metrics       *Metrics                    `json:"metrics,omitempty"`
-	Security      *Security                   `json:"security,omitempty"`
+	Affinity      *corev1.Affinity  `json:"affinity,omitempty"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+	BufferStorage BufferStorage     `json:"bufferStorage,omitempty"`
 	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
-	PositionDB volume.KubernetesVolume `json:"positiondb,omitempty"`
-	// Deprecated, use positiondb
-	PosisionDBLegacy  *volume.KubernetesVolume `json:"position_db,omitempty"`
-	MountPath         string                   `json:"mountPath,omitempty"`
-	ExtraVolumeMounts []*VolumeMount           `json:"extraVolumeMounts,omitempty"`
-	InputTail         InputTail                `json:"inputTail,omitempty"`
-	FilterAws         *FilterAws               `json:"filterAws,omitempty"`
-	FilterModify      []FilterModify           `json:"filterModify,omitempty"`
-	// Deprecated, use inputTail.parser
-	Parser string `json:"parser,omitempty"`
-	// Parameters for Kubernetes metadata filter
-	FilterKubernetes FilterKubernetes `json:"filterKubernetes,omitempty"`
-	// Disable Kubernetes metadata filter
-	DisableKubernetesFilter *bool         `json:"disableKubernetesFilter,omitempty"`
-	BufferStorage           BufferStorage `json:"bufferStorage,omitempty"`
-	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
-	BufferStorageVolume     volume.KubernetesVolume        `json:"bufferStorageVolume,omitempty"`
-	BufferVolumeMetrics     *Metrics                       `json:"bufferVolumeMetrics,omitempty"`
-	BufferVolumeImage       ImageSpec                      `json:"bufferVolumeImage,omitempty"`
-	BufferVolumeArgs        []string                       `json:"bufferVolumeArgs,omitempty"`
-	CustomConfigSecret      string                         `json:"customConfigSecret,omitempty"`
-	PodPriorityClassName    string                         `json:"podPriorityClassName,omitempty"`
-	LivenessProbe           *corev1.Probe                  `json:"livenessProbe,omitempty"`
-	LivenessDefaultCheck    bool                           `json:"livenessDefaultCheck,omitempty"`
-	ReadinessProbe          *corev1.Probe                  `json:"readinessProbe,omitempty"`
-	Network                 *FluentbitNetwork              `json:"network,omitempty"`
-	ForwardOptions          *ForwardOptions                `json:"forwardOptions,omitempty"`
-	EnableUpstream          bool                           `json:"enableUpstream,omitempty"`
-	ServiceAccountOverrides *typeoverride.ServiceAccount   `json:"serviceAccount,omitempty"`
-	DNSPolicy               corev1.DNSPolicy               `json:"dnsPolicy,omitempty"`
-	DNSConfig               *corev1.PodDNSConfig           `json:"dnsConfig,omitempty"`
-	HostNetwork             bool                           `json:"HostNetwork,omitempty"`
-	SyslogNGOutput          *FluentbitTCPOutput            `json:"syslogng_output,omitempty"`
-	UpdateStrategy          appsv1.DaemonSetUpdateStrategy `json:"updateStrategy,omitempty"`
+	BufferStorageVolume volume.KubernetesVolume `json:"bufferStorageVolume,omitempty"`
+	BufferVolumeArgs    []string                `json:"bufferVolumeArgs,omitempty"`
+	BufferVolumeImage   ImageSpec               `json:"bufferVolumeImage,omitempty"`
+	BufferVolumeMetrics *Metrics                `json:"bufferVolumeMetrics,omitempty"`
 	// Specify a custom parser file to load in addition to the default parsers file.
 	// It must be a valid key in the configmap specified by customConfig
 	CustomParsers string `json:"customParsers,omitempty"`
+	// Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer.
+	// Do not change the default value of this parameter unless you know what you are doing. (default: 24576)
+	CoroStackSize        int32             `json:"coroStackSize,omitempty" plugin:"default:24576"`
+	CustomConfigSecret   string            `json:"customConfigSecret,omitempty"`
+	DaemonSetAnnotations map[string]string `json:"daemonsetAnnotations,omitempty"`
+	// Disable Kubernetes metadata filter
+	DisableKubernetesFilter *bool                `json:"disableKubernetesFilter,omitempty"`
+	DNSPolicy               corev1.DNSPolicy     `json:"dnsPolicy,omitempty"`
+	DNSConfig               *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+	EnableUpstream          bool                 `json:"enableUpstream,omitempty"`
+	EnvVars                 []corev1.EnvVar      `json:"envVars,omitempty"`
+	ExtraVolumeMounts       []*VolumeMount       `json:"extraVolumeMounts,omitempty"`
+	FilterAws               *FilterAws           `json:"filterAws,omitempty"`
+	// Parameters for Kubernetes metadata filter
+	FilterKubernetes FilterKubernetes `json:"filterKubernetes,omitempty"`
+	FilterModify     []FilterModify   `json:"filterModify,omitempty"`
+	// Set the flush time in seconds.nanoseconds. The engine loop uses a Flush timeout to define when is required to flush the records ingested by input plugins through the defined output plugins. (default: 1)
+	Flush int32 `json:"flush,omitempty"  plugin:"default:1"`
+	// Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit (default: 5)
+	ForwardOptions *ForwardOptions `json:"forwardOptions,omitempty"`
+	Grace          int32           `json:"grace,omitempty" plugin:"default:5"`
+	HostNetwork    bool            `json:"HostNetwork,omitempty"`
+	Image          ImageSpec       `json:"image,omitempty"`
+	InputTail      InputTail       `json:"inputTail,omitempty"`
+	// Deprecated, use inputTail.parser
+	Labels               map[string]string `json:"labels,omitempty"`
+	LivenessProbe        *corev1.Probe     `json:"livenessProbe,omitempty"`
+	LivenessDefaultCheck bool              `json:"livenessDefaultCheck,omitempty"`
+	LoggingRef           string            `json:"loggingRef,omitempty"`
+	// Set the logging verbosity level. Allowed values are: error, warn, info, debug and trace. Values are accumulative, e.g: if 'debug' is set, it will include error, warning, info and debug.  Note that trace mode is only available if Fluent Bit was built with the WITH_TRACE option enabled. (default: info)
+	LogLevel     string            `json:"logLevel,omitempty" plugin:"default:info"`
+	Metrics      *Metrics          `json:"metrics,omitempty"`
+	MountPath    string            `json:"mountPath,omitempty"`
+	Network      *FluentbitNetwork `json:"network,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	Parser       string            `json:"parser,omitempty"`
+	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
+	PositionDB volume.KubernetesVolume `json:"positiondb,omitempty"`
+	// Deprecated, use positiondb
+	PosisionDBLegacy        *volume.KubernetesVolume       `json:"position_db,omitempty"`
+	PodPriorityClassName    string                         `json:"podPriorityClassName,omitempty"`
+	ReadinessProbe          *corev1.Probe                  `json:"readinessProbe,omitempty"`
+	Resources               corev1.ResourceRequirements    `json:"resources,omitempty"`
+	Security                *Security                      `json:"security,omitempty"`
+	ServiceAccountOverrides *typeoverride.ServiceAccount   `json:"serviceAccount,omitempty"`
+	SyslogNGOutput          *FluentbitTCPOutput            `json:"syslogng_output,omitempty"`
+	TargetHost              string                         `json:"targetHost,omitempty"`
+	TargetPort              int32                          `json:"targetPort,omitempty"`
+	TLS                     *FluentbitTLS                  `json:"tls,omitempty"`
+	Tolerations             []corev1.Toleration            `json:"tolerations,omitempty"`
+	UpdateStrategy          appsv1.DaemonSetUpdateStrategy `json:"updateStrategy,omitempty"`
 }
 
 // FluentbitStatus defines the resource status for FluentbitAgent
@@ -199,28 +198,10 @@ type BufferStorage struct {
 
 // InputTail defines FluentbitAgent tail input configuration The tail input plugin allows to monitor one or several text files. It has a similar behavior like tail -f shell command.
 type InputTail struct {
-	// Specify the buffering mechanism to use. It can be memory or filesystem. (default:memory)
-	StorageType string `json:"storage.type,omitempty"`
 	// Set the buffer size for HTTP client when reading responses from Kubernetes API server. The value must be according to the Unit Size specification. (default:32k)
 	BufferChunkSize string `json:"Buffer_Chunk_Size,omitempty"`
 	// Set the limit of the buffer size per monitored file. When a buffer needs to be increased (e.g: very long lines), this value is used to restrict how much the memory buffer can grow. If reading a file exceed this limit, the file is removed from the monitored file list. The value must be according to the Unit Size specification. (default:Buffer_Chunk_Size)
 	BufferMaxSize string `json:"Buffer_Max_Size,omitempty"`
-	// Pattern specifying a specific log files or multiple ones through the use of common wildcards.
-	Path string `json:"Path,omitempty"`
-	// If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map.
-	PathKey string `json:"Path_Key,omitempty"`
-	// Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip
-	ExcludePath string `json:"Exclude_Path,omitempty"`
-	// For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail.
-	ReadFromHead bool `json:"Read_From_Head,omitempty"`
-	// The interval of refreshing the list of watched files in seconds. (default:60)
-	RefreshInterval string `json:"Refresh_Interval,omitempty"`
-	// Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed. (default:5)
-	RotateWait string `json:"Rotate_Wait,omitempty"`
-	// Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax. Default behavior is to read all specified files.
-	IgnoreOlder string `json:"Ignore_Older,omitempty"`
-	// When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file. Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size. (default:Off)
-	SkipLongLines string `json:"Skip_Long_Lines,omitempty"`
 	// Specify the database file to keep track of monitored files and offsets.
 	DB *string `json:"DB,omitempty"`
 	// Set a default synchronization (I/O) method. Values: Extra, Full, Normal, Off. This flag affects how the internal SQLite engine do synchronization to disk, for more details about each option please refer to this section. (default:Full)
@@ -229,52 +210,94 @@ type InputTail struct {
 	DBLocking *bool `json:"DB.locking,omitempty"`
 	// sets the journal mode for databases (WAL). Enabling WAL provides higher performance. Note that WAL is not compatible with shared network file systems. (default: WAL)
 	DBJournalMode string `json:"DB.journal_mode,omitempty"`
-	// Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes.
-	MemBufLimit string `json:"Mem_Buf_Limit,omitempty"`
-	// Specify the name of a parser to interpret the entry as a structured message.
-	Parser string `json:"Parser,omitempty"`
+	// If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline. (default:Off)
+	DockerMode string `json:"Docker_Mode,omitempty"`
+	// Wait period time in seconds to flush queued unfinished split lines. (default:4)
+	DockerModeFlush string `json:"Docker_Mode_Flush,omitempty"`
+	// Specify an optional parser for the first line of the docker multiline mode.
+	DockerModeParser string `json:"Docker_Mode_Parser,omitempty"`
+	// Set one or multiple shell patterns separated by commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip
+	ExcludePath string `json:"Exclude_Path,omitempty"`
+	// Ignores files that have been last modified before this time in seconds. Supports m,h,d (minutes, hours,days) syntax. Default behavior is to read all specified files.
+	IgnoreOlder string `json:"Ignore_Older,omitempty"`
 	// When a message is unstructured (no parser applied), it's appended as a string under the key name log. This option allows to define an alternative name for that key. (default:log)
 	Key string `json:"Key,omitempty"`
-	// Set a tag (with regex-extract fields) that will be placed on lines read.
-	Tag string `json:"Tag,omitempty"`
-	// Set a regex to extract fields from the file.
-	TagRegex string `json:"Tag_Regex,omitempty"`
+	// Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes.
+	MemBufLimit string `json:"Mem_Buf_Limit,omitempty"`
 	// If enabled, the plugin will try to discover multiline messages and use the proper parsers to compose the outgoing messages. Note that when this option is enabled the Parser option is not used. (default:Off)
 	Multiline string `json:"Multiline,omitempty"`
 	// Wait period time in seconds to process queued multiline messages (default:4)
 	MultilineFlush string `json:"Multiline_Flush,omitempty"`
+	// Specify one or multiple parser definitions to apply to the content. Part of the new Multiline Core support in 1.8 (default: "")
+	MultilineParser []string `json:"multiline.parser,omitempty"`
+	// Specify the name of a parser to interpret the entry as a structured message.
+	Parser string `json:"Parser,omitempty"`
 	// Name of the parser that machs the beginning of a multiline message. Note that the regular expression defined in the parser must include a group name (named capture)
 	ParserFirstline string `json:"Parser_Firstline,omitempty"`
 	// Optional-extra parser to interpret and structure multiline entries. This option can be used to define multiple parsers, e.g: Parser_1 ab1,  Parser_2 ab2, Parser_N abN.
 	ParserN []string `json:"Parser_N,omitempty"`
-	// If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline. (default:Off)
-	DockerMode string `json:"Docker_Mode,omitempty"`
-	// Specify an optional parser for the first line of the docker multiline mode.
-	DockerModeParser string `json:"Docker_Mode_Parser,omitempty"`
-	// Wait period time in seconds to flush queued unfinished split lines. (default:4)
-	DockerModeFlush string `json:"Docker_Mode_Flush,omitempty"`
-	// Specify one or multiple parser definitions to apply to the content. Part of the new Multiline Core support in 1.8 (default: "")
-	MultilineParser []string `json:"multiline.parser,omitempty"`
+	// Pattern specifying a specific log files or multiple ones through the use of common wildcards.
+	Path string `json:"Path,omitempty"`
+	// If enabled, it appends the name of the monitored file as part of the record. The value assigned becomes the key in the map.
+	PathKey string `json:"Path_Key,omitempty"`
+	// For new discovered files on start (without a database offset/position), read the content from the head of the file, not tail.
+	ReadFromHead bool `json:"Read_From_Head,omitempty"`
+	// The interval of refreshing the list of watched files in seconds. (default:60)
+	RefreshInterval string `json:"Refresh_Interval,omitempty"`
+	// Specify the number of extra time in seconds to monitor a file once is rotated in case some pending data is flushed. (default:5)
+	RotateWait string `json:"Rotate_Wait,omitempty"`
+	// When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file. Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size. (default:Off)
+	SkipLongLines string `json:"Skip_Long_Lines,omitempty"`
+	// Specify the buffering mechanism to use. It can be memory or filesystem. (default:memory)
+	StorageType string `json:"storage.type,omitempty"`
+	// Set a tag (with regex-extract fields) that will be placed on lines read.
+	Tag string `json:"Tag,omitempty"`
+	// Set a regex to extract fields from the file.
+	TagRegex string `json:"Tag_Regex,omitempty"`
 }
 
 // FilterKubernetes Fluent Bit Kubernetes Filter allows to enrich your log files with Kubernetes metadata.
 type FilterKubernetes struct {
-	// Match filtered records (default:kube.*)
-	Match string `json:"Match,omitempty" plugin:"default:kubernetes.*"`
+	// Include Kubernetes resource annotations in the extra metadata. (default:On)
+	Annotations string `json:"Annotations,omitempty"`
 	// Set the buffer size for HTTP client when reading responses from Kubernetes API server. The value must be according to the Unit Size specification. A value of 0 results in no limit, and the buffer will expand as-needed. Note that if pod specifications exceed the buffer limit, the API response will be discarded when retrieving metadata, and some kubernetes metadata will fail to be injected to the logs. If this value is empty we will set it "0". (default:"0")
 	BufferSize string `json:"Buffer_Size,omitempty"`
+	// When enabled, metadata will be fetched from K8s when docker_id is changed. (default:Off)
+	CacheUseDockerId string `json:"Cache_Use_Docker_Id,omitempty"`
+	// DNS lookup retries N times until the network start working (default:6)
+	DNSRetries string `json:"DNS_Retries,omitempty"`
+	// DNS lookup interval between network status checks (default:30)
+	DNSWaitTime string `json:"DNS_Wait_Time,omitempty"`
+	// If set, use dummy-meta data (for test/dev purposes) (default:Off)
+	DummyMeta string `json:"Dummy_Meta,omitempty"`
+	// Allow Kubernetes Pods to suggest a pre-defined Parser (read more about it in Kubernetes Annotations section) (default:Off)
+	K8SLoggingParser string `json:"K8S-Logging.Parser,omitempty"`
+	// Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section). (default:On)
+	K8SLoggingExclude string `json:"K8S-Logging.Exclude,omitempty"`
+	// When Keep_Log is disabled, the log field is removed from the incoming message once it has been successfully merged (Merge_Log must be enabled as well). (default:On)
+	KeepLog string `json:"Keep_Log,omitempty"`
 	// API Server end-point (default:https://kubernetes.default.svc:443)
 	KubeURL string `json:"Kube_URL,omitempty" plugin:"default:https://kubernetes.default.svc:443"`
 	//	CA certificate file (default:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt)
 	KubeCAFile string `json:"Kube_CA_File,omitempty" plugin:"default:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"`
 	// Absolute path to scan for certificate files
 	KubeCAPath string `json:"Kube_CA_Path,omitempty"`
+	// kubelet port using for HTTP request, this only works when Use_Kubelet  set to On (default:10250)
+	KubeletPort string `json:"Kubelet_Port,omitempty"`
+	// Configurable TTL for K8s cached metadata. By default, it is set to 0 which means TTL for cache entries is disabled and cache entries are evicted at random when capacity is reached. In order to enable this option, you should set the number to a time interval. For example, set this value to 60 or 60s and cache entries which have been created more than 60s will be evicted. (default:0)
+	KubeMetaCacheTTL string `json:"Kube_Meta_Cache_TTL,omitempty"`
+	// When the source records comes from Tail input plugin, this option allows to specify what's the prefix used in Tail configuration. (default:kube.var.log.containers.)
+	KubeTagPrefix string `json:"Kube_Tag_Prefix,omitempty" plugin:"default:kubernetes.var.log.containers"`
+	// If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory, named as namespace-pod.meta
+	KubeMetaPreloadCacheDir string `json:"Kube_meta_preload_cache_dir,omitempty"`
 	// Token file  (default:/var/run/secrets/kubernetes.io/serviceaccount/token)
 	KubeTokenFile string `json:"Kube_Token_File,omitempty" plugin:"default:/var/run/secrets/kubernetes.io/serviceaccount/token"`
 	// Token TTL configurable 'time to live' for the K8s token. By default, it is set to 600 seconds. After this time, the token is reloaded from Kube_Token_File or the Kube_Token_Command.  (default:"600")
 	KubeTokenTTL string `json:"Kube_Token_TTL,omitempty" plugin:"default:600"`
-	// When the source records comes from Tail input plugin, this option allows to specify what's the prefix used in Tail configuration. (default:kube.var.log.containers.)
-	KubeTagPrefix string `json:"Kube_Tag_Prefix,omitempty" plugin:"default:kubernetes.var.log.containers"`
+	// Include Kubernetes resource labels in the extra metadata. (default:On)
+	Labels string `json:"Labels,omitempty"`
+	// Match filtered records (default:kube.*)
+	Match string `json:"Match,omitempty" plugin:"default:kubernetes.*"`
 	// When enabled, it checks if the log field content is a JSON string map, if so, it append the map fields as part of the log structure. (default:Off)
 	MergeLog string `json:"Merge_Log,omitempty" plugin:"default:On"`
 	// When Merge_Log is enabled, the filter tries to assume the log field from the incoming message is a JSON string message and make a structured representation of it at the same level of the log field in the map. Now if Merge_Log_Key is set (a string name), all the new structured fields taken from the original log content are inserted under the new key.
@@ -283,118 +306,94 @@ type FilterKubernetes struct {
 	MergeLogTrim string `json:"Merge_Log_Trim,omitempty"`
 	// Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only.
 	MergeParser string `json:"Merge_Parser,omitempty"`
-	// When Keep_Log is disabled, the log field is removed from the incoming message once it has been successfully merged (Merge_Log must be enabled as well). (default:On)
-	KeepLog string `json:"Keep_Log,omitempty"`
+	// Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id. The parser must be registered in a parsers file (refer to parser filter-kube-test as an example).
+	RegexParser string `json:"Regex_Parser,omitempty"`
 	// Debug level between 0 (nothing) and 4 (every detail). (default:-1)
 	TLSDebug string `json:"tls.debug,omitempty"`
 	// When enabled, turns on certificate validation when connecting to the Kubernetes API server. (default:On)
 	TLSVerify string `json:"tls.verify,omitempty"`
 	// When enabled, the filter reads logs coming in Journald format. (default:Off)
 	UseJournal string `json:"Use_Journal,omitempty"`
-	// When enabled, metadata will be fetched from K8s when docker_id is changed. (default:Off)
-	CacheUseDockerId string `json:"Cache_Use_Docker_Id,omitempty"`
-	// Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id. The parser must be registered in a parsers file (refer to parser filter-kube-test as an example).
-	RegexParser string `json:"Regex_Parser,omitempty"`
-	// Allow Kubernetes Pods to suggest a pre-defined Parser (read more about it in Kubernetes Annotations section) (default:Off)
-	K8SLoggingParser string `json:"K8S-Logging.Parser,omitempty"`
-	// Allow Kubernetes Pods to exclude their logs from the log processor (read more about it in Kubernetes Annotations section). (default:On)
-	K8SLoggingExclude string `json:"K8S-Logging.Exclude,omitempty"`
-	// Include Kubernetes resource labels in the extra metadata. (default:On)
-	Labels string `json:"Labels,omitempty"`
-	// Include Kubernetes resource annotations in the extra metadata. (default:On)
-	Annotations string `json:"Annotations,omitempty"`
-	// If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory, named as namespace-pod.meta
-	KubeMetaPreloadCacheDir string `json:"Kube_meta_preload_cache_dir,omitempty"`
-	// If set, use dummy-meta data (for test/dev purposes) (default:Off)
-	DummyMeta string `json:"Dummy_Meta,omitempty"`
-	// DNS lookup retries N times until the network start working (default:6)
-	DNSRetries string `json:"DNS_Retries,omitempty"`
-	// DNS lookup interval between network status checks (default:30)
-	DNSWaitTime string `json:"DNS_Wait_Time,omitempty"`
 	// This is an optional feature flag to get metadata information from kubelet instead of calling Kube Server API to enhance the log. (default:Off)
 	UseKubelet string `json:"Use_Kubelet,omitempty"`
-	// kubelet port using for HTTP request, this only works when Use_Kubelet  set to On (default:10250)
-	KubeletPort string `json:"Kubelet_Port,omitempty"`
-	// Configurable TTL for K8s cached metadata. By default, it is set to 0 which means TTL for cache entries is disabled and cache entries are evicted at random when capacity is reached. In order to enable this option, you should set the number to a time interval. For example, set this value to 60 or 60s and cache entries which have been created more than 60s will be evicted. (default:0)
-	KubeMetaCacheTTL string `json:"Kube_Meta_Cache_TTL,omitempty"`
 }
 
 // FilterAws The AWS Filter Enriches logs with AWS Metadata.
 type FilterAws struct {
-	// Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2' (default).
-	ImdsVersion string `json:"imds_version,omitempty" plugin:"default:v2"`
+	// The account ID for current EC2 instance. (default:false)
+	AccountID *bool `json:"account_id,omitempty" plugin:"default:false"`
+	// The EC2 instance image id. (default:false)
+	AmiID *bool `json:"ami_id,omitempty" plugin:"default:false"`
 	// The availability zone (default:true).
 	AZ *bool `json:"az,omitempty" plugin:"default:true"`
 	// The EC2 instance ID. (default:true)
 	Ec2InstanceID *bool `json:"ec2_instance_id,omitempty" plugin:"default:true"`
 	// The EC2 instance type. (default:false)
 	Ec2InstanceType *bool `json:"ec2_instance_type,omitempty" plugin:"default:false"`
-	// The EC2 instance private ip. (default:false)
-	PrivateIP *bool `json:"private_ip,omitempty" plugin:"default:false"`
-	// The EC2 instance image id. (default:false)
-	AmiID *bool `json:"ami_id,omitempty" plugin:"default:false"`
-	// The account ID for current EC2 instance. (default:false)
-	AccountID *bool `json:"account_id,omitempty" plugin:"default:false"`
 	// The hostname for current EC2 instance. (default:false)
 	Hostname *bool `json:"hostname,omitempty" plugin:"default:false"`
-	// The VPC ID for current EC2 instance. (default:false)
-	VpcID *bool `json:"vpc_id,omitempty" plugin:"default:false"`
+	// Specify which version of the instance metadata service to use. Valid values are 'v1' or 'v2' (default).
+	ImdsVersion string `json:"imds_version,omitempty" plugin:"default:v2"`
 	// Match filtered records (default:*)
 	Match string `json:"Match,omitempty" plugin:"default:*"`
+	// The EC2 instance private ip. (default:false)
+	PrivateIP *bool `json:"private_ip,omitempty" plugin:"default:false"`
+	// The VPC ID for current EC2 instance. (default:false)
+	VpcID *bool `json:"vpc_id,omitempty" plugin:"default:false"`
 }
 
 // FilterModify The Modify Filter plugin allows you to change records using rules and conditions.
 type FilterModify struct {
-	// FluentbitAgent Filter Modification Rule
-	Rules []FilterModifyRule `json:"rules,omitempty"`
 	// FluentbitAgent Filter Modification Condition
 	Conditions []FilterModifyCondition `json:"conditions,omitempty"`
+	// FluentbitAgent Filter Modification Rule
+	Rules []FilterModifyRule `json:"rules,omitempty"`
 }
 
 // FilterModifyRule The Modify Filter plugin allows you to change records using rules and conditions.
 type FilterModifyRule struct {
-	// Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten
-	Set *FilterKeyValue `json:"Set,omitempty"`
 	// Add a key/value pair with key KEY and value VALUE if KEY does not exist
 	Add *FilterKeyValue `json:"Add,omitempty" `
-	// Remove a key/value pair with key KEY if it exists
-	Remove *FilterKey `json:"Remove,omitempty" `
-	// Remove all key/value pairs with key matching wildcard KEY
-	RemoveWildcard *FilterKey `json:"Remove_wildcard,omitempty" `
-	// Remove all key/value pairs with key matching regexp KEY
-	RemoveRegex *FilterKey `json:"Remove_regex,omitempty" `
-	// Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist
-	Rename *FilterKeyValue `json:"Rename,omitempty" `
-	// Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists. If RENAMED_KEY already exists, this field is overwritten
-	HardRename *FilterKeyValue `json:"Hard_rename,omitempty" `
 	// Copy a key/value pair with key KEY to COPIED_KEY if KEY exists AND COPIED_KEY does not exist
 	Copy *FilterKeyValue `json:"Copy,omitempty" `
 	// Copy a key/value pair with key KEY to COPIED_KEY if KEY exists. If COPIED_KEY already exists, this field is overwritten
 	HardCopy *FilterKeyValue `json:"Hard_copy,omitempty" `
+	// Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists. If RENAMED_KEY already exists, this field is overwritten
+	HardRename *FilterKeyValue `json:"Hard_rename,omitempty" `
+	// Rename a key/value pair with key KEY to RENAMED_KEY if KEY exists AND RENAMED_KEY does not exist
+	Rename *FilterKeyValue `json:"Rename,omitempty" `
+	// Remove a key/value pair with key KEY if it exists
+	Remove *FilterKey `json:"Remove,omitempty" `
+	// Remove all key/value pairs with key matching regexp KEY
+	RemoveRegex *FilterKey `json:"Remove_regex,omitempty" `
+	// Remove all key/value pairs with key matching wildcard KEY
+	RemoveWildcard *FilterKey `json:"Remove_wildcard,omitempty" `
+	// Add a key/value pair with key KEY and value VALUE. If KEY already exists, this field is overwritten
+	Set *FilterKeyValue `json:"Set,omitempty"`
 }
 
 // FilterModifyCondition The Modify Filter plugin allows you to change records using rules and conditions.
 type FilterModifyCondition struct {
-	// Is true if KEY exists
-	KeyExists *FilterKey `json:"Key_exists,omitempty"`
-	// Is true if KEY does not exist
-	KeyDoesNotExist *FilterKeyValue `json:"Key_does_not_exist,omitempty"`
 	// Is true if a key matches regex KEY
 	AKeyMatches *FilterKey `json:"A_key_matches,omitempty"`
-	// Is true if no key matches regex KEY
-	NoKeyMatches *FilterKey `json:"No_key_matches,omitempty"`
-	// Is true if KEY exists and its value is VALUE
-	KeyValueEquals *FilterKeyValue `json:"Key_value_equals,omitempty"`
+	// Is true if KEY does not exist
+	KeyDoesNotExist *FilterKeyValue `json:"Key_does_not_exist,omitempty"`
+	// Is true if KEY exists
+	KeyExists *FilterKey `json:"Key_exists,omitempty"`
 	// Is true if KEY exists and its value is not VALUE
 	KeyValueDoesNotEqual *FilterKeyValue `json:"Key_value_does_not_equal,omitempty"`
-	// Is true if key KEY exists and its value matches VALUE
-	KeyValueMatches *FilterKeyValue `json:"Key_value_matches,omitempty"`
+	// Is true if KEY exists and its value is VALUE
+	KeyValueEquals *FilterKeyValue `json:"Key_value_equals,omitempty"`
 	// Is true if key KEY exists and its value does not match VALUE
 	KeyValueDoesNotMatch *FilterKeyValue `json:"Key_value_does_not_match,omitempty"`
-	// Is true if all keys matching KEY have values that match VALUE
-	MatchingKeysHaveMatchingValues *FilterKeyValue `json:"Matching_keys_have_matching_values,omitempty"`
+	// Is true if key KEY exists and its value matches VALUE
+	KeyValueMatches *FilterKeyValue `json:"Key_value_matches,omitempty"`
 	// Is true if all keys matching KEY have values that do not match VALUE
 	MatchingKeysDoNotHaveMatchingValues *FilterKeyValue `json:"Matching_keys_do_not_have_matching_values,omitempty"`
+	// Is true if all keys matching KEY have values that match VALUE
+	MatchingKeysHaveMatchingValues *FilterKeyValue `json:"Matching_keys_have_matching_values,omitempty"`
+	// Is true if no key matches regex KEY
+	NoKeyMatches *FilterKey `json:"No_key_matches,omitempty"`
 }
 
 // Operation Doc stub
@@ -451,18 +450,18 @@ type VolumeMount struct {
 
 // ForwardOptions defines custom forward output plugin options, see https://docs.fluentbit.io/manual/pipeline/outputs/forward
 type ForwardOptions struct {
-	TimeAsInteger      bool   `json:"Time_as_Integer,omitempty"`
-	SendOptions        bool   `json:"Send_options,omitempty"`
 	RequireAckResponse bool   `json:"Require_ack_response,omitempty"`
-	Tag                string `json:"Tag,omitempty"`
 	RetryLimit         string `json:"Retry_Limit,omitempty"`
+	SendOptions        bool   `json:"Send_options,omitempty"`
 	// `storage.total_limit_size` Limit the maximum number of Chunks in the filesystem for the current output logical destination.
 	StorageTotalLimitSize string `json:"storage.total_limit_size,omitempty"`
+	Tag                   string `json:"Tag,omitempty"`
+	TimeAsInteger         bool   `json:"Time_as_Integer,omitempty"`
 }
 
 type FluentbitNameProvider struct {
-	logging   *Logging		`json:"logging,omitempty"`
-	fluentbit *FluentbitAgent	`json:"fluentbit,omitempty"`
+	fluentbit *FluentbitAgent `json:"fluentbit,omitempty"`
+	logging   *Logging        `json:"logging,omitempty"`
 }
 
 func (l *FluentbitNameProvider) ComponentName(name string) string {

--- a/pkg/sdk/logging/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_types.go
@@ -34,73 +34,73 @@ type _metaFluentdSpec interface{} //nolint:deadcode,unused
 
 // FluentdSpec defines the desired state of Fluentd
 type FluentdSpec struct {
-	StatefulSetAnnotations map[string]string `json:"statefulsetAnnotations,omitempty"`
-	Annotations            map[string]string `json:"annotations,omitempty"`
-	ConfigCheckAnnotations map[string]string `json:"configCheckAnnotations,omitempty"`
-	Labels                 map[string]string `json:"labels,omitempty"`
-	EnvVars                []corev1.EnvVar   `json:"envVars,omitempty"`
-	TLS                    FluentdTLS        `json:"tls,omitempty"`
-	Image                  ImageSpec         `json:"image,omitempty"`
-	DisablePvc             bool              `json:"disablePvc,omitempty"`
+	Affinity    *corev1.Affinity  `json:"affinity,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// BufferStorageVolume is by default configured as PVC using FluentdPvcSpec
 	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
-	BufferStorageVolume volume.KubernetesVolume `json:"bufferStorageVolume,omitempty"`
-	ExtraVolumes        []ExtraVolume           `json:"extraVolumes,omitempty"`
+	BufferStorageVolume     volume.KubernetesVolume     `json:"bufferStorageVolume,omitempty"`
+	BufferVolumeMetrics     *Metrics                    `json:"bufferVolumeMetrics,omitempty"`
+	BufferVolumeImage       ImageSpec                   `json:"bufferVolumeImage,omitempty"`
+	BufferVolumeArgs        []string                    `json:"bufferVolumeArgs,omitempty"`
+	ConfigCheckAnnotations  map[string]string           `json:"configCheckAnnotations,omitempty"`
+	ConfigReloaderImage     ImageSpec                   `json:"configReloaderImage,omitempty"`
+	ConfigCheckResources    corev1.ResourceRequirements `json:"configCheckResources,omitempty"`
+	ConfigReloaderResources corev1.ResourceRequirements `json:"configReloaderResources,omitempty"`
+	CompressConfigFile      bool                        `json:"compressConfigFile,omitempty"`
+	DisablePvc              bool                        `json:"disablePvc,omitempty"`
+	DNSPolicy               corev1.DNSPolicy            `json:"dnsPolicy,omitempty"`
+	DNSConfig               *corev1.PodDNSConfig        `json:"dnsConfig,omitempty"`
+	// Allows Time object in buffer's MessagePack serde
+	// +docLink:"more info, https://docs.fluentd.org/deployment/system-config#enable_msgpack_time_support"
+	EnableMsgpackTimeSupport bool            `json:"enableMsgpackTimeSupport,omitempty"`
+	EnvVars                  []corev1.EnvVar `json:"envVars,omitempty"`
+	ExtraArgs                []string        `json:"extraArgs,omitempty"`
+	ExtraVolumes             []ExtraVolume   `json:"extraVolumes,omitempty"`
 	// Deprecated, use bufferStorageVolume
-	FluentdPvcSpec            *volume.KubernetesVolume          `json:"fluentdPvcSpec,omitempty"`
-	VolumeMountChmod          bool                              `json:"volumeMountChmod,omitempty"`
-	VolumeModImage            ImageSpec                         `json:"volumeModImage,omitempty"`
-	ConfigReloaderImage       ImageSpec                         `json:"configReloaderImage,omitempty"`
-	Resources                 corev1.ResourceRequirements       `json:"resources,omitempty"`
-	ConfigCheckResources      corev1.ResourceRequirements       `json:"configCheckResources,omitempty"`
-	ConfigReloaderResources   corev1.ResourceRequirements       `json:"configReloaderResources,omitempty"`
-	LivenessProbe             *corev1.Probe                     `json:"livenessProbe,omitempty"`
-	LivenessDefaultCheck      bool                              `json:"livenessDefaultCheck,omitempty"`
-	ReadinessProbe            *corev1.Probe                     `json:"readinessProbe,omitempty"`
-	ReadinessDefaultCheck     ReadinessDefaultCheck             `json:"readinessDefaultCheck,omitempty"`
-	Port                      int32                             `json:"port,omitempty"`
-	Tolerations               []corev1.Toleration               `json:"tolerations,omitempty"`
-	NodeSelector              map[string]string                 `json:"nodeSelector,omitempty"`
-	Affinity                  *corev1.Affinity                  `json:"affinity,omitempty"`
-	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
-	Metrics                   *Metrics                          `json:"metrics,omitempty"`
-	BufferVolumeMetrics       *Metrics                          `json:"bufferVolumeMetrics,omitempty"`
-	BufferVolumeImage         ImageSpec                         `json:"bufferVolumeImage,omitempty"`
-	BufferVolumeArgs          []string                          `json:"bufferVolumeArgs,omitempty"`
-	Security                  *Security                         `json:"security,omitempty"`
-	Scaling                   *FluentdScaling                   `json:"scaling,omitempty"`
-	Workers                   int32                             `json:"workers,omitempty"`
-	RootDir                   string                            `json:"rootDir,omitempty"`
-	// +kubebuilder:validation:enum=fatal,error,warn,info,debug,trace
-	LogLevel string `json:"logLevel,omitempty"`
+	FluentdPvcSpec *volume.KubernetesVolume `json:"fluentdPvcSpec,omitempty"`
+	// +kubebuilder:validation:enum=stdout,null
+	FluentLogDestination string `json:"fluentLogDestination,omitempty"`
+	// FluentOutLogrotate sends fluent's stdout to file and rotates it
+	FluentOutLogrotate *FluentOutLogrotate       `json:"fluentOutLogrotate,omitempty"`
+	ForwardInputConfig *input.ForwardInputConfig `json:"forwardInputConfig,omitempty"`
 	// Ignore same log lines
 	// +docLink:"more info, https://docs.fluentd.org/deployment/logging#ignore_same_log_interval"
 	IgnoreSameLogInterval string `json:"ignoreSameLogInterval,omitempty"`
 	// Ignore repeated log lines
 	// +docLink:"more info, https://docs.fluentd.org/deployment/logging#ignore_repeated_log_interval"
-	IgnoreRepeatedLogInterval string `json:"ignoreRepeatedLogInterval,omitempty"`
-	// Allows Time object in buffer's MessagePack serde
-	// +docLink:"more info, https://docs.fluentd.org/deployment/system-config#enable_msgpack_time_support"
-	EnableMsgpackTimeSupport bool   `json:"enableMsgpackTimeSupport,omitempty"`
-	PodPriorityClassName     string `json:"podPriorityClassName,omitempty"`
-	// +kubebuilder:validation:enum=stdout,null
-	FluentLogDestination string `json:"fluentLogDestination,omitempty"`
-	// FluentOutLogrotate sends fluent's stdout to file and rotates it
-	FluentOutLogrotate      *FluentOutLogrotate          `json:"fluentOutLogrotate,omitempty"`
-	ForwardInputConfig      *input.ForwardInputConfig    `json:"forwardInputConfig,omitempty"`
-	ServiceAccountOverrides *typeoverride.ServiceAccount `json:"serviceAccount,omitempty"`
-	DNSPolicy               corev1.DNSPolicy             `json:"dnsPolicy,omitempty"`
-	DNSConfig               *corev1.PodDNSConfig         `json:"dnsConfig,omitempty"`
-	ExtraArgs               []string                     `json:"extraArgs,omitempty"`
-	CompressConfigFile      bool                         `json:"compressConfigFile,omitempty"`
+	IgnoreRepeatedLogInterval string            `json:"ignoreRepeatedLogInterval,omitempty"`
+	Image                     ImageSpec         `json:"image,omitempty"`
+	Labels                    map[string]string `json:"labels,omitempty"`
+	LivenessProbe             *corev1.Probe     `json:"livenessProbe,omitempty"`
+	LivenessDefaultCheck      bool              `json:"livenessDefaultCheck,omitempty"`
+	// +kubebuilder:validation:enum=fatal,error,warn,info,debug,trace
+	LogLevel                  string                            `json:"logLevel,omitempty"`
+	Metrics                   *Metrics                          `json:"metrics,omitempty"`
+	NodeSelector              map[string]string                 `json:"nodeSelector,omitempty"`
+	PodPriorityClassName      string                            `json:"podPriorityClassName,omitempty"`
+	Port                      int32                             `json:"port,omitempty"`
+	ReadinessProbe            *corev1.Probe                     `json:"readinessProbe,omitempty"`
+	ReadinessDefaultCheck     ReadinessDefaultCheck             `json:"readinessDefaultCheck,omitempty"`
+	Resources                 corev1.ResourceRequirements       `json:"resources,omitempty"`
+	RootDir                   string                            `json:"rootDir,omitempty"`
+	Scaling                   *FluentdScaling                   `json:"scaling,omitempty"`
+	Security                  *Security                         `json:"security,omitempty"`
+	ServiceAccountOverrides   *typeoverride.ServiceAccount      `json:"serviceAccount,omitempty"`
+	StatefulSetAnnotations    map[string]string                 `json:"statefulsetAnnotations,omitempty"`
+	TLS                       FluentdTLS                        `json:"tls,omitempty"`
+	Tolerations               []corev1.Toleration               `json:"tolerations,omitempty"`
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	VolumeMountChmod          bool                              `json:"volumeMountChmod,omitempty"`
+	VolumeModImage            ImageSpec                         `json:"volumeModImage,omitempty"`
+	Workers                   int32                             `json:"workers,omitempty"`
 }
 
 // +kubebuilder:object:generate=true
 
 type FluentOutLogrotate struct {
+	Age     string `json:"age,omitempty"`
 	Enabled bool   `json:"enabled"`
 	Path    string `json:"path,omitempty"`
-	Age     string `json:"age,omitempty"`
 	Size    string `json:"size,omitempty"`
 }
 
@@ -108,10 +108,10 @@ type FluentOutLogrotate struct {
 
 // ExtraVolume defines the fluentd extra volumes
 type ExtraVolume struct {
-	VolumeName    string                   `json:"volumeName,omitempty"`
-	Path          string                   `json:"path,omitempty"`
 	ContainerName string                   `json:"containerName,omitempty"`
+	Path          string                   `json:"path,omitempty"`
 	Volume        *volume.KubernetesVolume `json:"volume,omitempty"`
+	VolumeName    string                   `json:"volumeName,omitempty"`
 }
 
 func (e *ExtraVolume) GetVolume() (corev1.Volume, error) {
@@ -126,9 +126,9 @@ func (e *ExtraVolume) ApplyVolumeForPodSpec(spec *corev1.PodSpec) error {
 
 // FluentdScaling enables configuring the scaling behaviour of the fluentd statefulset
 type FluentdScaling struct {
-	Replicas            int                `json:"replicas,omitempty"`
-	PodManagementPolicy string             `json:"podManagementPolicy,omitempty"`
 	Drain               FluentdDrainConfig `json:"drain,omitempty"`
+	PodManagementPolicy string             `json:"podManagementPolicy,omitempty"`
+	Replicas            int                `json:"replicas,omitempty"`
 }
 
 // +kubebuilder:object:generate=true
@@ -144,10 +144,10 @@ type FluentdTLS struct {
 
 // FluentdDrainConfig enables configuring the drain behavior when scaling down the fluentd statefulset
 type FluentdDrainConfig struct {
-	// Should buffers on persistent volumes left after scaling down the statefulset be drained
-	Enabled bool `json:"enabled,omitempty"`
 	// Container image to use for the drain watch sidecar
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Should buffers on persistent volumes left after scaling down the statefulset be drained
+	Enabled bool `json:"enabled,omitempty"`
 	// Should persistent volume claims be deleted after draining is done
 	DeleteVolume bool      `json:"deleteVolume,omitempty"`
 	Image        ImageSpec `json:"image,omitempty"`

--- a/pkg/sdk/logging/api/v1beta1/node_agent_types.go
+++ b/pkg/sdk/logging/api/v1beta1/node_agent_types.go
@@ -86,42 +86,42 @@ type InlineNodeAgent struct {
 // +kubebuilder:object:generate=true
 
 type NodeAgentFluentbit struct {
-	Enabled                 *bool                        `json:"enabled,omitempty"`
-	DaemonSetOverrides      *typeoverride.DaemonSet      `json:"daemonSet,omitempty"`
+	BufferStorage BufferStorage `json:"bufferStorage,omitempty"`
+	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
+	BufferStorageVolume volume.KubernetesVolume `json:"bufferStorageVolume,omitempty"`
+	CustomConfigSecret  string                  `json:"customConfigSecret,omitempty"`
+	ContainersPath      string                  `json:"containersPath,omitempty"`
+	// Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer.
+	//Do not change the default value of this parameter unless you know what you are doing. (default: 24576)
+	CoroStackSize           int32                   `json:"coroStackSize,omitempty" plugin:"default:24576"`
+	DaemonSetOverrides      *typeoverride.DaemonSet `json:"daemonSet,omitempty"`
+	DisableKubernetesFilter *bool                   `json:"disableKubernetesFilter,omitempty"`
+	Enabled                 *bool                   `json:"enabled,omitempty"`
+	EnableUpstream          *bool                   `json:"enableUpstream,omitempty"`
+	ExtraVolumeMounts       []*VolumeMount          `json:"extraVolumeMounts,omitempty"`
+	FilterAws               *FilterAws              `json:"filterAws,omitempty"`
+	FilterKubernetes        FilterKubernetes        `json:"filterKubernetes,omitempty"`
+	// Set the flush time in seconds.nanoseconds. The engine loop uses a Flush timeout to define when is required to flush the records ingested by input plugins through the defined output plugins. (default: 1)
+	Flush          int32           `json:"flush,omitempty"  plugin:"default:1"`
+	ForwardOptions *ForwardOptions `json:"forwardOptions,omitempty"`
+	// Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit (default: 5)
+	Grace                int32     `json:"grace,omitempty" plugin:"default:5"`
+	InputTail            InputTail `json:"inputTail,omitempty"`
+	LivenessDefaultCheck *bool     `json:"livenessDefaultCheck,omitempty" plugin:"default:true"`
+	// Set the logging verbosity level. Allowed values are: error, warn, info, debug and trace. Values are accumulative, e.g: if 'debug' is set, it will include error, warning, info and debug.  Note that trace mode is only available if Fluent Bit was built with the WITH_TRACE option enabled. (default: info)
+	LogLevel       string                `json:"logLevel,omitempty" plugin:"default:info"`
+	Metrics        *Metrics              `json:"metrics,omitempty"`
+	MetricsService *typeoverride.Service `json:"metricsService,omitempty"`
+	Network        *FluentbitNetwork     `json:"network,omitempty"`
+	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
+	PositionDB              volume.KubernetesVolume      `json:"positiondb,omitempty"`
+	PodPriorityClassName    string                       `json:"podPriorityClassName,omitempty"`
+	Security                *Security                    `json:"security,omitempty"`
 	ServiceAccountOverrides *typeoverride.ServiceAccount `json:"serviceAccount,omitempty"`
 	TLS                     *FluentbitTLS                `json:"tls,omitempty"`
 	TargetHost              string                       `json:"targetHost,omitempty"`
 	TargetPort              int32                        `json:"targetPort,omitempty"`
-	// Set the flush time in seconds.nanoseconds. The engine loop uses a Flush timeout to define when is required to flush the records ingested by input plugins through the defined output plugins. (default: 1)
-	Flush int32 `json:"flush,omitempty"  plugin:"default:1"`
-	// Set the grace time in seconds as Integer value. The engine loop uses a Grace timeout to define wait time on exit (default: 5)
-	Grace int32 `json:"grace,omitempty" plugin:"default:5"`
-	// Set the logging verbosity level. Allowed values are: error, warn, info, debug and trace. Values are accumulative, e.g: if 'debug' is set, it will include error, warning, info and debug.  Note that trace mode is only available if Fluent Bit was built with the WITH_TRACE option enabled. (default: info)
-	LogLevel string `json:"logLevel,omitempty" plugin:"default:info"`
-	// Set the coroutines stack size in bytes. The value must be greater than the page size of the running system. Don't set too small value (say 4096), or coroutine threads can overrun the stack buffer.
-	//Do not change the default value of this parameter unless you know what you are doing. (default: 24576)
-	CoroStackSize  int32                 `json:"coroStackSize,omitempty" plugin:"default:24576"`
-	Metrics        *Metrics              `json:"metrics,omitempty"`
-	MetricsService *typeoverride.Service `json:"metricsService,omitempty"`
-	Security       *Security             `json:"security,omitempty"`
-	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
-	PositionDB              volume.KubernetesVolume `json:"positiondb,omitempty"`
-	ContainersPath          string                  `json:"containersPath,omitempty"`
-	VarLogsPath             string                  `json:"varLogsPath,omitempty"`
-	ExtraVolumeMounts       []*VolumeMount          `json:"extraVolumeMounts,omitempty"`
-	InputTail               InputTail               `json:"inputTail,omitempty"`
-	FilterAws               *FilterAws              `json:"filterAws,omitempty"`
-	FilterKubernetes        FilterKubernetes        `json:"filterKubernetes,omitempty"`
-	DisableKubernetesFilter *bool                   `json:"disableKubernetesFilter,omitempty"`
-	BufferStorage           BufferStorage           `json:"bufferStorage,omitempty"`
-	// +docLink:"volume.KubernetesVolume,https://github.com/cisco-open/operator-tools/tree/master/docs/types"
-	BufferStorageVolume  volume.KubernetesVolume `json:"bufferStorageVolume,omitempty"`
-	CustomConfigSecret   string                  `json:"customConfigSecret,omitempty"`
-	PodPriorityClassName string                  `json:"podPriorityClassName,omitempty"`
-	LivenessDefaultCheck *bool                   `json:"livenessDefaultCheck,omitempty" plugin:"default:true"`
-	Network              *FluentbitNetwork       `json:"network,omitempty"`
-	ForwardOptions       *ForwardOptions         `json:"forwardOptions,omitempty"`
-	EnableUpstream       *bool                   `json:"enableUpstream,omitempty"`
+	VarLogsPath             string                       `json:"varLogsPath,omitempty"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/output_types.go
+++ b/pkg/sdk/logging/api/v1beta1/output_types.go
@@ -30,34 +30,34 @@ type _metaOutputSpec interface{} //nolint:deadcode,unused
 
 // OutputSpec defines the desired state of Output
 type OutputSpec struct {
-	LoggingRef                   string                               `json:"loggingRef,omitempty"`
-	S3OutputConfig               *output.S3OutputConfig               `json:"s3,omitempty"`
+	AwsElasticsearchOutputConfig *output.AwsElasticsearchOutputConfig `json:"awsElasticsearch,omitempty"`
 	AzureStorage                 *output.AzureStorage                 `json:"azurestorage,omitempty"`
-	GCSOutput                    *output.GCSOutput                    `json:"gcs,omitempty"`
-	OSSOutput                    *output.OSSOutput                    `json:"oss,omitempty"`
-	ElasticsearchOutput          *output.ElasticsearchOutput          `json:"elasticsearch,omitempty"`
-	OpenSearchOutput             *output.OpenSearchOutput             `json:"opensearch,omitempty"`
-	LogZOutput                   *output.LogZOutput                   `json:"logz,omitempty"`
-	LokiOutput                   *output.LokiOutput                   `json:"loki,omitempty"`
-	SumologicOutput              *output.SumologicOutput              `json:"sumologic,omitempty"`
-	DatadogOutput                *output.DatadogOutput                `json:"datadog,omitempty"`
-	ForwardOutput                *output.ForwardOutput                `json:"forward,omitempty"`
-	FileOutput                   *output.FileOutputConfig             `json:"file,omitempty"`
-	NullOutputConfig             *output.NullOutputConfig             `json:"nullout,omitempty"`
-	KafkaOutputConfig            *output.KafkaOutputConfig            `json:"kafka,omitempty"`
 	CloudWatchOutput             *output.CloudWatchOutput             `json:"cloudwatch,omitempty"`
+	DatadogOutput                *output.DatadogOutput                `json:"datadog,omitempty"`
+	ElasticsearchOutput          *output.ElasticsearchOutput          `json:"elasticsearch,omitempty"`
+	FileOutput                   *output.FileOutputConfig             `json:"file,omitempty"`
+	ForwardOutput                *output.ForwardOutput                `json:"forward,omitempty"`
+	GELFOutputConfig             *output.GELFOutputConfig             `json:"gelf,omitempty"`
+	GCSOutput                    *output.GCSOutput                    `json:"gcs,omitempty"`
+	HTTPOutput                   *output.HTTPOutputConfig             `json:"http,omitempty"`
+	KafkaOutputConfig            *output.KafkaOutputConfig            `json:"kafka,omitempty"`
 	KinesisStreamOutputConfig    *output.KinesisStreamOutputConfig    `json:"kinesisStream,omitempty"`
 	LogDNAOutput                 *output.LogDNAOutput                 `json:"logdna,omitempty"`
-	NewRelicOutputConfig         *output.NewRelicOutputConfig         `json:"newrelic,omitempty"`
-	SplunkHecOutput              *output.SplunkHecOutput              `json:"splunkHec,omitempty"`
-	HTTPOutput                   *output.HTTPOutputConfig             `json:"http,omitempty"`
-	AwsElasticsearchOutputConfig *output.AwsElasticsearchOutputConfig `json:"awsElasticsearch,omitempty"`
-	RedisOutputConfig            *output.RedisOutputConfig            `json:"redis,omitempty"`
-	SyslogOutputConfig           *output.SyslogOutputConfig           `json:"syslog,omitempty"`
-	GELFOutputConfig             *output.GELFOutputConfig             `json:"gelf,omitempty"`
-	SQSOutputConfig              *output.SQSOutputConfig              `json:"sqs,omitempty"`
+	LoggingRef                   string                               `json:"loggingRef,omitempty"`
+	LogZOutput                   *output.LogZOutput                   `json:"logz,omitempty"`
+	LokiOutput                   *output.LokiOutput                   `json:"loki,omitempty"`
 	MattermostOutputConfig       *output.MattermostOutputConfig       `json:"mattermost,omitempty"`
+	NewRelicOutputConfig         *output.NewRelicOutputConfig         `json:"newrelic,omitempty"`
+	NullOutputConfig             *output.NullOutputConfig             `json:"nullout,omitempty"`
+	OSSOutput                    *output.OSSOutput                    `json:"oss,omitempty"`
+	OpenSearchOutput             *output.OpenSearchOutput             `json:"opensearch,omitempty"`
+	RedisOutputConfig            *output.RedisOutputConfig            `json:"redis,omitempty"`
 	RelabelOutputConfig          *output.RelabelOutputConfig          `json:"relabel,omitempty"`
+	S3OutputConfig               *output.S3OutputConfig               `json:"s3,omitempty"`
+	SplunkHecOutput              *output.SplunkHecOutput              `json:"splunkHec,omitempty"`
+	SQSOutputConfig              *output.SQSOutputConfig              `json:"sqs,omitempty"`
+	SumologicOutput              *output.SumologicOutput              `json:"sumologic,omitempty"`
+	SyslogOutputConfig           *output.SyslogOutputConfig           `json:"syslog,omitempty"`
 }
 
 // OutputStatus defines the observed state of Output
@@ -78,18 +78,17 @@ type OutputStatus struct {
 type Output struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   OutputSpec   `json:"spec,omitempty"`
-	Status OutputStatus `json:"status,omitempty"`
+	Spec              OutputSpec   `json:"spec,omitempty"`
+	Status            OutputStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // OutputList contains a list of Output
 type OutputList struct {
+	Items           []Output `json:"items"`
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []Output `json:"items"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/syslogng_clusterflow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_clusterflow_types.go
@@ -38,17 +38,16 @@ type _metaSyslogNGClusterFlow interface{} //nolint:deadcode,unused
 type SyslogNGClusterFlow struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   SyslogNGClusterFlowSpec `json:"spec,omitempty"`
-	Status SyslogNGFlowStatus      `json:"status,omitempty"`
+	Spec              SyslogNGClusterFlowSpec `json:"spec,omitempty"`
+	Status            SyslogNGFlowStatus      `json:"status,omitempty"`
 }
 
 // SyslogNGClusterFlowSpec is the Kubernetes spec for Flows
 type SyslogNGClusterFlowSpec struct {
-	Match            *SyslogNGMatch   `json:"match,omitempty"`
 	Filters          []SyslogNGFilter `json:"filters,omitempty"`
-	LoggingRef       string           `json:"loggingRef,omitempty"`
 	GlobalOutputRefs []string         `json:"globalOutputRefs,omitempty"`
+	LoggingRef       string           `json:"loggingRef,omitempty"`
+	Match            *SyslogNGMatch   `json:"match,omitempty"`
 }
 
 type SyslogNGClusterMatch SyslogNGMatch
@@ -57,9 +56,9 @@ type SyslogNGClusterMatch SyslogNGMatch
 
 // SyslogNGClusterFlowList contains a list of SyslogNGClusterFlow
 type SyslogNGClusterFlowList struct {
+	Items           []SyslogNGClusterFlow `json:"items"`
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []SyslogNGClusterFlow `json:"items"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/syslogng_clusteroutput_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_clusteroutput_types.go
@@ -38,26 +38,25 @@ type _metaSyslogNGClusterOutput interface{} //nolint:deadcode,unused
 type SyslogNGClusterOutput struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   SyslogNGClusterOutputSpec `json:"spec"`
-	Status SyslogNGOutputStatus      `json:"status,omitempty"`
+	Spec              SyslogNGClusterOutputSpec `json:"spec"`
+	Status            SyslogNGOutputStatus      `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:generate=true
 
 // SyslogNGClusterOutputSpec contains Kubernetes spec for SyslogNGClusterOutput
 type SyslogNGClusterOutputSpec struct {
-	SyslogNGOutputSpec `json:",inline"`
 	EnabledNamespaces  []string `json:"enabledNamespaces,omitempty"`
+	SyslogNGOutputSpec `json:",inline"`
 }
 
 // +kubebuilder:object:root=true
 
 // SyslogNGClusterOutputList contains a list of SyslogNGClusterOutput
 type SyslogNGClusterOutputList struct {
+	Items           []SyslogNGClusterOutput `json:"items"`
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []SyslogNGClusterOutput `json:"items"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/syslogng_flow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_flow_types.go
@@ -30,11 +30,11 @@ type _metaSyslogNGFlowSpec interface{} //nolint:deadcode,unused
 
 // SyslogNGFlowSpec is the Kubernetes spec for SyslogNGFlows
 type SyslogNGFlowSpec struct {
-	Match            *SyslogNGMatch   `json:"match,omitempty"`
 	Filters          []SyslogNGFilter `json:"filters,omitempty"`
-	LoggingRef       string           `json:"loggingRef,omitempty"`
 	GlobalOutputRefs []string         `json:"globalOutputRefs,omitempty"`
 	LocalOutputRefs  []string         `json:"localOutputRefs,omitempty"`
+	LoggingRef       string           `json:"loggingRef,omitempty"`
+	Match            *SyslogNGMatch   `json:"match,omitempty"`
 }
 
 type SyslogNGMatch filter.MatchExpr
@@ -65,18 +65,17 @@ type SyslogNGFlowStatus FlowStatus
 type SyslogNGFlow struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Spec   SyslogNGFlowSpec   `json:"spec,omitempty"`
-	Status SyslogNGFlowStatus `json:"status,omitempty"`
+	Spec              SyslogNGFlowSpec   `json:"spec,omitempty"`
+	Status            SyslogNGFlowStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
 // FlowList contains a list of Flow
 type SyslogNGFlowList struct {
+	Items           []SyslogNGFlow `json:"items"`
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []SyslogNGFlow `json:"items"`
 }
 
 func init() {

--- a/pkg/sdk/logging/api/v1beta1/syslogng_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_types.go
@@ -31,22 +31,22 @@ type _metaSyslogNGSpec interface{} //nolint:deadcode,unused
 
 // SyslogNGSpec defines the desired state of SyslogNG
 type SyslogNGSpec struct {
-	TLS                                 SyslogNGTLS                  `json:"tls,omitempty"`
+	BufferVolumeMetrics                 *BufferMetrics               `json:"bufferVolumeMetrics,omitempty"`
+	BufferVolumeMetricsServiceOverrides *typeoverride.Service        `json:"bufferVolumeMetricsService,omitempty"`
+	ConfigCheckPodOverrides             *typeoverride.PodSpec        `json:"configCheckPod,omitempty"`
+	GlobalOptions                       *GlobalOptions               `json:"globalOptions,omitempty"`
+	JSONKeyPrefix                       string                       `json:"jsonKeyPrefix,omitempty"`
+	JSONKeyDelimiter                    string                       `json:"jsonKeyDelim,omitempty"`
+	LogIWSize                           int                          `json:"logIWSize,omitempty"`
+	MaxConnections                      int                          `json:"maxConnections,omitempty"`
+	Metrics                             *Metrics                     `json:"metrics,omitempty"`
+	MetricsServiceOverrides             *typeoverride.Service        `json:"metricsService,omitempty"`
 	ReadinessDefaultCheck               ReadinessDefaultCheck        `json:"readinessDefaultCheck,omitempty"`
 	SkipRBACCreate                      bool                         `json:"skipRBACCreate,omitempty"`
 	StatefulSetOverrides                *typeoverride.StatefulSet    `json:"statefulSet,omitempty"`
 	ServiceOverrides                    *typeoverride.Service        `json:"service,omitempty"`
 	ServiceAccountOverrides             *typeoverride.ServiceAccount `json:"serviceAccount,omitempty"`
-	ConfigCheckPodOverrides             *typeoverride.PodSpec        `json:"configCheckPod,omitempty"`
-	Metrics                             *Metrics                     `json:"metrics,omitempty"`
-	MetricsServiceOverrides             *typeoverride.Service        `json:"metricsService,omitempty"`
-	BufferVolumeMetrics                 *BufferMetrics               `json:"bufferVolumeMetrics,omitempty"`
-	BufferVolumeMetricsServiceOverrides *typeoverride.Service        `json:"bufferVolumeMetricsService,omitempty"`
-	GlobalOptions                       *GlobalOptions               `json:"globalOptions,omitempty"`
-	JSONKeyPrefix                       string                       `json:"jsonKeyPrefix,omitempty"`
-	JSONKeyDelimiter                    string                       `json:"jsonKeyDelim,omitempty"`
-	MaxConnections                      int                          `json:"maxConnections,omitempty"`
-	LogIWSize                           int                          `json:"logIWSize,omitempty"`
+	TLS                                 SyslogNGTLS                  `json:"tls,omitempty"`
 
 	// TODO: option to turn on/off buffer volume PVC
 }
@@ -61,15 +61,15 @@ type SyslogNGTLS struct {
 }
 
 type GlobalOptions struct {
-	// deprecated use stats/level from 4.1+
-	StatsLevel *int `json:"stats_level,omitempty"`
-	// deprecated use stats/freq from 4.1+
-	StatsFreq *int `json:"stats_freq,omitempty"`
 	// TODO switch to this by default
 	Stats *Stats `json:"stats,omitempty"`
+	// deprecated use stats/freq from 4.1+
+	StatsFreq *int `json:"stats_freq,omitempty"`
+	// deprecated use stats/level from 4.1+
+	StatsLevel *int `json:"stats_level,omitempty"`
 }
 
 type Stats struct {
-	Level *int `json:"level,omitempty"`
 	Freq  *int `json:"freq,omitempty"`
+	Level *int `json:"level,omitempty"`
 }


### PR DESCRIPTION
CRD docs are hard to read if values are not orderly. The user need to read the full page to find out configuration options.  
Let's order alphabetically, so same options are together and the full page has a better readable.