### PR TITLE
Support read only root file system use case in fluentd

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -921,8 +921,6 @@ github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
-github.com/cisco-open/operator-tools v0.32.0 h1:CGBCnfQNIq1SUo5Cfabk/NFugNx3X5HerxDVNpHoEvQ=
-github.com/cisco-open/operator-tools v0.32.0/go.mod h1:dknM0Is0/QUaslpzNbtQvlJPfboVXAmCjRgLJpAfcsI=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -1048,6 +1046,7 @@ github.com/containerd/nri v0.3.0 h1:2ZM4WImye1ypSnE7COjOvPAiLv84kaPILBDvb1tbDK8=
 github.com/containerd/nri v0.3.0/go.mod h1:Zw9q2lP16sdg0zYybemZ9yTDy8g7fPCIB3KXOGlggXI=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/stargz-snapshotter/estargz v0.12.1/go.mod h1:12VUuCq3qPq4y8yUW+l5w3+oXV3cx2Po3KSe/SmPGqw=
+github.com/containerd/stargz-snapshotter/estargz v0.14.3/go.mod h1:KY//uOCIkSuNAHhJogcZtrNHdKrA99/FCCRjE3HD36o=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=

--- a/pkg/resources/fluentd/drainjob.go
+++ b/pkg/resources/fluentd/drainjob.go
@@ -44,6 +44,9 @@ func (r *Reconciler) drainerJobFor(pvc corev1.PersistentVolumeClaim) (*batchv1.J
 	if i := generateInitContainer(r.Logging.Spec.FluentdSpec); i != nil {
 		initContainers = append(initContainers, *i)
 	}
+	if c := r.tmpDirHackContainer(); c != nil {
+		initContainers = append(initContainers, *c)
+	}
 
 	spec := batchv1.JobSpec{
 		Template: corev1.PodTemplateSpec{

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -374,17 +374,7 @@ func (r *Reconciler) tmpDirHackContainer() *corev1.Container {
 		ImagePullPolicy: corev1.PullPolicy(r.Logging.Spec.FluentdSpec.Image.PullPolicy),
 		Name:            "tmp-dir-hack",
 		Resources:       r.Logging.Spec.FluentdSpec.Resources,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:                r.Logging.Spec.FluentdSpec.Security.SecurityContext.RunAsUser,
-			RunAsGroup:               r.Logging.Spec.FluentdSpec.Security.SecurityContext.RunAsGroup,
-			ReadOnlyRootFilesystem:   r.Logging.Spec.FluentdSpec.Security.SecurityContext.ReadOnlyRootFilesystem,
-			AllowPrivilegeEscalation: r.Logging.Spec.FluentdSpec.Security.SecurityContext.AllowPrivilegeEscalation,
-			Privileged:               r.Logging.Spec.FluentdSpec.Security.SecurityContext.Privileged,
-			RunAsNonRoot:             r.Logging.Spec.FluentdSpec.Security.SecurityContext.RunAsNonRoot,
-			SELinuxOptions:           r.Logging.Spec.FluentdSpec.Security.SecurityContext.SELinuxOptions,
-			SeccompProfile:           r.Logging.Spec.FluentdSpec.Security.SecurityContext.SeccompProfile,
-			Capabilities:             r.Logging.Spec.FluentdSpec.Security.SecurityContext.Capabilities,
-		},
+		SecurityContext: r.Logging.Spec.FluentdSpec.Security.SecurityContext,
 		VolumeMounts: generateVolumeMounts(r.Logging.Spec.FluentdSpec),
 	}
 }

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -75,7 +75,7 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 func (r *Reconciler) statefulsetSpec() *appsv1.StatefulSetSpec {
 	var initContainers []corev1.Container
 
-	initContainers = append(initContainers)
+	initContainers = append(initContainers, *r.tmpDirHackContainer())
 
 	if c := r.volumeMountHackContainer(); c != nil {
 		initContainers = append(initContainers, *c)
@@ -375,7 +375,7 @@ func (r *Reconciler) tmpDirHackContainer() *corev1.Container {
 		Name:            "tmp-dir-hack",
 		Resources:       r.Logging.Spec.FluentdSpec.Resources,
 		SecurityContext: r.Logging.Spec.FluentdSpec.Security.SecurityContext,
-		VolumeMounts: generateVolumeMounts(r.Logging.Spec.FluentdSpec),
+		VolumeMounts:    generateVolumeMounts(r.Logging.Spec.FluentdSpec),
 	}
 }
 

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -385,9 +385,8 @@ func (r *Reconciler) tmpDirHackContainer() *corev1.Container {
 			SeccompProfile:           r.Logging.Spec.FluentdSpec.Security.SecurityContext.SeccompProfile,
 			Capabilities:             r.Logging.Spec.FluentdSpec.Security.SecurityContext.Capabilities,
 		},
-		VolumeMounts:    generateVolumeMounts(r.Logging.Spec.FluentdSpec),
+		VolumeMounts: generateVolumeMounts(r.Logging.Spec.FluentdSpec),
 	}
-	return nil
 }
 
 func (r *Reconciler) volumeMountHackContainer() *corev1.Container {

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -74,9 +74,9 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 
 func (r *Reconciler) statefulsetSpec() *appsv1.StatefulSetSpec {
 	var initContainers []corev1.Container
-	if c := r.tmpDirHackContainer(); c != nil {
-		initContainers = append(initContainers, *c)
-	}
+
+	initContainers = append(initContainers)
+
 	if c := r.volumeMountHackContainer(); c != nil {
 		initContainers = append(initContainers, *c)
 	}

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -144,20 +144,10 @@ func fluentContainer(spec *v1beta1.FluentdSpec) corev1.Container {
 		Ports:           generatePorts(spec),
 		VolumeMounts:    generateVolumeMounts(spec),
 		Resources:       spec.Resources,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:                spec.Security.SecurityContext.RunAsUser,
-			RunAsGroup:               spec.Security.SecurityContext.RunAsGroup,
-			ReadOnlyRootFilesystem:   spec.Security.SecurityContext.ReadOnlyRootFilesystem,
-			AllowPrivilegeEscalation: spec.Security.SecurityContext.AllowPrivilegeEscalation,
-			Privileged:               spec.Security.SecurityContext.Privileged,
-			RunAsNonRoot:             spec.Security.SecurityContext.RunAsNonRoot,
-			SELinuxOptions:           spec.Security.SecurityContext.SELinuxOptions,
-			SeccompProfile:           spec.Security.SecurityContext.SeccompProfile,
-			Capabilities:             spec.Security.SecurityContext.Capabilities,
-		},
-		Env:            envVars,
-		LivenessProbe:  spec.LivenessProbe,
-		ReadinessProbe: generateReadinessCheck(spec),
+		SecurityContext: spec.Security.SecurityContext,
+		Env:             envVars,
+		LivenessProbe:   spec.LivenessProbe,
+		ReadinessProbe:  generateReadinessCheck(spec),
 	}
 
 	if spec.FluentOutLogrotate != nil && spec.FluentOutLogrotate.Enabled {


### PR DESCRIPTION
Fluentd expects the `/tmp` directory to be writable even if the root file system is mounted as read only. This PR adds a writeable empty dir volume to the fluentd container mounted as `/tmp` as a workaround.

For more details see the linked issue.
fix: #1517 
