### PR TITLE
chore: global generate makefile rule

### DIFF
--- a/config/samples/mulitenant-hard/README.md
+++ b/config/samples/mulitenant-hard/README.md
@@ -6,7 +6,7 @@ minikube start --nodes=2
 kubectl label node minikube tenant=tenant-a
 kubectl label node minikube-m02 tenant=tenant-b
 
-make generate manifests install
+make codegen manifests install
 kubectl apply -f config/samples/multitenant-hard/logging
 
 helm upgrade --install --namespace a --create-namespace --set "nodeSelector.tenant=tenant-a" log-generator oci://ghcr.io/kube-logging/helm-charts/log-generator


### PR DESCRIPTION
Rename the `generate` makefile rule to `codegen`
Add a new `generate` rule that runs `codegen fmt manifests docs helm-docs`
`check-diff` rule now calls `generate`