### PR TITLE
add missing dnsconfig to configcheck pods as well

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -267,6 +267,7 @@ func (r *Reconciler) newCheckPod(hashKey string, fluentdSpec v1beta1.FluentdSpec
 			ImagePullSecrets:   fluentdSpec.Image.ImagePullSecrets,
 			InitContainers:     initContainer,
 			Containers:         container,
+			DNSConfig:          fluentdSpec.DNSConfig,
 		},
 	}
 	if fluentdSpec.ConfigCheckAnnotations != nil {


### PR DESCRIPTION
Fixes https://github.com/kube-logging/logging-operator/issues/1557