### PR TITLE
Fix fluentdconfig and syslogngconfig deletion

### DIFF
--- a/charts/logging-operator/templates/clusterrole.yaml
+++ b/charts/logging-operator/templates/clusterrole.yaml
@@ -293,6 +293,12 @@ rules:
 - apiGroups:
   - logging.banzaicloud.io
   resources:
+  - loggings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - logging.banzaicloud.io
+  resources:
   - syslogngclusterflows
   - syslogngclusteroutputs
   - syslogngflows

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -293,6 +293,12 @@ rules:
 - apiGroups:
   - logging.banzaicloud.io
   resources:
+  - loggings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - logging.banzaicloud.io
+  resources:
   - syslogngclusterflows
   - syslogngclusteroutputs
   - syslogngflows

--- a/config/samples/fluentdconfig.yaml
+++ b/config/samples/fluentdconfig.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: fluentd-config
+spec:
+  controlNamespace: logging
+---
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: FluentdConfig
+metadata:
+  name: fluentd-config
+  namespace: logging
+spec: {}

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -353,14 +353,14 @@ func (r *LoggingReconciler) checkSyslogNGConfigFinalizer(ctx context.Context, lo
 }
 
 func (r *LoggingReconciler) cleanupFluentdConfigReference(ctx context.Context, logging *loggingv1beta1.Logging, log logr.Logger) (ctrl.Result, error) {
-	log.Info("cleaned up fluentdConfigRef", "name", logging.Status.FluentdConfigName)
+	log.Info("cleaning up fluentdConfig reference from status", "name", logging.Status.FluentdConfigName)
 	logging.Status.FluentdConfigName = ""
 	err := r.Status().Update(ctx, logging)
 
 	return ctrl.Result{}, err
 }
 func (r *LoggingReconciler) cleanupSyslogNGConfigReference(ctx context.Context, logging *loggingv1beta1.Logging, log logr.Logger) (ctrl.Result, error) {
-	log.Info("cleaned up syslogNGConfigRef", "name", logging.Status.SyslogNGConfigName)
+	log.Info("cleaning up syslogNGConfig reference from status", "name", logging.Status.SyslogNGConfigName)
 	logging.Status.SyslogNGConfigName = ""
 	err := r.Status().Update(ctx, logging)
 

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -311,7 +311,7 @@ func (r *LoggingReconciler) checkFluentdConfigFinalizer(ctx context.Context, log
 		if !controllerutil.ContainsFinalizer(logging, fluentdConfigFinalizer) {
 			controllerutil.AddFinalizer(logging, fluentdConfigFinalizer)
 			if err := r.Update(ctx, logging); err != nil {
-				return ctrl.Result{}, nil
+				return ctrl.Result{}, err
 			}
 		}
 	} else {
@@ -322,7 +322,7 @@ func (r *LoggingReconciler) checkFluentdConfigFinalizer(ctx context.Context, log
 		}
 		controllerutil.RemoveFinalizer(logging, fluentdConfigFinalizer)
 		if err := r.Update(ctx, logging); err != nil {
-			return r.cleanupFluentdConfigReference(ctx, logging, log)
+			return ctrl.Result{}, err
 		}
 	}
 	return ctrl.Result{}, nil
@@ -335,7 +335,7 @@ func (r *LoggingReconciler) checkSyslogNGConfigFinalizer(ctx context.Context, lo
 		if !controllerutil.ContainsFinalizer(logging, syslogNGConfigFinalizer) {
 			controllerutil.AddFinalizer(logging, syslogNGConfigFinalizer)
 			if err := r.Update(ctx, logging); err != nil {
-				return ctrl.Result{}, nil
+				return ctrl.Result{}, err
 			}
 		}
 	} else {
@@ -346,7 +346,7 @@ func (r *LoggingReconciler) checkSyslogNGConfigFinalizer(ctx context.Context, lo
 		}
 		controllerutil.RemoveFinalizer(logging, syslogNGConfigFinalizer)
 		if err := r.Update(ctx, logging); err != nil {
-			return r.cleanupSyslogNGConfigReference(ctx, logging, log)
+			return ctrl.Result{}, err
 		}
 	}
 	return ctrl.Result{}, nil

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -368,16 +368,16 @@ func (r *LoggingReconciler) cleanupSyslogNGConfigReference(ctx context.Context, 
 }
 
 func (r *LoggingReconciler) isExistingFluentdConfig(ctx context.Context, fluentdConfigRef types.NamespacedName) bool {
-	var fluentdConfig loggingv1beta1.FluentdConfig
-	if err := r.Client.Get(ctx, fluentdConfigRef, &fluentdConfig); err != nil && apierrors.IsNotFound(err) {
+	var config loggingv1beta1.FluentdConfig
+	if err := r.Client.Get(ctx, fluentdConfigRef, &config); err != nil && apierrors.IsNotFound(err) {
 		return false
 	}
 	return true
 }
 
 func (r *LoggingReconciler) isExistingSyslogNGConfig(ctx context.Context, syslogNGConfigref types.NamespacedName) bool {
-	var fluentdConfig loggingv1beta1.SyslogNGConfig
-	if err := r.Client.Get(ctx, syslogNGConfigref, &fluentdConfig); err != nil && apierrors.IsNotFound(err) {
+	var config loggingv1beta1.SyslogNGConfig
+	if err := r.Client.Get(ctx, syslogNGConfigref, &config); err != nil && apierrors.IsNotFound(err) {
 		return false
 	}
 	return true

--- a/controllers/logging/logging_controller_test.go
+++ b/controllers/logging/logging_controller_test.go
@@ -41,12 +41,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
 	controllers "github.com/kube-logging/logging-operator/controllers/logging"
 	"github.com/kube-logging/logging-operator/pkg/resources/fluentd"
 	"github.com/kube-logging/logging-operator/pkg/resources/model"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 var (
@@ -1410,7 +1411,7 @@ func beforeEachWithError(t *testing.T, errors chan<- error) func() {
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	flowReconciler := controllers.NewLoggingReconciler(mgr.GetClient(), ctrl.Log.WithName("controllers").WithName("Flow"))
+	flowReconciler := controllers.NewLoggingReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("logging-operator"), ctrl.Log.WithName("controllers").WithName("Flow"))
 
 	var stopped bool
 	wrappedReconciler := duplicateRequest(t, flowReconciler, &stopped, errors)

--- a/main.go
+++ b/main.go
@@ -169,11 +169,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !PSPEnabled(mgr.GetConfig()) {
-		setupLog.Info("WARNING PodSecurityPolicies are disabled. Can be enabled manually with PSP_ENABLED=1")
-	}
-
-	loggingReconciler := loggingControllers.NewLoggingReconciler(mgr.GetClient(), ctrl.Log.WithName("logging"))
+	loggingReconciler := loggingControllers.NewLoggingReconciler(mgr.GetClient(), mgr.GetEventRecorderFor("logging-operator"), ctrl.Log.WithName("logging"))
 
 	if err := (&extensionsControllers.EventTailerReconciler{
 		Client: mgr.GetClient(),
@@ -224,6 +220,7 @@ func main() {
 
 	// +kubebuilder:scaffold:builder
 	setupLog.Info("starting manager")
+
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -243,7 +243,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		return nil, nil, errs
 	}
 
-	fluentdSpec := loggingResources.GetFluentdSpec()
+	_, fluentdSpec := loggingResources.GetFluentd()
 
 	if fluentdSpec != nil {
 		fluentbitTargetHost := r.fluentbitSpec.TargetHost

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -361,7 +361,8 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		}
 	}
 
-	if loggingResources.GetSyslogNGSpec() != nil {
+	_, syslogNGSPec := loggingResources.GetSyslogNGSpec()
+	if syslogNGSPec != nil {
 		input.SyslogNGOutput = newSyslogNGOutputConfig()
 		input.SyslogNGOutput.Host = aggregatorEndpoint(r.Logging, syslogng.ServiceName)
 		input.SyslogNGOutput.Port = syslogng.ServicePort

--- a/pkg/resources/fluentbit/tenants.go
+++ b/pkg/resources/fluentbit/tenants.go
@@ -107,7 +107,8 @@ func (r *Reconciler) configureOutputsForTenants(ctx context.Context, tenants []v
 			continue
 		}
 
-		if loggingResources.GetFluentdSpec() != nil {
+		_, fluentdSpec := loggingResources.GetFluentd()
+		if fluentdSpec != nil {
 			if input.FluentForwardOutput == nil {
 				input.FluentForwardOutput = &fluentForwardOutputConfig{}
 			}

--- a/pkg/resources/fluentbit/tenants.go
+++ b/pkg/resources/fluentbit/tenants.go
@@ -118,7 +118,7 @@ func (r *Reconciler) configureOutputsForTenants(ctx context.Context, tenants []v
 				Host:           aggregatorEndpoint(logging, fluentd.ServiceName),
 				Port:           fluentd.ServicePort,
 			})
-		} else if loggingResources.GetSyslogNGSpec() != nil {
+		} else if _, syslogNGSPec := loggingResources.GetSyslogNGSpec(); syslogNGSPec != nil {
 			if input.SyslogNGOutput == nil {
 				input.SyslogNGOutput = newSyslogNGOutputConfig()
 			}

--- a/pkg/resources/fluentd/dataprovider.go
+++ b/pkg/resources/fluentd/dataprovider.go
@@ -25,23 +25,25 @@ import (
 )
 
 type DataProvider struct {
-	client      client.Client
-	logging     *v1beta1.Logging
-	fluentdSpec *v1beta1.FluentdSpec
+	client        client.Client
+	logging       *v1beta1.Logging
+	fluentdSpec   *v1beta1.FluentdSpec
+	fluentdConfig *v1beta1.FluentdConfig
 }
 
-func NewDataProvider(client client.Client, logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec) *DataProvider {
+func NewDataProvider(client client.Client, logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, fluentdConfig *v1beta1.FluentdConfig) *DataProvider {
 	return &DataProvider{
-		client:      client,
-		logging:     logging,
-		fluentdSpec: fluentdSpec,
+		client:        client,
+		logging:       logging,
+		fluentdSpec:   fluentdSpec,
+		fluentdConfig: fluentdConfig,
 	}
 }
 
 func (p *DataProvider) GetReplicaCount(ctx context.Context) (*int32, error) {
 	if p.fluentdSpec != nil {
 		sts := &v1.StatefulSet{}
-		om := p.logging.FluentdObjectMeta(StatefulSetName, ComponentFluentd, *p.fluentdSpec)
+		om := p.logging.FluentdObjectMeta(StatefulSetName, ComponentFluentd, *p.fluentdSpec, p.fluentdConfig)
 		err := p.client.Get(ctx, types.NamespacedName{Namespace: om.Namespace, Name: om.Name}, sts)
 		if err != nil {
 			return nil, errors.WrapIf(client.IgnoreNotFound(err), "getting fluentd statefulset")

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -68,8 +68,9 @@ const (
 
 // Reconciler holds info what resource to reconcile
 type Reconciler struct {
-	Logging     *v1beta1.Logging
-	fluentdSpec *v1beta1.FluentdSpec
+	Logging       *v1beta1.Logging
+	fluentdSpec   *v1beta1.FluentdSpec
+	fluentdConfig *v1beta1.FluentdConfig
 	*reconciler.GenericResourceReconciler
 	config  *string
 	secrets *secret.MountSecrets
@@ -112,10 +113,11 @@ func (r *Reconciler) getServiceAccount() string {
 }
 
 func New(client client.Client, log logr.Logger,
-	logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, config *string, secrets *secret.MountSecrets, opts reconciler.ReconcilerOpts) *Reconciler {
+	logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, fluentdConfig *v1beta1.FluentdConfig, config *string, secrets *secret.MountSecrets, opts reconciler.ReconcilerOpts) *Reconciler {
 	return &Reconciler{
 		Logging:                   logging,
 		fluentdSpec:               fluentdSpec,
+		fluentdConfig:             fluentdConfig,
 		GenericResourceReconciler: reconciler.NewGenericReconciler(client, log, opts),
 		config:                    config,
 		secrets:                   secrets,
@@ -318,7 +320,7 @@ func (r *Reconciler) reconcileDrain(ctx context.Context) (*reconcile.Result, err
 		}
 	}
 
-	replicaCount, err := NewDataProvider(r.Client, r.Logging, r.fluentdSpec).GetReplicaCount(ctx)
+	replicaCount, err := NewDataProvider(r.Client, r.Logging, r.fluentdSpec, r.fluentdConfig).GetReplicaCount(ctx)
 	if err != nil {
 		return nil, errors.WrapIf(err, "get replica count for fluentd")
 	}

--- a/pkg/resources/fluentd/meta.go
+++ b/pkg/resources/fluentd/meta.go
@@ -21,19 +21,29 @@ import (
 
 // FluentdObjectMeta creates an objectMeta for resource fluentd
 func (r *Reconciler) FluentdObjectMeta(name, component string) metav1.ObjectMeta {
+	ownerReference := metav1.OwnerReference{
+		APIVersion: r.Logging.APIVersion,
+		Kind:       r.Logging.Kind,
+		Name:       r.Logging.Name,
+		UID:        r.Logging.UID,
+		Controller: util.BoolPointer(true),
+	}
+
+	if r.fluentdConfig != nil {
+		ownerReference = metav1.OwnerReference{
+			APIVersion: r.fluentdConfig.APIVersion,
+			Kind:       r.fluentdConfig.Kind,
+			Name:       r.fluentdConfig.Name,
+			UID:        r.fluentdConfig.UID,
+			Controller: util.BoolPointer(true),
+		}
+	}
+
 	o := metav1.ObjectMeta{
-		Name:      r.Logging.QualifiedName(name),
-		Namespace: r.Logging.Spec.ControlNamespace,
-		Labels:    r.Logging.GetFluentdLabels(component, *r.fluentdSpec),
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				APIVersion: r.Logging.APIVersion,
-				Kind:       r.Logging.Kind,
-				Name:       r.Logging.Name,
-				UID:        r.Logging.UID,
-				Controller: util.BoolPointer(true),
-			},
-		},
+		Name:            r.Logging.QualifiedName(name),
+		Namespace:       r.Logging.Spec.ControlNamespace,
+		Labels:          r.Logging.GetFluentdLabels(component, *r.fluentdSpec),
+		OwnerReferences: []metav1.OwnerReference{ownerReference},
 	}
 	return *o.DeepCopy()
 }

--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -235,7 +235,6 @@ func NewValidationReconciler(
 			}
 			logger.Info("found detached fluentd aggregator, making association", "name", resources.Fluentd.Configuration.Name)
 			resources.Logging.Status.FluentdConfigName = resources.Fluentd.Configuration.Name
-			resources.Logging.Finalizers = append(resources.Logging.Finalizers, resources.Fluentd.Configuration.Name)
 
 			resources.Fluentd.Configuration.Status.Active = utils.BoolPointer(true)
 			resources.Fluentd.Configuration.Status.Logging = resources.Logging.Name

--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -235,6 +235,7 @@ func NewValidationReconciler(
 			}
 			logger.Info("found detached fluentd aggregator, making association", "name", resources.Fluentd.Configuration.Name)
 			resources.Logging.Status.FluentdConfigName = resources.Fluentd.Configuration.Name
+			resources.Logging.Finalizers = append(resources.Logging.Finalizers, resources.Fluentd.Configuration.Name)
 
 			resources.Fluentd.Configuration.Status.Active = utils.BoolPointer(true)
 			resources.Fluentd.Configuration.Status.Logging = resources.Logging.Name

--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -238,6 +238,8 @@ func NewValidationReconciler(
 
 			resources.Fluentd.Configuration.Status.Active = utils.BoolPointer(true)
 			resources.Fluentd.Configuration.Status.Logging = resources.Logging.Name
+		} else {
+			resources.Logging.Status.FluentdConfigName = ""
 		}
 
 		if len(resources.SyslogNG.ExcessSyslogNGs) != 0 {
@@ -271,6 +273,8 @@ func NewValidationReconciler(
 			logger.Info("found detached syslog-ng aggregator, making association, done: ", "name=", resources.Logging.Status.SyslogNGConfigName)
 			resources.SyslogNG.Configuration.Status.Active = utils.BoolPointer(true)
 			resources.SyslogNG.Configuration.Status.Logging = resources.Logging.Name
+		} else {
+			resources.Logging.Status.SyslogNGConfigName = ""
 		}
 
 		if !resources.Logging.WatchAllNamespaces() {

--- a/pkg/resources/model/resources.go
+++ b/pkg/resources/model/resources.go
@@ -29,23 +29,19 @@ type LoggingResources struct {
 	WatchNamespaces []string
 }
 
-func (l LoggingResources) getFluentd() *v1beta1.FluentdConfig {
+func (l LoggingResources) getFluentdConfig() *v1beta1.FluentdConfig {
 	if l.Fluentd.Configuration != nil {
 		return l.Fluentd.Configuration
 	}
 	return nil
 }
 
-func (l LoggingResources) GetFluentdSpec() *v1beta1.FluentdSpec {
-
-	if detachedFluentd := l.getFluentd(); detachedFluentd != nil {
-		return &detachedFluentd.Spec
-	}
-	if l.Logging.Spec.FluentdSpec != nil {
-		return l.Logging.Spec.FluentdSpec
+func (l LoggingResources) GetFluentd() (*v1beta1.FluentdConfig, *v1beta1.FluentdSpec) {
+	if detachedFluentd := l.getFluentdConfig(); detachedFluentd != nil {
+		return detachedFluentd, &detachedFluentd.Spec
 	}
 
-	return nil
+	return nil, l.Logging.Spec.FluentdSpec
 }
 
 type FluentdLoggingResources struct {

--- a/pkg/resources/model/resources.go
+++ b/pkg/resources/model/resources.go
@@ -60,16 +60,13 @@ func (l LoggingResources) getSyslogNG() *v1beta1.SyslogNGConfig {
 	return nil
 }
 
-func (l LoggingResources) GetSyslogNGSpec() *v1beta1.SyslogNGSpec {
+func (l LoggingResources) GetSyslogNGSpec() (*v1beta1.SyslogNGConfig, *v1beta1.SyslogNGSpec) {
 
 	if detachedSyslogNG := l.getSyslogNG(); detachedSyslogNG != nil {
-		return &detachedSyslogNG.Spec
+		return detachedSyslogNG, &detachedSyslogNG.Spec
 	}
-	if l.Logging.Spec.SyslogNGSpec != nil {
-		return l.Logging.Spec.SyslogNGSpec
-	}
+	return nil, l.Logging.Spec.SyslogNGSpec
 
-	return nil
 }
 
 type SyslogNGLoggingResources struct {

--- a/pkg/resources/model/system.go
+++ b/pkg/resources/model/system.go
@@ -32,7 +32,7 @@ import (
 
 func CreateSystem(resources LoggingResources, secrets SecretLoaderFactory, logger logr.Logger) (*types.System, error) {
 	logging := resources.Logging
-	fluentdSpec := resources.GetFluentdSpec()
+	_, fluentdSpec := resources.GetFluentd()
 
 	var forwardInput *input.ForwardInputConfig
 	if fluentdSpec != nil && fluentdSpec.ForwardInputConfig != nil {

--- a/pkg/resources/syslogng/dataprovider.go
+++ b/pkg/resources/syslogng/dataprovider.go
@@ -26,20 +26,22 @@ import (
 )
 
 type DataProvider struct {
-	client  client.Client
-	logging *v1beta1.Logging
+	client          client.Client
+	logging         *v1beta1.Logging
+	syslogNGSConfig *v1beta1.SyslogNGConfig
 }
 
-func NewDataProvider(client client.Client, logging *v1beta1.Logging) *DataProvider {
+func NewDataProvider(client client.Client, logging *v1beta1.Logging, syslogNGSConfig *v1beta1.SyslogNGConfig) *DataProvider {
 	return &DataProvider{
-		client:  client,
-		logging: logging,
+		client:          client,
+		logging:         logging,
+		syslogNGSConfig: syslogNGSConfig,
 	}
 }
 
 func (p *DataProvider) GetReplicaCount(ctx context.Context) (*int32, error) {
 	sts := &v1.StatefulSet{}
-	om := p.logging.SyslogNGObjectMeta(StatefulSetName, ComponentSyslogNG)
+	om := p.logging.SyslogNGObjectMeta(StatefulSetName, ComponentSyslogNG, p.syslogNGSConfig)
 	err := p.client.Get(ctx, types.NamespacedName{Namespace: om.Namespace, Name: om.Name}, sts)
 	if err != nil {
 		return nil, errors.WrapIf(client.IgnoreNotFound(err), "getting syslog-ng statefulset")

--- a/pkg/resources/syslogng/meta.go
+++ b/pkg/resources/syslogng/meta.go
@@ -21,19 +21,27 @@ import (
 
 // SyslogNGObjectMeta creates an objectMeta for resource syslog-ng
 func (r *Reconciler) SyslogNGObjectMeta(name, component string) metav1.ObjectMeta {
+	ownerReference := metav1.OwnerReference{
+		APIVersion: r.Logging.APIVersion,
+		Kind:       r.Logging.Kind,
+		Name:       r.Logging.Name,
+		UID:        r.Logging.UID,
+		Controller: util.BoolPointer(true),
+	}
+	if r.syslogNGConfig != nil {
+		ownerReference = metav1.OwnerReference{
+			APIVersion: r.syslogNGConfig.APIVersion,
+			Kind:       r.syslogNGConfig.Kind,
+			Name:       r.syslogNGConfig.Name,
+			UID:        r.syslogNGConfig.UID,
+			Controller: util.BoolPointer(true),
+		}
+	}
 	o := metav1.ObjectMeta{
-		Name:      r.Logging.QualifiedName(name),
-		Namespace: r.Logging.Spec.ControlNamespace,
-		Labels:    r.Logging.GetSyslogNGLabels(component),
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				APIVersion: r.Logging.APIVersion,
-				Kind:       r.Logging.Kind,
-				Name:       r.Logging.Name,
-				UID:        r.Logging.UID,
-				Controller: util.BoolPointer(true),
-			},
-		},
+		Name:            r.Logging.QualifiedName(name),
+		Namespace:       r.Logging.Spec.ControlNamespace,
+		Labels:          r.Logging.GetSyslogNGLabels(component),
+		OwnerReferences: []metav1.OwnerReference{ownerReference},
 	}
 	return *o.DeepCopy()
 }

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -43,7 +43,7 @@ func (r *Reconciler) statefulset() (runtime.Object, reconciler.DesiredState, err
 	}
 
 	desired := &appsv1.StatefulSet{
-		ObjectMeta: r.Logging.SyslogNGObjectMeta(StatefulSetName, ComponentSyslogNG),
+		ObjectMeta: r.Logging.SyslogNGObjectMeta(StatefulSetName, ComponentSyslogNG, r.syslogNGConfig),
 		Spec: appsv1.StatefulSetSpec{
 			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
 			Selector: &metav1.LabelSelector{

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -71,8 +71,9 @@ const (
 
 // Reconciler holds info what resource to reconcile
 type Reconciler struct {
-	Logging      *v1beta1.Logging
-	syslogNGSpec *v1beta1.SyslogNGSpec
+	Logging        *v1beta1.Logging
+	syslogNGSpec   *v1beta1.SyslogNGSpec
+	syslogNGConfig *v1beta1.SyslogNGConfig
 	*reconciler.GenericResourceReconciler
 	config  string
 	secrets *secret.MountSecrets
@@ -91,6 +92,7 @@ func New(
 	log logr.Logger,
 	logging *v1beta1.Logging,
 	syslogNGSPec *v1beta1.SyslogNGSpec,
+	syslogNGCOnfig *v1beta1.SyslogNGConfig,
 	config string,
 	secrets *secret.MountSecrets,
 	opts reconciler.ReconcilerOpts,
@@ -98,6 +100,7 @@ func New(
 	return &Reconciler{
 		Logging:                   logging,
 		syslogNGSpec:              syslogNGSPec,
+		syslogNGConfig:            syslogNGCOnfig,
 		GenericResourceReconciler: reconciler.NewGenericReconciler(client, log, opts),
 		config:                    config,
 		secrets:                   secrets,

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -448,20 +448,29 @@ func persistentVolumeModePointer(mode v1.PersistentVolumeMode) *v1.PersistentVol
 }
 
 // FluentdObjectMeta creates an objectMeta for resource fluentd
-func (l *Logging) FluentdObjectMeta(name, component string, f FluentdSpec) metav1.ObjectMeta {
+func (l *Logging) FluentdObjectMeta(name, component string, f FluentdSpec, fc *FluentdConfig) metav1.ObjectMeta {
+	ownerReference := metav1.OwnerReference{
+		APIVersion: l.APIVersion,
+		Kind:       l.Kind,
+		Name:       l.Name,
+		UID:        l.UID,
+		Controller: util.BoolPointer(true),
+	}
+
+	if fc != nil {
+		ownerReference = metav1.OwnerReference{
+			APIVersion: fc.APIVersion,
+			Kind:       fc.Kind,
+			Name:       fc.Name,
+			UID:        fc.UID,
+			Controller: util.BoolPointer(true),
+		}
+	}
 	o := metav1.ObjectMeta{
-		Name:      l.QualifiedName(name),
-		Namespace: l.Spec.ControlNamespace,
-		Labels:    l.GetFluentdLabels(component, f),
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				APIVersion: l.APIVersion,
-				Kind:       l.Kind,
-				Name:       l.Name,
-				UID:        l.UID,
-				Controller: util.BoolPointer(true),
-			},
-		},
+		Name:            l.QualifiedName(name),
+		Namespace:       l.Spec.ControlNamespace,
+		Labels:          l.GetFluentdLabels(component, f),
+		OwnerReferences: []metav1.OwnerReference{ownerReference},
 	}
 	return o
 }

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -487,20 +487,28 @@ func (l *Logging) GetFluentdLabels(component string, f FluentdSpec) map[string]s
 }
 
 // SyslogNGObjectMeta creates an objectMeta for resource syslog-ng
-func (l *Logging) SyslogNGObjectMeta(name, component string) metav1.ObjectMeta {
+func (l *Logging) SyslogNGObjectMeta(name, component string, sc *SyslogNGConfig) metav1.ObjectMeta {
+	ownerReference := metav1.OwnerReference{
+		APIVersion: l.APIVersion,
+		Kind:       l.Kind,
+		Name:       l.Name,
+		UID:        l.UID,
+		Controller: util.BoolPointer(true),
+	}
+	if sc != nil {
+		ownerReference = metav1.OwnerReference{
+			APIVersion: sc.APIVersion,
+			Kind:       sc.Kind,
+			Name:       sc.Name,
+			UID:        sc.UID,
+			Controller: util.BoolPointer(true),
+		}
+	}
 	o := metav1.ObjectMeta{
-		Name:      l.QualifiedName(name),
-		Namespace: l.Spec.ControlNamespace,
-		Labels:    l.GetSyslogNGLabels(component),
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				APIVersion: l.APIVersion,
-				Kind:       l.Kind,
-				Name:       l.Name,
-				UID:        l.UID,
-				Controller: util.BoolPointer(true),
-			},
-		},
+		Name:            l.QualifiedName(name),
+		Namespace:       l.Spec.ControlNamespace,
+		Labels:          l.GetSyslogNGLabels(component),
+		OwnerReferences: []metav1.OwnerReference{ownerReference},
 	}
 	return o
 }


### PR DESCRIPTION
This PR aims to fix two problems:
- deleting a fluentdconfig/syslogngconfig resource should also delete the child resources (solved by changing the ownerreferences)
- deleting a logging resource should not be possible until a fluentdconfig/syslogngconfig resource exists. we don't delete the fluentdconfig/syslogngconfig forcefully because those are created by the user, but we can protect against this by using a finalizer. we send an event to the logging object for the user to be able to see other than looking at the operator logs

Fixes #1667.

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>