### PR TITLE
chore: remove obsolete deprecation warning from logging status

### DIFF
--- a/controllers/logging/logging_controller_test.go
+++ b/controllers/logging/logging_controller_test.go
@@ -279,6 +279,7 @@ func TestLogginResourcesWithNonUniqueLoggingRefs(t *testing.T) {
 		},
 		Spec: v1beta1.LoggingSpec{
 			ControlNamespace: controlNamespace,
+			WatchNamespaces:  []string{"a", "b"},
 		},
 	}
 	logging2 := &v1beta1.Logging{
@@ -287,6 +288,7 @@ func TestLogginResourcesWithNonUniqueLoggingRefs(t *testing.T) {
 		},
 		Spec: v1beta1.LoggingSpec{
 			ControlNamespace: controlNamespace,
+			WatchNamespaces:  []string{"b", "c"},
 		},
 	}
 	logging3 := &v1beta1.Logging{
@@ -305,7 +307,7 @@ func TestLogginResourcesWithNonUniqueLoggingRefs(t *testing.T) {
 
 	// The first logging resource won't be populated with a warning initially since at the time of creation it is unique
 	g.Eventually(getLoggingProblems(logging1)).WithPolling(time.Second).WithTimeout(5 * time.Second).Should(gomega.BeEmpty())
-	g.Eventually(getLoggingProblems(logging2)).WithPolling(time.Second).WithTimeout(5 * time.Second).Should(gomega.ContainElement(gomega.ContainSubstring("Deprecated")))
+	g.Eventually(getLoggingProblems(logging2)).WithPolling(time.Second).WithTimeout(5 * time.Second).Should(gomega.ContainElement(gomega.ContainSubstring(model.LoggingRefConflict)))
 	g.Eventually(getLoggingProblems(logging3)).WithPolling(time.Second).WithTimeout(5 * time.Second).Should(gomega.BeEmpty())
 
 	g.Eventually(func() error {
@@ -316,7 +318,7 @@ func TestLogginResourcesWithNonUniqueLoggingRefs(t *testing.T) {
 		l.Spec.ErrorOutputRef = "trigger reconcile"
 		return mgr.GetClient().Update(context.TODO(), l)
 	}).WithPolling(time.Second).WithTimeout(5 * time.Second).Should(gomega.Succeed())
-	g.Eventually(getLoggingProblems(logging1)).WithPolling(time.Second).WithTimeout(5 * time.Second).Should(gomega.ContainElement(gomega.ContainSubstring("Deprecated")))
+	g.Eventually(getLoggingProblems(logging1)).WithPolling(time.Second).WithTimeout(5 * time.Second).Should(gomega.ContainElement(gomega.ContainSubstring(model.LoggingRefConflict)))
 }
 
 func getLoggingProblems(logging *v1beta1.Logging) func() ([]string, error) {

--- a/pkg/resources/model/reconciler_test.go
+++ b/pkg/resources/model/reconciler_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2024 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import "testing"
+
+func Test_hasIntersection(t *testing.T) {
+	type args struct {
+		a []string
+		b []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "no intersection empty",
+			args: args{
+				a: []string{},
+				b: []string{},
+			},
+			want: false,
+		},
+		{
+			name: "no intersection nonempty",
+			args: args{
+				a: []string{"a", "b", "c"},
+				b: []string{"d", "e"},
+			},
+			want: false,
+		},
+		{
+			name: "has intersection",
+			args: args{
+				a: []string{"a", "b", "c"},
+				b: []string{"b"},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasIntersection(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("hasIntersection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 make the conflict warning smarter and more informative

fixes #1666 