### PR TITLE
fix(configcheck): wait for secrets to be available

### DIFF
--- a/pkg/resources/syslogng/configcheck.go
+++ b/pkg/resources/syslogng/configcheck.go
@@ -48,6 +48,21 @@ func (r *Reconciler) configHash() (string, error) {
 	return fmt.Sprintf("%x", hasher.Sum32()), nil
 }
 
+func (r *Reconciler) CheckForObjectExistence(ctx context.Context, object client.Object) (*ConfigCheckResult, error) {
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(object), object); err != nil {
+		if apierrors.IsNotFound(err) {
+			objNotFoundMsg := fmt.Sprintf("object %s (kind: secret) in namespace %s not found", object.GetName(), object.GetNamespace())
+			r.Log.Info(objNotFoundMsg)
+			err = nil
+		}
+		errMsg := fmt.Sprintf("object %s (kind: secret) in namespace %s is not available", object.GetName(), object.GetNamespace())
+		return &ConfigCheckResult{
+			Ready: false, Valid: false, Message: errMsg,
+		}, err
+	}
+	return nil, nil
+}
+
 func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error) {
 	hashKey, err := r.configHash()
 	if err != nil {
@@ -63,6 +78,9 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, errors.WrapIf(err, "failed to create secret for syslog-ng configcheck")
 	}
+	if res, err := r.CheckForObjectExistence(ctx, checkSecret); res != nil {
+		return res, errors.WrapIf(err, "failed to find secret for syslog-ng configcheck")
+	}
 
 	checkOutputSecret, err := r.newCheckOutputSecret(hashKey)
 	if err != nil {
@@ -72,6 +90,9 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	err = r.Client.Create(ctx, checkOutputSecret)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return nil, errors.WrapIf(err, "failed to create output secret for syslog-ng configcheck")
+	}
+	if res, err := r.CheckForObjectExistence(ctx, checkSecret); res != nil {
+		return res, errors.WrapIf(err, "failed to find output secret for syslog-ng configcheck")
 	}
 
 	pod, err := r.newCheckPod(hashKey)


### PR DESCRIPTION
This PR aims to delay the configcheck pod creation until secrets are available.

Fixes #1406.