### PR TITLE
GHA: fix OCI description, add extra OCI labels

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -82,6 +82,12 @@ jobs:
             type=ref,event=pr,prefix=pr-
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.description=The Logging operator solves your logging-related problems in Kubernetes environments by automating the deployment and configuration of a Kubernetes logging pipeline.
+            org.opencontainers.image.title=Logging operator
+            org.opencontainers.image.authors=Kube logging authors
+            org.opencontainers.image.documentation=https://kube-logging.dev/docs/
+
 
       # Multiple exporters are not supported yet
       # See https://github.com/moby/buildkit/pull/2760
@@ -111,7 +117,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: ${{ steps.build-output.outputs.value }}
+          outputs: ${{ steps.build-output.outputs.value }},name=target,annotation-index.org.opencontainers.image.description=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }}
           # push: ${{ inputs.publish }}
 
       - name: Set image ref

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,5 @@
 FROM --platform=$BUILDPLATFORM golang:1.20-alpine3.18@sha256:7839c9f01b5502d7cb5198b2c032857023424470b3e31ae46a8261ffca72912a AS builder
 
-# https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.title="Logging operator"
-LABEL org.opencontainers.image.description="The Logging operator solves your logging-related problems in Kubernetes environments by automating the deployment and configuration of a Kubernetes logging pipeline."
-LABEL org.opencontainers.image.authors="Kube logging authors"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
-LABEL org.opencontainers.image.source="https://github.com/kube-logging/logging-operator"
-LABEL org.opencontainers.image.documentation="https://kube-logging.dev/docs/"
-LABEL org.opencontainers.image.url="https://kube-logging.dev/"
-
 RUN apk add --update --no-cache ca-certificates make git curl
 
 ARG TARGETOS


### PR DESCRIPTION
~In PR https://github.com/kube-logging/logging-operator/pull/1506 the OCI labels should have been just after the last `FROM` command, because currently it shows 0 labels.~

~I am not sure why the added tags are not seen on ghcr.io, will test this version and get back to you whether it is shown or not.~

EDIT: Checked the labels added by GHA `meta` step and added some values. Also fixed the missing description on ghcr.io.
See my fork's page: https://github.com/overorion/logging-operator/pkgs/container/logging-operator/134955502?tag=4.4.2

The problem was in fact the multi-arch image, the docs were really helpful:
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images 