### PR TITLE
chore(fluentd): do not override fluentd's default buffer size

### DIFF
--- a/docs/configuration/plugins/outputs/buffer.md
+++ b/docs/configuration/plugins/outputs/buffer.md
@@ -18,9 +18,8 @@ The max number of events that each chunks can store in it
 
 ### chunk_limit_size (string, optional) {#buffer-chunk_limit_size}
 
-The max size of each chunks: events will be written into chunks until the size of chunks become this size (default: 8MB) 
+The max size of each chunks: events will be written into chunks until the size of chunks become this size 
 
-Default: 8MB
 
 ### compress (string, optional) {#buffer-compress}
 

--- a/pkg/sdk/logging/model/output/aws_elasticsearch_test.go
+++ b/pkg/sdk/logging/model/output/aws_elasticsearch_test.go
@@ -65,7 +65,6 @@ buffer:
 	</endpoint>
 	<buffer tag,time>
 	  @type file
-	  chunk_limit_size 8MB
 	  path /buffers/test.*.buffer
 	  retry_forever true
 	  timekey 1m

--- a/pkg/sdk/logging/model/output/azurestore_test.go
+++ b/pkg/sdk/logging/model/output/azurestore_test.go
@@ -41,7 +41,6 @@ buffer:
     path logs/${tag}/%Y/%m/%d/
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/buffer.go
+++ b/pkg/sdk/logging/model/output/buffer.go
@@ -43,17 +43,17 @@ type Buffer struct {
 	Tags *string `json:"tags,omitempty"`
 	// The path where buffer chunks are stored. The '*' is replaced with random characters. It's highly recommended to leave this default. (default: operator generated)
 	Path string `json:"path,omitempty"`
-	// The max size of each chunks: events will be written into chunks until the size of chunks become this size (default: 8MB)
-	ChunkLimitSize string `json:"chunk_limit_size,omitempty" plugin:"default:8MB"`
+	// The max size of each chunks: events will be written into chunks until the size of chunks become this size
+	ChunkLimitSize string `json:"chunk_limit_size,omitempty"`
 	// The max number of events that each chunks can store in it
 	ChunkLimitRecords int `json:"chunk_limit_records,omitempty"`
 	// The size limitation of this buffer plugin instance. Once the total size of stored buffer reached this threshold, all append operations will fail with error (and data will be lost)
 	TotalLimitSize string `json:"total_limit_size,omitempty"`
-	//The queue length limitation of this buffer plugin instance
+	// The queue length limitation of this buffer plugin instance
 	QueueLimitLength int `json:"queue_limit_length,omitempty"`
 	// The percentage of chunk size threshold for flushing. output plugin will flush the chunk when actual size reaches chunk_limit_size * chunk_full_threshold (== 8MB * 0.95 in default)
 	ChunkFullThreshold string `json:"chunk_full_threshold,omitempty"`
-	//Limit the number of queued chunks. If you set smaller flush_interval, e.g. 1s, there are lots of small queued chunks in buffer. This is not good with file buffer because it consumes lots of fd resources when output destination has a problem. This parameter mitigates such situations.
+	// Limit the number of queued chunks. If you set smaller flush_interval, e.g. 1s, there are lots of small queued chunks in buffer. This is not good with file buffer because it consumes lots of fd resources when output destination has a problem. This parameter mitigates such situations.
 	QueuedChunksLimitSize int `json:"queued_chunks_limit_size,omitempty"`
 	// If you set this option to gzip, you can get Fluentd to compress data records before writing to buffer chunks.
 	Compress string `json:"compress,omitempty"`

--- a/pkg/sdk/logging/model/output/cloudwatch_test.go
+++ b/pkg/sdk/logging/model/output/cloudwatch_test.go
@@ -43,7 +43,6 @@ buffer:
     region us-east-1
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test_loki.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/datadog_test.go
+++ b/pkg/sdk/logging/model/output/datadog_test.go
@@ -42,7 +42,6 @@ buffer:
 	dd_tags <KEY1:VALUE1>,<KEY2:VALUE2>
 	<buffer tag,time>
 	  @type file
-	  chunk_limit_size 8MB
 	  path /buffers/test.*.buffer
 	  retry_forever true
 	  timekey 1m

--- a/pkg/sdk/logging/model/output/elasticsearch_test.go
+++ b/pkg/sdk/logging/model/output/elasticsearch_test.go
@@ -54,7 +54,6 @@ compression_level: default_compression
 	verify_es_version_at_startup true
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m
@@ -102,7 +101,6 @@ buffer:
     verify_es_version_at_startup true
     <buffer tag,time>
       @type file
-      chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/file_test.go
+++ b/pkg/sdk/logging/model/output/file_test.go
@@ -41,7 +41,6 @@ buffer:
 	path /tmp/logs/${tag}/%Y/%m/%d.%H.%M
 	<buffer tag,time>
 	  @type file
-	  chunk_limit_size 8MB
 	  path /buffers/test.*.buffer
 	  retry_forever true
 	  timekey 1m

--- a/pkg/sdk/logging/model/output/format_test.go
+++ b/pkg/sdk/logging/model/output/format_test.go
@@ -43,7 +43,6 @@ buffer:
 	path /tmp/logs/${tag}/%Y/%m/%d.%H.%M
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/gcs_test.go
+++ b/pkg/sdk/logging/model/output/gcs_test.go
@@ -42,7 +42,6 @@ buffer:
     project logging-example
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/http_test.go
+++ b/pkg/sdk/logging/model/output/http_test.go
@@ -48,7 +48,6 @@ auth:
 	retryable_response_codes [503,504]
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/kafka_test.go
+++ b/pkg/sdk/logging/model/output/kafka_test.go
@@ -46,7 +46,6 @@ buffer:
     ssl_verify_hostname false
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/kinesis_firehose_test.go
+++ b/pkg/sdk/logging/model/output/kinesis_firehose_test.go
@@ -49,7 +49,6 @@ buffer:
     </assume_role_credentials>
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/kinesis_stream_test.go
+++ b/pkg/sdk/logging/model/output/kinesis_stream_test.go
@@ -54,7 +54,6 @@ buffer:
 	</process_credentials>
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/logdna_test.go
+++ b/pkg/sdk/logging/model/output/logdna_test.go
@@ -49,7 +49,6 @@ buffer:
 	tags web,dev
 	<buffer tag,time>
 	  @type file
-	  chunk_limit_size 8MB
 	  path /buffers/test_logdna.*.buffer
 	  retry_forever true
 	  timekey 1m

--- a/pkg/sdk/logging/model/output/loki_test.go
+++ b/pkg/sdk/logging/model/output/loki_test.go
@@ -57,7 +57,6 @@ buffer:
     </label>
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/newrelic_test.go
+++ b/pkg/sdk/logging/model/output/newrelic_test.go
@@ -36,7 +36,6 @@ license_key:
 		license_key 000000000000000000000000
 		<buffer tag,time>
 			@type file
-			chunk_limit_size 8MB
 			path /buffers/test.*.buffer
 			retry_forever true
 			timekey 10m

--- a/pkg/sdk/logging/model/output/opensearch_test.go
+++ b/pkg/sdk/logging/model/output/opensearch_test.go
@@ -56,7 +56,6 @@ buffer:
   verify_os_version_at_startup true
   <buffer tag,time>
     @type file
-  chunk_limit_size 8MB
     path /buffers/test.*.buffer
     retry_forever true
     timekey 1m
@@ -116,7 +115,6 @@ buffer:
   </endpoint>
   <buffer tag,time>
     @type file
-  chunk_limit_size 8MB
     path /buffers/test.*.buffer
     retry_forever true
     timekey 1m
@@ -166,7 +164,6 @@ buffer:
     verify_os_version_at_startup true
     <buffer tag,time>
       @type file
-      chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/oss_test.go
+++ b/pkg/sdk/logging/model/output/oss_test.go
@@ -42,7 +42,6 @@ buffer:
     path fluent-oss/logs
     <buffer tag,time>
       @type file
-      chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/redis_test.go
+++ b/pkg/sdk/logging/model/output/redis_test.go
@@ -46,7 +46,6 @@ buffer:
 	port 6379
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/s3_test.go
+++ b/pkg/sdk/logging/model/output/s3_test.go
@@ -47,7 +47,6 @@ buffer:
     s3_region eu-central-1
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 1m

--- a/pkg/sdk/logging/model/output/splunk_hec_test.go
+++ b/pkg/sdk/logging/model/output/splunk_hec_test.go
@@ -64,7 +64,6 @@ buffer:
 		sourcetype foo
 		<buffer tag,time>
 		  @type file
-		  chunk_limit_size 8MB
 		  path /buffers/test.*.buffer
 		  retry_forever true
 		  timekey 1m

--- a/pkg/sdk/logging/model/output/sqs_test.go
+++ b/pkg/sdk/logging/model/output/sqs_test.go
@@ -31,7 +31,6 @@ region: us-east-2
 buffer:
   flush_thread_count: 8
   flush_interval: 5s
-  chunk_limit_size: 8M
   queue_limit_length: 512
   retry_max_interval: 30
   retry_forever: true
@@ -45,7 +44,6 @@ buffer:
     region us-east-2
     <buffer tag,time>
       @type file
-      chunk_limit_size 8M
       flush_interval 5s
       flush_thread_count 8
       path /buffers/test.*.buffer

--- a/pkg/sdk/logging/model/output/sumologic_test.go
+++ b/pkg/sdk/logging/model/output/sumologic_test.go
@@ -48,7 +48,6 @@ buffer:
     source_name AppA
     <buffer tag,time>
       @type file
-	  chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 30s

--- a/pkg/sdk/logging/model/output/syslog_test.go
+++ b/pkg/sdk/logging/model/output/syslog_test.go
@@ -43,7 +43,6 @@ buffer:
 	port 123
 	<buffer tag,time>
 	  @type file
-	  chunk_limit_size 8MB
 	  path /buffers/test.*.buffer
 	  retry_forever true
 	  timekey 1m
@@ -80,7 +79,6 @@ buffer:
 	port 123
 	<buffer tag,time>
 	  @type file
-	  chunk_limit_size 8MB
 	  path /buffers/test.*.buffer
 	  retry_forever true
 	  timekey 1m
@@ -128,7 +126,6 @@ buffer:
 	version TLSv1_2
 	<buffer tag,time>
 	  @type file
-	  chunk_limit_size 8MB
 	  path /buffers/test.*.buffer
 	  retry_forever true
 	  timekey 1m

--- a/pkg/sdk/logging/model/output/vmware_log_intelligence_test.go
+++ b/pkg/sdk/logging/model/output/vmware_log_intelligence_test.go
@@ -55,7 +55,6 @@ buffer:
   <buffer tag,time>
 	@type file
 	chunk_limit_records 300
-	chunk_limit_size 8MB
 	flush_interval 3s
 	path /buffers/test.*.buffer
 	retry_forever true
@@ -100,7 +99,6 @@ buffer:
   <buffer tag,time>
 	@type file
 	chunk_limit_records 300
-	chunk_limit_size 8MB
 	flush_interval 3s
 	path /buffers/test.*.buffer
 	retry_forever true
@@ -147,7 +145,6 @@ format:
   <buffer tag,time>
 	@type file
 	chunk_limit_records 300
-	chunk_limit_size 8MB
 	flush_interval 3s
 	path /buffers/test.*.buffer
 	retry_forever true

--- a/pkg/sdk/logging/model/output/vmware_loginsight_test.go
+++ b/pkg/sdk/logging/model/output/vmware_loginsight_test.go
@@ -86,7 +86,6 @@ shorten_keys:
 	ssl_verify false
 	<buffer tag,time>
       @type file
-      chunk_limit_size 8MB
       path /buffers/test.*.buffer
       retry_forever true
       timekey 10m

--- a/pkg/sdk/logging/model/render/fluent_test.go
+++ b/pkg/sdk/logging/model/render/fluent_test.go
@@ -613,7 +613,6 @@ func TestRenderS3(t *testing.T) {
 						s3_object_key_format %{path}%{time_slice}_%{uuid_hash}_%{index}.%{file_extension}
 						<buffer tag,time>
 						@type file
-						chunk_limit_size 8MB
 						path asd
 						retry_forever true
 						timekey 10m
@@ -638,7 +637,6 @@ func TestRenderS3(t *testing.T) {
 						s3_object_key_format %{path}%{time_slice}_%{uuid_hash}_%{index}.%{file_extension}
         				<buffer tag,time>
 							@type file
-							chunk_limit_size 8MB
 							path /buffers/test.*.buffer
 							retry_forever true
 							timekey 10m
@@ -664,7 +662,6 @@ func TestRenderS3(t *testing.T) {
 						s3_object_key_format %{path}%{time_slice}_%{uuid_hash}_%{index}.%{file_extension}
         				<buffer tag,time>
 							@type file
-							chunk_limit_size 8MB
 							path /buffers/test.*.buffer
 							retry_forever true
 							timekey 10m
@@ -690,7 +687,6 @@ func TestRenderS3(t *testing.T) {
 						s3_object_key_format %{path}%H:%M_%{index}.%{file_extension}
 						<buffer tag,time,$.kubernetes.namespace_name,$.kubernetes.pod_name,$.kubernetes.container_name>
 						@type file
-						chunk_limit_size 8MB
 						path /buffers/test.*.buffer
 						retry_forever true
 						timekey 10m


### PR DESCRIPTION
We are changing the default value which had already been updated to a much saner default in fluentd to avoid creating an extensive number of small buffer chunks.

This isn't an intrusive breaking change, but should be highlighted in the release notes in case someone depended on this intentionally or accidentally.

Fixes #1099.