### PR TITLE
deps: update node-exporter image version to v0.7.1

### DIFF
--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -57,7 +57,7 @@ const (
 	prometheusExporterImageRepository = "ghcr.io/kube-logging/syslog-ng-exporter"
 	prometheusExporterImageTag        = "v0.0.16"
 	bufferVolumeImageRepository       = "ghcr.io/kube-logging/node-exporter"
-	bufferVolumeImageTag              = "v0.6.1"
+	bufferVolumeImageTag              = "v0.7.1"
 	configReloaderImageRepository     = "ghcr.io/kube-logging/syslogng-reload"
 	configReloaderImageTag            = "v1.3.1"
 	socketVolumeName                  = "socket"

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -130,7 +130,7 @@ const (
 	DefaultFluentbitImageRepository             = "fluent/fluent-bit"
 	DefaultFluentbitImageTag                    = "2.1.4"
 	DefaultFluentbitBufferVolumeImageRepository = "ghcr.io/kube-logging/node-exporter"
-	DefaultFluentbitBufferVolumeImageTag        = "v0.6.1"
+	DefaultFluentbitBufferVolumeImageTag        = "v0.7.1"
 	DefaultFluentbitBufferStorageVolumeName     = "fluentbit-buffer"
 	DefaultFluentdImageRepository               = "ghcr.io/kube-logging/fluentd"
 	DefaultFluentdImageTag                      = "v1.15-ruby3"
@@ -144,7 +144,7 @@ const (
 	DefaultFluentdConfigReloaderImageRepository = "ghcr.io/kube-logging/config-reloader"
 	DefaultFluentdConfigReloaderImageTag        = "v0.0.5"
 	DefaultFluentdBufferVolumeImageRepository   = "ghcr.io/kube-logging/node-exporter"
-	DefaultFluentdBufferVolumeImageTag          = "v0.6.1"
+	DefaultFluentdBufferVolumeImageTag          = "v0.7.1"
 )
 
 // SetDefaults fills empty attributes


### PR DESCRIPTION
Bump node-exporter image to https://github.com/kube-logging/node-exporter-image/releases/tag/v0.7.1


Before

```
# HELP node_buffer_size_bytes Disk space used
# TYPE node_buffer_size_bytes gauge
node_buffer_size_bytes{entity="/buffers"} 1.7847494e+07
node_buffer_size_bytes{entity="/buffers/lost+found"} 16384
node_buffer_size_bytes{entity="/buffers/tail.0"} 1.7827014e+07
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.546730320.flb"} 1.150976e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.550201690.flb"} 1.773568e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.555055389.flb"} 1.871872e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.564564982.flb"} 1.675264e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.571656826.flb"} 2.073798e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.578683569.flb"} 2.101248e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.593550872.flb"} 1.675264e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.600669016.flb"} 1.478656e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.608903184.flb"} 1.871872e+06
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.615029808.flb"} 856064
node_buffer_size_bytes{entity="/buffers/tail.0/1-1691495292.625939630.flb"} 1.24928e+06

```

After

```
# HELP logging_buffer_files File count
# TYPE logging_buffer_files gauge
logging_buffer_files{entity="/buffers",host="my-super-host-1"} 27
# HELP logging_buffer_size_bytes Disk space used
# TYPE logging_buffer_size_bytes gauge
logging_buffer_size_bytes{entity="/buffers",host="my-super-host-1"} 1.7847494e+07
# HELP node_buffer_size_bytes Disk space used [deprecated]
# TYPE node_buffer_size_bytes gauge
node_buffer_size_bytes{entity="/buffers"} 1.7847494e+07
```
