### PR TITLE
helm: allow eventtailer image override through chart

### DIFF
--- a/charts/logging-operator/templates/logging_eventtailer.yaml
+++ b/charts/logging-operator/templates/logging_eventtailer.yaml
@@ -31,5 +31,9 @@ spec:
   containerOverrides:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .image }}
+  image:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -232,6 +232,11 @@ logging:
   # -- EventTailer config
   eventTailer: {}
     # name: sample
+    # image:
+    #   repository: "ghcr.io/kube-logging/eventrouter"
+    #   tag: "0.4.0"
+    #   pullPolicy: IfNotPresent
+    #   imagePullSecrets: []
     # pvc:
     #   accessModes:
     #     - ReadWriteOnce


### PR DESCRIPTION
This is a supplement to #1510.

The `EventTailer` spec allows for overriding the image, but that options was not available through the helm chart. 
Here I add that option.