### PR TITLE
fix: remove requeue after

### DIFF
--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -17,7 +17,6 @@ package fluentd
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
@@ -203,7 +202,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 				} else {
 					r.Log.Info("still waiting for the configcheck result...")
 				}
-				return &reconcile.Result{RequeueAfter: time.Minute}, nil
+				return &reconcile.Result{Requeue: true}, nil
 			}
 		}
 	}

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -16,7 +16,6 @@ package syslogng
 
 import (
 	"context"
-	"time"
 
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
@@ -184,7 +183,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 				} else {
 					r.Log.Info("still waiting for the configcheck result...")
 				}
-				return &reconcile.Result{RequeueAfter: time.Minute}, nil
+				return &reconcile.Result{Requeue: true}, nil
 			}
 		}
 	}


### PR DESCRIPTION
Otherwise it halts all other events for the same object from being reconciled until the specified time

note: the rate limiter will protect us anyways