### PR TITLE
fix(fluentd): use aggregated metrics with multi workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ test: generate fmt vet manifests ${ENVTEST_BINARY_ASSETS} ${KUBEBUILDER} ## Run 
 
 .PHONY: test-e2e
 test-e2e: ${KIND} generate manifests docker-build stern ## Run E2E tests
-	$(MAKE) test-e2e-nodeps
+	$(MAKE) test-e2e-nodeps E2E_TEST=${E2E_TEST}
 
 .PHONY: test-e2e-ci
 test-e2e-ci: ${BIN}
@@ -164,12 +164,16 @@ test-e2e-ci: ${BIN}
 	chmod +x ./bin/kind
 	curl -L https://github.com/stern/stern/releases/download/v${STERN_VERSION}/stern_${STERN_VERSION}_linux_amd64.tar.gz | tar xz -C bin stern
 	chmod +x ./bin/stern
+	$(MAKE) test-e2e-nodeps E2E_TEST=${E2E_TEST}
+
+.PHONY: test-e2e-nodeps
+test-e2e-nodeps:
 	cd e2e && \
 		LOGGING_OPERATOR_IMAGE="${IMG}" \
 		KIND_PATH="$(KIND)" \
 		KIND_IMAGE="$(KIND_IMAGE)" \
 		PROJECT_DIR="$(PWD)" \
-		go test -v -timeout ${E2E_TEST_TIMEOUT} ./...
+		go test -v -timeout ${E2E_TEST_TIMEOUT} ./${E2E_TEST}/...
 
 .PHONY: tidy
 tidy: ## Tidy Go modules

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -1,0 +1,216 @@
+// Copyright © 2021 Cisco Systems, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentd_aggregator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cisco-open/operator-tools/pkg/utils"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
+
+	"github.com/kube-logging/logging-operator/e2e/common"
+	"github.com/kube-logging/logging-operator/e2e/common/cond"
+	"github.com/kube-logging/logging-operator/e2e/common/setup"
+)
+
+var TestTempDir string
+
+func init() {
+	var ok bool
+	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
+	if !ok {
+		TestTempDir = "../.."
+	}
+	TestTempDir = filepath.Join(TestTempDir, "build/_test")
+	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestFluentdAggregator_MultiWorker(t *testing.T) {
+	common.Initialize(t)
+	ns := "testing-1"
+	releaseNameOverride := "e2e"
+	testTag := "test.fluentd_aggregator_multiworker"
+	outputName := "test-output"
+	flowName := "test-flow"
+	common.WithCluster("fluentd-1", t, func(t *testing.T, c common.Cluster) {
+		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
+			options.Namespace = ns
+			options.NameOverride = releaseNameOverride
+		}))
+
+		ctx := context.Background()
+
+		logging := v1beta1.Logging{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fluentd-aggregator-multiworker-test",
+				Namespace: ns,
+			},
+			Spec: v1beta1.LoggingSpec{
+				EnableRecreateWorkloadOnImmutableFieldChange: true,
+				ControlNamespace: ns,
+				FluentbitSpec: &v1beta1.FluentbitSpec{
+					Network: &v1beta1.FluentbitNetwork{
+						Keepalive: utils.BoolPointer(false),
+					},
+				},
+				FluentdSpec: &v1beta1.FluentdSpec{
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("200M"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("50M"),
+						},
+					},
+					BufferVolumeMetrics: &v1beta1.Metrics{},
+					Scaling: &v1beta1.FluentdScaling{
+						Replicas: 1,
+						Drain: v1beta1.FluentdDrainConfig{
+							Enabled: true,
+						},
+					},
+					Workers: 2,
+				},
+			},
+		}
+		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
+		tags := "time"
+		output := v1beta1.Output{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      outputName,
+				Namespace: ns,
+			},
+			Spec: v1beta1.OutputSpec{
+				HTTPOutput: &output.HTTPOutputConfig{
+					Endpoint:    fmt.Sprintf("http://%s-test-receiver:8080/%s", releaseNameOverride, testTag),
+					ContentType: "application/json",
+					Buffer: &output.Buffer{
+						Type:        "file",
+						Tags:        &tags,
+						Timekey:     "1s",
+						TimekeyWait: "0s",
+					},
+				},
+			},
+		}
+
+		producerLabels := map[string]string{
+			"my-unique-label": "log-producer",
+		}
+
+		common.RequireNoError(t, c.GetClient().Create(ctx, &output))
+		flow := v1beta1.Flow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      flowName,
+				Namespace: ns,
+			},
+			Spec: v1beta1.FlowSpec{
+				Match: []v1beta1.Match{
+					{
+						Select: &v1beta1.Select{
+							Labels: producerLabels,
+						},
+					},
+				},
+				LocalOutputRefs: []string{output.Name},
+			},
+		}
+		common.RequireNoError(t, c.GetClient().Create(ctx, &flow))
+
+		aggregatorLabels := map[string]string{
+			"app.kubernetes.io/name":      "fluentd",
+			"app.kubernetes.io/component": "fluentd",
+		}
+		operatorLabels := map[string]string{
+			"app.kubernetes.io/name": releaseNameOverride,
+		}
+
+		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+			options.Namespace = ns
+			options.Labels = producerLabels
+		}))
+
+		require.Eventually(t, func() bool {
+			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+				t.Log("waiting for the operator")
+				return false
+			}
+			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+				t.Log("waiting for the producer")
+				return false
+			}
+			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+				t.Log("waiting for the aggregator")
+				return false
+			}
+
+			cmd := common.CmdEnv(exec.Command("kubectl",
+				"logs",
+				"-n", ns,
+				"-l", fmt.Sprintf("app.kubernetes.io/name=%s-test-receiver", releaseNameOverride)), c)
+			rawOut, err := cmd.Output()
+			if err != nil {
+				t.Logf("failed to get log consumer logs: %v", err)
+				return false
+			}
+			t.Logf("log consumer logs: %s", rawOut)
+			return strings.Contains(string(rawOut), testTag)
+		}, 5*time.Minute, 3*time.Second)
+
+	}, func(t *testing.T, c common.Cluster) error {
+		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
+		t.Logf("Printing cluster logs to %s", path)
+		return c.PrintLogs(common.PrintLogConfig{
+			Namespaces: []string{ns, "default"},
+			FilePath:   path,
+			Limit:      100 * 1000,
+		})
+	}, func(o *cluster.Options) {
+		if o.Scheme == nil {
+			o.Scheme = runtime.NewScheme()
+		}
+		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
+	})
+}

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -54,7 +54,9 @@ var fluentdInputTemplate = `
 <source>
     @type prometheus
     port {{ .Monitor.Port }}
+{{- if .Monitor.Path }}
     metrics_path {{ .Monitor.Path }}
+{{- end }}
 </source>
 <source>
     @type prometheus_monitor

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -58,6 +58,7 @@ func (r *Reconciler) generateConfigSecret() (map[string][]byte, error) {
 		IgnoreRepeatedLogInterval: r.Logging.Spec.FluentdSpec.IgnoreRepeatedLogInterval,
 		EnableMsgpackTimeSupport:  r.Logging.Spec.FluentdSpec.EnableMsgpackTimeSupport,
 		Workers:                   r.Logging.Spec.FluentdSpec.Workers,
+		LogLevel:                  r.Logging.Spec.FluentdSpec.LogLevel,
 	}
 
 	input.RootDir = r.Logging.Spec.FluentdSpec.RootDir
@@ -69,11 +70,6 @@ func (r *Reconciler) generateConfigSecret() (map[string][]byte, error) {
 		input.Monitor.Enabled = true
 		input.Monitor.Port = r.Logging.Spec.FluentdSpec.Metrics.Port
 		input.Monitor.Path = r.Logging.Spec.FluentdSpec.Metrics.Path
-	}
-
-	input.LogLevel = r.Logging.Spec.FluentdSpec.LogLevel
-	if input.LogLevel == "" {
-		input.LogLevel = "info"
 	}
 
 	inputConfig, err := generateConfig(input)

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -58,6 +58,7 @@ func (r *Reconciler) generateConfigSecret() (map[string][]byte, error) {
 		IgnoreRepeatedLogInterval: r.Logging.Spec.FluentdSpec.IgnoreRepeatedLogInterval,
 		RootDir:                   r.Logging.Spec.FluentdSpec.RootDir,
 		EnableMsgpackTimeSupport:  r.Logging.Spec.FluentdSpec.EnableMsgpackTimeSupport,
+		Workers:                   r.Logging.Spec.FluentdSpec.Workers,
 	}
 
 	if r.Logging.Spec.FluentdSpec.Metrics != nil {
@@ -69,11 +70,6 @@ func (r *Reconciler) generateConfigSecret() (map[string][]byte, error) {
 	input.LogLevel = r.Logging.Spec.FluentdSpec.LogLevel
 	if input.LogLevel == "" {
 		input.LogLevel = "info"
-	}
-
-	input.Workers = r.Logging.Spec.FluentdSpec.Workers
-	if input.Workers <= 0 {
-		input.Workers = 1
 	}
 
 	inputConfig, err := generateConfig(input)

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -56,9 +56,13 @@ func (r *Reconciler) generateConfigSecret() (map[string][]byte, error) {
 	input := fluentdConfig{
 		IgnoreSameLogInterval:     r.Logging.Spec.FluentdSpec.IgnoreSameLogInterval,
 		IgnoreRepeatedLogInterval: r.Logging.Spec.FluentdSpec.IgnoreRepeatedLogInterval,
-		RootDir:                   r.Logging.Spec.FluentdSpec.RootDir,
 		EnableMsgpackTimeSupport:  r.Logging.Spec.FluentdSpec.EnableMsgpackTimeSupport,
 		Workers:                   r.Logging.Spec.FluentdSpec.Workers,
+	}
+
+	input.RootDir = r.Logging.Spec.FluentdSpec.RootDir
+	if input.RootDir == "" {
+		input.RootDir = bufferPath
 	}
 
 	if r.Logging.Spec.FluentdSpec.Metrics != nil {

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -100,7 +100,7 @@ func (r *Reconciler) monitorServiceMetrics() (runtime.Object, reconciler.Desired
 				PodTargetLabels: nil,
 				Endpoints: []v1.Endpoint{{
 					Port:                 "http-metrics",
-					Path:                 r.Logging.Spec.FluentdSpec.Metrics.Path,
+					Path:                 r.Logging.GetFluentdMetricsPath(),
 					Interval:             v1.Duration(r.Logging.Spec.FluentdSpec.Metrics.Interval),
 					ScrapeTimeout:        v1.Duration(r.Logging.Spec.FluentdSpec.Metrics.Timeout),
 					HonorLabels:          r.Logging.Spec.FluentdSpec.Metrics.ServiceMonitorConfig.HonorLabels,

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -186,10 +186,10 @@ func (l *Logging) SetDefaults() error {
 		if l.Spec.FluentdSpec.Security.PodSecurityContext.FSGroup == nil {
 			l.Spec.FluentdSpec.Security.PodSecurityContext.FSGroup = util.IntPointer64(101)
 		}
+		if l.Spec.FluentdSpec.Workers <= 0 {
+			l.Spec.FluentdSpec.Workers = 1
+		}
 		if l.Spec.FluentdSpec.Metrics != nil {
-			if l.Spec.FluentdSpec.Metrics.Path == "" {
-				l.Spec.FluentdSpec.Metrics.Path = "/metrics"
-			}
 			if l.Spec.FluentdSpec.Metrics.Port == 0 {
 				l.Spec.FluentdSpec.Metrics.Port = 24231
 			}
@@ -199,15 +199,12 @@ func (l *Logging) SetDefaults() error {
 			if l.Spec.FluentdSpec.Metrics.Interval == "" {
 				l.Spec.FluentdSpec.Metrics.Interval = "15s"
 			}
-
 			if l.Spec.FluentdSpec.Metrics.PrometheusAnnotations {
 				l.Spec.FluentdSpec.Annotations["prometheus.io/scrape"] = "true"
-
-				l.Spec.FluentdSpec.Annotations["prometheus.io/path"] = l.Spec.FluentdSpec.Metrics.Path
+				l.Spec.FluentdSpec.Annotations["prometheus.io/path"] = l.GetFluentdMetricsPath()
 				l.Spec.FluentdSpec.Annotations["prometheus.io/port"] = fmt.Sprintf("%d", l.Spec.FluentdSpec.Metrics.Port)
 			}
 		}
-
 		if !l.Spec.FluentdSpec.DisablePvc {
 			if l.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim == nil {
 				l.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim = &volume.PersistentVolumeClaim{
@@ -675,4 +672,16 @@ func (l *Logging) GetSyslogNGLabels(component string) map[string]string {
 
 func GenerateLoggingRefLabels(loggingRef string) map[string]string {
 	return map[string]string{"app.kubernetes.io/managed-by": loggingRef}
+}
+
+// GetFluentdMetricsPath returns the right Fluentd metrics endpoint
+// depending on the number of workers and the user configuration
+func (l *Logging) GetFluentdMetricsPath() string {
+	if l.Spec.FluentdSpec.Metrics.Path == "" {
+		if l.Spec.FluentdSpec.Workers > 1 {
+			return "/aggregated_metrics"
+		}
+		return "/metrics"
+	}
+	return l.Spec.FluentdSpec.Metrics.Path
 }

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -205,6 +205,9 @@ func (l *Logging) SetDefaults() error {
 				l.Spec.FluentdSpec.Annotations["prometheus.io/port"] = fmt.Sprintf("%d", l.Spec.FluentdSpec.Metrics.Port)
 			}
 		}
+		if l.Spec.FluentdSpec.LogLevel == "" {
+			l.Spec.FluentdSpec.LogLevel = "info"
+		}
 		if !l.Spec.FluentdSpec.DisablePvc {
 			if l.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim == nil {
 				l.Spec.FluentdSpec.BufferStorageVolume.PersistentVolumeClaim = &volume.PersistentVolumeClaim{


### PR DESCRIPTION
Select `/aggregated_metrics` Fluentd metrics endpoint by default when multi worker is enabled.
Add E2E test that checks if multi worker is enabled and the two workers correctly get logs.

Tested:
- explicitly setting metrics.path to `/metrics` changes servicemonitor and prom annotation to point to `/metrics` independently of the worker count
- if metrics.path is not set and workers = 1, servicemonitor and prom annotations point to `/metrics`
- if metrics.path is not set and workers > 1, servicemonitor and prom annotations point to `/aggregated_metrics`

Fixes #1110 
