### PR TITLE
feat: kubernetes namespace labels and annotations with fluent-bit 3.0

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
@@ -1087,6 +1087,12 @@ spec:
                     type: string
                   Use_Kubelet:
                     type: string
+                  kube_meta_namespace_cache_ttl:
+                    type: string
+                  namespace_annotations:
+                    type: string
+                  namespace_labels:
+                    type: string
                   tls.debug:
                     type: string
                   tls.verify:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -2104,6 +2104,12 @@ spec:
                         type: string
                       Use_Kubelet:
                         type: string
+                      kube_meta_namespace_cache_ttl:
+                        type: string
+                      namespace_annotations:
+                        type: string
+                      namespace_labels:
+                        type: string
                       tls.debug:
                         type: string
                       tls.verify:
@@ -10777,6 +10783,12 @@ spec:
                             Use_Journal:
                               type: string
                             Use_Kubelet:
+                              type: string
+                            kube_meta_namespace_cache_ttl:
+                              type: string
+                            namespace_annotations:
+                              type: string
+                            namespace_labels:
                               type: string
                             tls.debug:
                               type: string

--- a/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
@@ -3644,6 +3644,12 @@ spec:
                         type: string
                       Use_Kubelet:
                         type: string
+                      kube_meta_namespace_cache_ttl:
+                        type: string
+                      namespace_annotations:
+                        type: string
+                      namespace_labels:
+                        type: string
                       tls.debug:
                         type: string
                       tls.verify:

--- a/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
@@ -1087,6 +1087,12 @@ spec:
                     type: string
                   Use_Kubelet:
                     type: string
+                  kube_meta_namespace_cache_ttl:
+                    type: string
+                  namespace_annotations:
+                    type: string
+                  namespace_labels:
+                    type: string
                   tls.debug:
                     type: string
                   tls.verify:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -2104,6 +2104,12 @@ spec:
                         type: string
                       Use_Kubelet:
                         type: string
+                      kube_meta_namespace_cache_ttl:
+                        type: string
+                      namespace_annotations:
+                        type: string
+                      namespace_labels:
+                        type: string
                       tls.debug:
                         type: string
                       tls.verify:
@@ -10777,6 +10783,12 @@ spec:
                             Use_Journal:
                               type: string
                             Use_Kubelet:
+                              type: string
+                            kube_meta_namespace_cache_ttl:
+                              type: string
+                            namespace_annotations:
+                              type: string
+                            namespace_labels:
                               type: string
                             tls.debug:
                               type: string

--- a/config/crd/bases/logging.banzaicloud.io_nodeagents.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_nodeagents.yaml
@@ -3644,6 +3644,12 @@ spec:
                         type: string
                       Use_Kubelet:
                         type: string
+                      kube_meta_namespace_cache_ttl:
+                        type: string
+                      namespace_annotations:
+                        type: string
+                      namespace_labels:
+                        type: string
                       tls.debug:
                         type: string
                       tls.verify:

--- a/docs/configuration/crds/v1beta1/fluentbit_types.md
+++ b/docs/configuration/crds/v1beta1/fluentbit_types.md
@@ -698,6 +698,21 @@ Default: On
 Optional parser name to specify how to parse the data contained in the log key. Recommended use is for developers or testing only. 
 
 
+### namespace_annotations (string, optional) {#filterkubernetes-namespace_annotations}
+
+Include Kubernetes namespace annotations on every record 
+
+
+### kube_meta_namespace_cache_ttl (string, optional) {#filterkubernetes-kube_meta_namespace_cache_ttl}
+
+Configurable TTL for K8s cached namespace metadata. (15m) 
+
+
+### namespace_labels (string, optional) {#filterkubernetes-namespace_labels}
+
+Include Kubernetes namespace labels on every record 
+
+
 ### Regex_Parser (string, optional) {#filterkubernetes-regex_parser}
 
 Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id. The parser must be registered in a parsers file (refer to parser filter-kube-test as an example). 

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -328,6 +328,12 @@ type FilterKubernetes struct {
 	Labels string `json:"Labels,omitempty"`
 	// Include Kubernetes resource annotations in the extra metadata. (default:On)
 	Annotations string `json:"Annotations,omitempty"`
+	// Include Kubernetes namespace labels on every record
+	NamespaceLabels string `json:"namespace_labels,omitempty"`
+	// Include Kubernetes namespace annotations on every record
+	NamespaceAnnotations string `json:"namespace_annotations,omitempty"`
+	// Configurable TTL for K8s cached namespace metadata. (15m)
+	NamespaceCacheTTL string `json:"kube_meta_namespace_cache_ttl,omitempty"`
 	// If set, Kubernetes meta-data can be cached/pre-loaded from files in JSON format in this directory, named as namespace-pod.meta
 	KubeMetaPreloadCacheDir string `json:"Kube_meta_preload_cache_dir,omitempty"`
 	// If set, use dummy-meta data (for test/dev purposes) (default:Off)


### PR DESCRIPTION
This PR adds new fields for the [new fluent-bit kubernetes filter options](https://github.com/fluent/fluent-bit/pull/8279/) to allow for enriching logs with kubernetes namespace labels and annotations right at the source

```
apiVersion: logging.banzaicloud.io/v1beta1
kind: FluentbitAgent
metadata:
  name: namespace-label-test
spec:
  filterKubernetes:
    namespace_annotations: "On"
    namespace_labels: "On"
  image:
    repository: ghcr.io/fluent/fluent-bit/unstable
    tag: latest
```
<img width="792" alt="image" src="https://github.com/kube-logging/logging-operator/assets/682440/20be6757-4e66-434c-9bc0-32c3f5ba99bf">
