### PR TITLE
Feat: add json format for fluentd output

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -1515,6 +1515,8 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              logFormat:
+                type: string
               logLevel:
                 type: string
               metrics:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -4808,6 +4808,8 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  logFormat:
+                    type: string
                   logLevel:
                     type: string
                   metrics:

--- a/config/crd/bases/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -1515,6 +1515,8 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              logFormat:
+                type: string
               logLevel:
                 type: string
               metrics:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -4808,6 +4808,8 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  logFormat:
+                    type: string
                   logLevel:
                     type: string
                   metrics:

--- a/config/samples/archive/logging_v1alpha2_logging_debug.yaml
+++ b/config/samples/archive/logging_v1alpha2_logging_debug.yaml
@@ -4,6 +4,7 @@ metadata:
   name: defaultlogging
 spec:
   fluentd:
+    logFormat: text
     logLevel: debug
     disablePvc: true
   fluentbit:

--- a/docs/configuration/crds/v1beta1/fluentd_types.md
+++ b/docs/configuration/crds/v1beta1/fluentd_types.md
@@ -109,9 +109,8 @@ Ignore same log lines [more info]( https://docs.fluentd.org/deployment/logging#i
 
 ### logFormat (string, optional) {#fluentdspec-logformat}
 
-Set the logging format. Allowed values are: text and json. Default: text 
+Set the logging format. Allowed values are: "text" (default) and "json". 
 
-Default: text
 
 ### logLevel (string, optional) {#fluentdspec-loglevel}
 

--- a/docs/configuration/crds/v1beta1/fluentd_types.md
+++ b/docs/configuration/crds/v1beta1/fluentd_types.md
@@ -107,6 +107,12 @@ Ignore same log lines [more info]( https://docs.fluentd.org/deployment/logging#i
 ### livenessProbe (*corev1.Probe, optional) {#fluentdspec-livenessprobe}
 
 
+### logFormat (string, optional) {#fluentdspec-logformat}
+
+Set the logging format. Allowed values are: text and json. Default: text 
+
+Default: text
+
 ### logLevel (string, optional) {#fluentdspec-loglevel}
 
 

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -33,6 +33,7 @@ var fluentdInputTemplate = `
 # Enable RPC endpoint (this allows to trigger config reload without restart)
 <system>
   rpc_endpoint 127.0.0.1:24444
+  format {{ .LogFormat }}
   log_level {{ .LogLevel }}
   workers {{ .Workers }}
 {{- if .RootDir }}

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -33,7 +33,9 @@ var fluentdInputTemplate = `
 # Enable RPC endpoint (this allows to trigger config reload without restart)
 <system>
   rpc_endpoint 127.0.0.1:24444
+  {{- if .LogFormat }}
   format {{ .LogFormat }}
+  {{- end }}
   log_level {{ .LogLevel }}
   workers {{ .Workers }}
 {{- if .RootDir }}

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -27,8 +27,9 @@ import (
 )
 
 type fluentdConfig struct {
-	LogLevel string
-	Monitor  struct {
+	LogFormat string
+	LogLevel  string
+	Monitor   struct {
 		Enabled bool
 		Port    int32
 		Path    string
@@ -59,6 +60,7 @@ func (r *Reconciler) generateConfigSecret(fluentdSpec v1beta1.FluentdSpec) (map[
 		IgnoreRepeatedLogInterval: fluentdSpec.IgnoreRepeatedLogInterval,
 		EnableMsgpackTimeSupport:  fluentdSpec.EnableMsgpackTimeSupport,
 		Workers:                   fluentdSpec.Workers,
+		LogFormat:                 fluentdSpec.LogFormat,
 		LogLevel:                  fluentdSpec.LogLevel,
 	}
 

--- a/pkg/sdk/logging/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_types.go
@@ -84,10 +84,9 @@ type FluentdSpec struct {
 	Scaling                   *FluentdScaling                   `json:"scaling,omitempty"`
 	Workers                   int32                             `json:"workers,omitempty"`
 	RootDir                   string                            `json:"rootDir,omitempty"`
-	// Set the logging format. Allowed values are: text and json.
-	// Default: text
+	// Set the logging format. Allowed values are: "text" (default) and "json".
 	// +kubebuilder:validation:enum=json,text
-	LogFormat string `json:"logFormat,omitempty" plugin:"default:text"`
+	LogFormat string `json:"logFormat,omitempty"`
 	// +kubebuilder:validation:enum=fatal,error,warn,info,debug,trace
 	LogLevel string `json:"logLevel,omitempty"`
 	// Ignore same log lines
@@ -187,9 +186,6 @@ func (f *FluentdSpec) SetDefaults() error {
 				f.Annotations["prometheus.io/path"] = f.GetFluentdMetricsPath()
 				f.Annotations["prometheus.io/port"] = fmt.Sprintf("%d", f.Metrics.Port)
 			}
-		}
-		if f.LogFormat == "" {
-			f.LogFormat = "text"
 		}
 		if f.LogLevel == "" {
 			f.LogLevel = "info"

--- a/pkg/sdk/logging/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_types.go
@@ -84,6 +84,10 @@ type FluentdSpec struct {
 	Scaling                   *FluentdScaling                   `json:"scaling,omitempty"`
 	Workers                   int32                             `json:"workers,omitempty"`
 	RootDir                   string                            `json:"rootDir,omitempty"`
+	// Set the logging format. Allowed values are: text and json.
+	// Default: text
+	// +kubebuilder:validation:enum=json,text
+	LogFormat string `json:"logFormat,omitempty" plugin:"default:text"`
 	// +kubebuilder:validation:enum=fatal,error,warn,info,debug,trace
 	LogLevel string `json:"logLevel,omitempty"`
 	// Ignore same log lines
@@ -183,6 +187,9 @@ func (f *FluentdSpec) SetDefaults() error {
 				f.Annotations["prometheus.io/path"] = f.GetFluentdMetricsPath()
 				f.Annotations["prometheus.io/port"] = fmt.Sprintf("%d", f.Metrics.Port)
 			}
+		}
+		if f.LogFormat == "" {
+			f.LogFormat = "text"
 		}
 		if f.LogLevel == "" {
 			f.LogLevel = "info"


### PR DESCRIPTION
This change adds a feature to set FluentD output to json format.


```
spec:
  fluentd:
    logFormat: json
```

The default is still text. Adding the new value logFormat: json will modify the fluendtd-Container file /fluentd/etc/input.conf.