### PR TITLE
feat: protected clusteroutput for fluentd

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -5264,6 +5264,8 @@ spec:
                 - bucket
                 - endpoint
                 type: object
+              protected:
+                type: boolean
               redis:
                 properties:
                   allow_duplicate_key:
@@ -12196,6 +12198,8 @@ spec:
                 - bucket
                 - endpoint
                 type: object
+              protected:
+                type: boolean
               redis:
                 properties:
                   allow_duplicate_key:

--- a/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
@@ -5264,6 +5264,8 @@ spec:
                 - bucket
                 - endpoint
                 type: object
+              protected:
+                type: boolean
               redis:
                 properties:
                   allow_duplicate_key:
@@ -12196,6 +12198,8 @@ spec:
                 - bucket
                 - endpoint
                 type: object
+              protected:
+                type: boolean
               redis:
                 properties:
                   allow_duplicate_key:

--- a/controllers/logging/logging_controller_test.go
+++ b/controllers/logging/logging_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/utils"
 	"github.com/onsi/gomega"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -265,6 +266,85 @@ func TestSingleFlowWithClusterOutput(t *testing.T) {
 
 	secret := &corev1.Secret{}
 	defer ensureCreatedEventually(t, controlNamespace, logging.QualifiedName(fluentd.AppSecretConfigName), secret)()
+
+	err := mgr.GetClient().Get(context.TODO(), client.ObjectKeyFromObject(output), output)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, nil, output.Status.Active)
+	assert.True(t, *output.Status.Active)
+
+	errFlow := mgr.GetClient().Get(context.TODO(), client.ObjectKeyFromObject(flow), flow)
+	assert.NoError(t, errFlow)
+
+	assert.NotEqual(t, nil, flow.Status.Active)
+	// This is a protected output, so it should not be available
+	assert.True(t, *flow.Status.Active)
+
+	g.Expect(string(secret.Data[fluentd.AppConfigKey])).Should(gomega.ContainSubstring("a:b"))
+}
+
+func TestSingleFlowWithProtectedClusterOutput(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	defer beforeEach(t)()
+
+	logging := &v1beta1.Logging{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-" + uuid.New()[:8],
+		},
+		Spec: v1beta1.LoggingSpec{
+			WatchNamespaces:         []string{testNamespace},
+			FluentdSpec:             &v1beta1.FluentdSpec{},
+			FlowConfigCheckDisabled: true,
+			ControlNamespace:        controlNamespace,
+		},
+	}
+
+	output := &v1beta1.ClusterOutput{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-cluster-output",
+			Namespace: controlNamespace,
+		},
+		Spec: v1beta1.ClusterOutputSpec{
+			Protected: true,
+			OutputSpec: v1beta1.OutputSpec{
+				NullOutputConfig: output.NewNullOutputConfig(),
+			},
+		},
+	}
+
+	flow := &v1beta1.Flow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-flow",
+			Namespace: testNamespace,
+		},
+		Spec: v1beta1.FlowSpec{
+			Selectors: map[string]string{
+				"a": "b",
+			},
+			GlobalOutputRefs: []string{"test-cluster-output"},
+		},
+	}
+
+	defer ensureCreated(t, logging)()
+	defer ensureCreated(t, output)()
+	defer ensureCreated(t, flow)()
+
+	secret := &corev1.Secret{}
+	defer ensureCreatedEventually(t, controlNamespace, logging.QualifiedName(fluentd.AppSecretConfigName), secret)()
+
+	err := mgr.GetClient().Get(context.TODO(), client.ObjectKeyFromObject(output), output)
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, nil, output.Status.Active)
+	// This is a protected output, so it should not be available
+	assert.False(t, *output.Status.Active)
+
+	errFlow := mgr.GetClient().Get(context.TODO(), client.ObjectKeyFromObject(flow), flow)
+	assert.NoError(t, errFlow)
+
+	assert.NotEqual(t, nil, flow.Status.Active)
+	// This is a protected output, so it should not be available
+	assert.False(t, *flow.Status.Active)
 
 	g.Expect(string(secret.Data[fluentd.AppConfigKey])).Should(gomega.ContainSubstring("a:b"))
 }

--- a/docs/configuration/crds/v1beta1/clusteroutput_types.md
+++ b/docs/configuration/crds/v1beta1/clusteroutput_types.md
@@ -31,6 +31,9 @@ ClusterOutputSpec contains Kubernetes spec for ClusterOutput
 ### enabledNamespaces ([]string, optional) {#clusteroutputspec-enablednamespaces}
 
 
+### protected (bool, optional) {#clusteroutputspec-protected}
+
+
 
 ## ClusterOutputList
 

--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -142,7 +142,7 @@ func NewValidationReconciler(
 			}
 
 			for _, ref := range flow.Spec.GlobalOutputRefs {
-				if output := resources.Fluentd.ClusterOutputs.FindByName(ref); output != nil {
+				if output := resources.Fluentd.ClusterOutputs.FindByName(ref); output != nil && !output.Spec.Protected {
 					flow.Status.Active = utils.BoolPointer(true)
 					output.Status.Active = utils.BoolPointer(true)
 				} else {

--- a/pkg/resources/model/system.go
+++ b/pkg/resources/model/system.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/secret"
 	"github.com/cisco-open/operator-tools/pkg/utils"
 	"github.com/go-logr/logr"
+
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/common"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/input"
@@ -269,6 +270,10 @@ func FlowForFlow(flow v1beta1.Flow, clusterOutputs ClusterOutputs, outputs Outpu
 	var allOutputs []types.Output
 	for _, outputRef := range flow.Spec.GlobalOutputRefs {
 		if clusterOutput := clusterOutputs.FindByName(outputRef); clusterOutput != nil {
+			if clusterOutput.Spec.Protected {
+				errs = errors.Append(errs, errors.WrapIff(err, "referenced clusteroutput is protected %s", outputRef))
+				continue
+			}
 			outputID := fmt.Sprintf("%s:clusteroutput:%s:%s", flowID, clusterOutput.Namespace, clusterOutput.Name)
 			plugin, err := plugins.CreateOutput(clusterOutput.Spec.OutputSpec, outputID, secrets.OutputSecretLoaderForNamespace(clusterOutput.Namespace))
 			if err != nil {

--- a/pkg/sdk/logging/api/v1beta1/clusteroutput_types.go
+++ b/pkg/sdk/logging/api/v1beta1/clusteroutput_types.go
@@ -48,6 +48,7 @@ type ClusterOutput struct {
 // ClusterOutputSpec contains Kubernetes spec for ClusterOutput
 type ClusterOutputSpec struct {
 	OutputSpec        `json:",inline"`
+	Protected         bool     `json:"protected,omitempty"`
 	EnabledNamespaces []string `json:"enabledNamespaces,omitempty"`
 }
 


### PR DESCRIPTION
Protected output flag for ClusterOutputs to disable references from namespaced flows. Docs will need to be updated.

fixes #1709 