### PR TITLE
doc: Remove internal type

### DIFF
--- a/docs/configuration/plugins/outputs/vmware_log_intelligence.md
+++ b/docs/configuration/plugins/outputs/vmware_log_intelligence.md
@@ -88,28 +88,3 @@ Structure for http request to VMware Log Intelligence
 Default: simple
 
 
-## LogIntelligenceHeadersOut
-
-LogIntelligenceHeadersOut is used to convert the input LogIntelligenceHeaders to a fluentd
-output that uses the correct key names for the VMware Log Intelligence plugin. This allows the
-Ouput to accept the config is snake_case (as other output plugins do) but output the fluentd
-<headers> config with the proper key names (ie. content_type -> Content-Type)
-
-### Authorization (*secret.Secret, required) {#logintelligenceheadersout-authorization}
-
-Authorization Bearer token for http request to VMware Log Intelligence 
-
-
-### Content-Type (string, required) {#logintelligenceheadersout-content-type}
-
-Content Type for http request to VMware Log Intelligence 
-
-Default: application/json
-
-### structure (string, required) {#logintelligenceheadersout-structure}
-
-Structure for http request to VMware Log Intelligence 
-
-Default: simple
-
-

--- a/pkg/sdk/logging/model/output/vmware_log_intelligence.go
+++ b/pkg/sdk/logging/model/output/vmware_log_intelligence.go
@@ -87,11 +87,11 @@ type LogIntelligenceHeaders struct {
 	Structure string `json:"structure" plugin:"default:simple"`
 }
 
-// LogIntelligenceHeadersOut is used to convert the input LogIntelligenceHeaders to a fluentd
+// logIntelligenceHeadersOut is used to convert the input LogIntelligenceHeaders to a fluentd
 // output that uses the correct key names for the VMware Log Intelligence plugin. This allows the
 // Ouput to accept the config is snake_case (as other output plugins do) but output the fluentd
 // <headers> config with the proper key names (ie. content_type -> Content-Type)
-type LogIntelligenceHeadersOut struct {
+type logIntelligenceHeadersOut struct {
 	// Authorization Bearer token for http request to VMware Log Intelligence
 	Authorization *secret.Secret `json:"Authorization"`
 	// Content Type for http request to VMware Log Intelligence
@@ -100,7 +100,7 @@ type LogIntelligenceHeadersOut struct {
 	Structure string `json:"structure" plugin:"default:simple"`
 }
 
-func (l *LogIntelligenceHeadersOut) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
+func (l *logIntelligenceHeadersOut) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	return types.NewFlatDirective(types.PluginMeta{
 		Directive: "headers",
 	}, l, secretLoader)
@@ -123,7 +123,7 @@ func (v *VMwareLogIntelligenceOutputConfig) ToDirective(secretLoader secret.Secr
 		vmwli.Params = params
 	}
 
-	h := LogIntelligenceHeadersOut{
+	h := logIntelligenceHeadersOut{
 		ContentType:   v.Headers.ContentType,
 		Authorization: v.Headers.Authorization,
 		Structure:     v.Headers.Structure,


### PR DESCRIPTION
- Internal type in vmware log intelligence plugin shouldn't be exposed or be included in docs