### PR TITLE
feat: exclude aggregators logs from fluentbit 

### DIFF
--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -55,6 +55,9 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: r.Logging.GetSyslogNGLabels(ComponentSyslogNG),
+					Annotations: map[string]string{
+						"fluentbit.io/exclude": "true",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: containers,

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -314,8 +314,11 @@ func (l *Logging) SetDefaults() error {
 		}
 		if l.Spec.FluentdSpec.FluentOutLogrotate == nil {
 			l.Spec.FluentdSpec.FluentOutLogrotate = &FluentOutLogrotate{
-				Enabled: true,
+				Enabled: false,
 			}
+		}
+		if _, ok := l.Spec.FluentdSpec.Annotations["fluentbit.io/exclude"]; !ok {
+			l.Spec.FluentdSpec.Annotations["fluentbit.io/exclude"] = "true"
 		}
 		if l.Spec.FluentdSpec.FluentOutLogrotate.Path == "" {
 			l.Spec.FluentdSpec.FluentOutLogrotate.Path = "/fluentd/log/out"


### PR DESCRIPTION
- Send fluentd output to stdout by default.
- Exclude fluentd logs from ingestion by default.
- Exclude syslog-ng logs from ingestion  by default.

Fixes #1076 