### PR TITLE
chore: reduce fluentd drainer check interval

### DIFF
--- a/pkg/resources/fluentd/drainjob.go
+++ b/pkg/resources/fluentd/drainjob.go
@@ -17,10 +17,11 @@ package fluentd
 import (
 	"strings"
 
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
 func (r *Reconciler) drainerJobFor(pvc corev1.PersistentVolumeClaim) (*batchv1.Job, error) {
@@ -97,6 +98,10 @@ func drainWatchContainer(cfg *v1beta1.FluentdDrainConfig, bufferVolumeName strin
 			{
 				Name:  "BUFFER_PATH",
 				Value: bufferPath,
+			},
+			{
+				Name:  "CHECK_INTERVAL",
+				Value: drainerCheckInterval,
 			},
 		},
 		Image:           cfg.Image.RepositoryWithTag(),

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -62,6 +62,7 @@ const (
 	clusterRoleName                = "fluentd"
 	containerName                  = "fluentd"
 	defaultBufferVolumeMetricsPort = 9200
+	drainerCheckInterval           = "10"
 )
 
 // Reconciler holds info what resource to reconcile


### PR DESCRIPTION
The check interval in the image is 60 (seconds), this can make the draining process significantly faster.

Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>
