### PR TITLE
fix(reconciler): make sure to not update the original object

### DIFF
--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -277,7 +277,8 @@ func NewValidationReconciler(
 				continue
 			}
 
-			if err := repo.Status().Patch(ctx, req.Obj, req.Patch); err != nil {
+			obj := req.Obj.DeepCopyObject().(client.Object) // copy object so that the original is not changed by the call to Patch
+			if err := repo.Status().Patch(ctx, obj, req.Patch); err != nil {
 				errs = errors.Append(errs, err)
 			}
 		}


### PR DESCRIPTION
If the original object contains a pointer, then without this patch that pointer will (inadvertently) change.

This is required for the detached fluentd use case.