### PR TITLE
fix: default parsers conf location wrong on windows

### DIFF
--- a/pkg/resources/nodeagent/config.go
+++ b/pkg/resources/nodeagent/config.go
@@ -23,7 +23,7 @@ var fluentBitConfigTemplate = `
     Grace        {{ .Grace }}
     Daemon       Off
     Log_Level    {{ .LogLevel }}
-    Parsers_File /fluent-bit/conf/parsers.conf
+    Parsers_File /fluent-bit/etc/parsers.conf
     Coro_Stack_Size    {{ .CoroStackSize }}
     {{- if .Monitor.Enabled }}
     HTTP_Server  On


### PR DESCRIPTION
both linux and windows have it at the same location

backport of #1656 to release-4.5