### PR TITLE
fix: rerun failed configcheck if there is no configcheck pod

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -61,6 +61,18 @@ func (r *Reconciler) configHash() (string, error) {
 	return fmt.Sprintf("%x", hasher.Sum32()), nil
 }
 
+func (r *Reconciler) hasConfigCheckPod(ctx context.Context, hashKey string) (bool, error) {
+	var err error
+	pod := r.newCheckPod(hashKey)
+
+	p := &corev1.Pod{}
+	err = r.Client.Get(ctx, client.ObjectKeyFromObject(pod), p)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error) {
 	hashKey, err := r.configHash()
 	if err != nil {

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -138,7 +138,11 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 
 		// Fail when the current config is invalid
 		if result, ok := r.Logging.Status.ConfigCheckResults[hash]; ok && !result {
-			return nil, errors.Errorf("current config is invalid")
+			if hasPod, err := r.hasConfigCheckPod(ctx, hash); hasPod {
+				return nil, errors.WrapIf(err, "current config is invalid")
+			}
+			// clean the status so that we can rerun the check
+			return r.statusUpdate(ctx, patchBase, nil)
 		}
 
 		if result, ok := r.Logging.Status.ConfigCheckResults[hash]; ok {
@@ -152,16 +156,9 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 				// Errors with the cleanup should not block the reconciliation, we just note it
 				r.Log.Error(err, "issues during configcheck cleanup, moving on")
 			} else if len(r.Logging.Status.ConfigCheckResults) > 1 {
-				//
-				r.Logging.Status.ConfigCheckResults = map[string]bool{
+				return r.statusUpdate(ctx, patchBase, map[string]bool{
 					hash: result,
-				}
-				if err := r.Client.Status().Patch(ctx, r.Logging, patchBase); err != nil {
-					return nil, errors.WrapWithDetails(err, "failed to patch status", "logging", r.Logging)
-				} else {
-					// explicitly ask for a requeue to short circuit the controller loop after the status update
-					return &reconcile.Result{Requeue: true}, nil
-				}
+				})
 			}
 		} else {
 			// We don't have an existing result
@@ -253,6 +250,16 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 	}
 
 	return nil, nil
+}
+
+func (r *Reconciler) statusUpdate(ctx context.Context, patchBase client.Patch, result map[string]bool) (*reconcile.Result, error) {
+	r.Logging.Status.ConfigCheckResults = result
+	if err := r.Client.Status().Patch(ctx, r.Logging, patchBase); err != nil {
+		return nil, errors.WrapWithDetails(err, "failed to patch status", "logging", r.Logging)
+	} else {
+		// explicitly ask for a requeue to short circuit the controller loop after the status update
+		return &reconcile.Result{Requeue: true}, nil
+	}
 }
 
 func (r *Reconciler) reconcileDrain(ctx context.Context) (*reconcile.Result, error) {

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -136,7 +136,11 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 
 		// Fail when the current config is invalid
 		if result, ok := r.Logging.Status.ConfigCheckResults[hash]; ok && !result {
-			return nil, errors.Errorf("current config is invalid")
+			if hasPod, err := r.hasConfigCheckPod(ctx, hash); hasPod {
+				return nil, errors.WrapIf(err, "current config is invalid")
+			}
+			// clean the status so that we can rerun the check
+			return r.statusUpdate(ctx, patchBase, nil)
 		}
 
 		// Cleanup previous configcheck results
@@ -151,16 +155,9 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 				// Errors with the cleanup should not block the reconciliation, we just note it
 				r.Log.Error(err, "issues during configcheck cleanup, moving on")
 			} else if len(r.Logging.Status.ConfigCheckResults) > 1 {
-				//
-				r.Logging.Status.ConfigCheckResults = map[string]bool{
+				return r.statusUpdate(ctx, patchBase, map[string]bool{
 					hash: result,
-				}
-				if err := r.Client.Status().Patch(ctx, r.Logging, patchBase); err != nil {
-					return nil, errors.WrapWithDetails(err, "failed to patch status", "logging", r.Logging)
-				} else {
-					// explicitly ask for a requeue to short circuit the controller loop after the status update
-					return &reconcile.Result{Requeue: true}, nil
-				}
+				})
 			}
 		} else {
 			// We don't have an existing result
@@ -246,6 +243,31 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 	}
 
 	return nil, nil
+}
+
+func (r *Reconciler) hasConfigCheckPod(ctx context.Context, hashKey string) (bool, error) {
+	var err error
+	pod, err := r.newCheckPod(hashKey)
+	if err != nil {
+		return false, err
+	}
+
+	p := &corev1.Pod{}
+	err = r.Client.Get(ctx, client.ObjectKeyFromObject(pod), p)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *Reconciler) statusUpdate(ctx context.Context, patchBase client.Patch, result map[string]bool) (*reconcile.Result, error) {
+	r.Logging.Status.ConfigCheckResults = result
+	if err := r.Client.Status().Patch(ctx, r.Logging, patchBase); err != nil {
+		return nil, errors.WrapWithDetails(err, "failed to patch status", "logging", r.Logging)
+	} else {
+		// explicitly ask for a requeue to short circuit the controller loop after the status update
+		return &reconcile.Result{Requeue: true}, nil
+	}
 }
 
 func (r *Reconciler) getServiceAccountName() string {


### PR DESCRIPTION
This should help us in a situation where the configcheck pod failed, but we expect to succeed the second time (with the same hash).

This might sound suprising first, but to be able to leverage other configcheck strategies like https://github.com/kube-logging/logging-operator/pull/1407 this is going to be useful.

Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>
