### PR TITLE
feat(aggregators): enable bufferVolumeMetrics custom metrics

### DIFF
--- a/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
+++ b/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
@@ -106,11 +106,31 @@ func TestSyslogNGIsRunningAndForwardingLogs(t *testing.T) {
 													corev1.ResourceMemory: resource.MustParse("10M"),
 												},
 											},
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name: "buffers",
+													MountPath: "/buffers",
+												},
+											},
+										},
+									},
+									Volumes: []corev1.Volume{
+										{
+											Name: "buffers",
+											VolumeSource: corev1.VolumeSource{
+												EmptyDir: &corev1.EmptyDirVolumeSource{},
+											},
 										},
 									},
 								},
 							},
 						},
+					},
+					BufferVolumeMetrics: &v1beta1.BufferMetrics{
+						Metrics: v1beta1.Metrics{
+							Interval: "1s",
+						},
+						MountName: "buffers",
 					},
 				},
 			},

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -38,9 +38,6 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 		syslogNGContainer(r.Logging.Spec.SyslogNGSpec),
 		configReloadContainer(r.Logging.Spec.SyslogNGSpec),
 	}
-	if c := r.bufferMetricsSidecarContainer(); c != nil {
-		containers = append(containers, *c)
-	}
 	if c := r.syslogNGMetricsSidecarContainer(); c != nil {
 		containers = append(containers, *c)
 	}
@@ -85,11 +82,16 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 			buffersVolumeName = name
 		}
 	}
+
 	syslogngContainer := kubetool.FindContainerByName(desired.Spec.Template.Spec.Containers, ContainerName)
 	if mnt := kubetool.FindVolumeMountByName(syslogngContainer.VolumeMounts, buffersVolumeName); mnt != nil {
 		if !sliceAny(syslogngContainer.Args, func(arg string) bool { return strings.Contains(arg, "--persist-file") }) {
 			syslogngContainer.Args = append(syslogngContainer.Args,
 				"--persist-file", filepath.Join(mnt.MountPath, "/syslog-ng.persist"))
+		}
+
+		if c := r.bufferMetricsSidecarContainer(); c != nil {
+			desired.Spec.Template.Spec.Containers = append(desired.Spec.Template.Spec.Containers, *c)
 		}
 	}
 
@@ -260,15 +262,27 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 			port = r.Logging.Spec.SyslogNGSpec.BufferVolumeMetrics.Port
 		}
 		portParam := fmt.Sprintf("--web.listen-address=:%d", port)
-		args := []string{portParam, "--collector.disable-defaults", "--collector.filesystem"}
+		args := []string{portParam, "--collector.disable-defaults", "--collector.filesystem", "--collector.textfile", "--collector.textfile.directory=/prometheus/node_exporter/textfile_collector/"}
 
-		customRunner := fmt.Sprintf("./bin/node_exporter %v", strings.Join(args, " "))
+		nodeExporterCmd := fmt.Sprintf("nodeexporter -> ./bin/node_exporter %v", strings.Join(args, " "))
+		bufferSizeCmd := "buffersize -> /prometheus/buffer-size.sh"
+
 		return &corev1.Container{
 			Name:            "buffer-metrics-sidecar",
 			Image:           v1beta1.RepositoryWithTag(bufferVolumeImageRepository, bufferVolumeImageTag),
 			ImagePullPolicy: corev1.PullIfNotPresent,
-			Args:            []string{"--port", "7358", "--startup", customRunner},
-			Ports:           generatePortsBufferVolumeMetrics(r.Logging.Spec.SyslogNGSpec),
+			Args: []string{
+				"--port", "7358",
+				"--exec", nodeExporterCmd,
+				"--exec", bufferSizeCmd,
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "BUFFER_PATH",
+					Value: BufferPath,
+				},
+			},
+			Ports: generatePortsBufferVolumeMetrics(r.Logging.Spec.SyslogNGSpec),
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      r.Logging.Spec.SyslogNGSpec.BufferVolumeMetrics.MountName,


### PR DESCRIPTION
- Enable buffer volume metrics buffer-size.sh custom metrics retrieval to ease access to buffer size and file count.
- Update syslog-ng e2e tests to configure an emptydir buffer volume and enable buffer metrics

Depends on https://github.com/kube-logging/logging-operator/pull/1423