### PR TITLE
Forward output time_as_integer

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -2206,6 +2206,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -9405,6 +9407,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
@@ -2202,6 +2202,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -8693,6 +8695,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:

--- a/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
@@ -2206,6 +2206,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -9405,6 +9407,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:

--- a/config/crd/bases/logging.banzaicloud.io_outputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_outputs.yaml
@@ -2202,6 +2202,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:
@@ -8693,6 +8695,8 @@ spec:
                     type: array
                   slow_flush_log_threshold:
                     type: string
+                  time_as_integer:
+                    type: boolean
                   tls_allow_self_signed_cert:
                     type: boolean
                   tls_cert_logical_store_name:

--- a/docs/configuration/plugins/outputs/forward.md
+++ b/docs/configuration/plugins/outputs/forward.md
@@ -111,6 +111,11 @@ Default: 60
 The threshold for chunk flush performance check. Parameter type is float, not time, default: 20.0 (seconds) If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count. 
 
 
+### time_as_integer (bool, optional) {#forwardoutput-time_as_integer}
+
+Format forwarded events time as an epoch Integer with second resolution. Useful when forwarding to old ( <= 0.12 ) Fluentd servers. 
+
+
 ### tls_allow_self_signed_cert (bool, optional) {#forwardoutput-tls_allow_self_signed_cert}
 
 Allow self signed certificates or not.

--- a/pkg/sdk/logging/model/output/forward.go
+++ b/pkg/sdk/logging/model/output/forward.go
@@ -104,6 +104,8 @@ type ForwardOutput struct {
 	// Parameter type is float, not time, default: 20.0 (seconds)
 	// If chunk flush takes longer time than this threshold, fluentd logs warning message and increases metric fluentd_output_status_slow_flush_count.
 	SlowFlushLogThreshold string `json:"slow_flush_log_threshold,omitempty"`
+	// Format forwarded events time as an epoch Integer with second resolution. Useful when forwarding to old ( <= 0.12 ) Fluentd servers.
+	TimeAsInteger bool `json:"time_as_integer,omitempty"`
 }
 
 func (f *ForwardOutput) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {

--- a/pkg/sdk/logging/model/output/forward_test.go
+++ b/pkg/sdk/logging/model/output/forward_test.go
@@ -1,0 +1,80 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output_test
+
+import (
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForward(t *testing.T) {
+	CONFIG := []byte(`
+  servers: 
+    - host: 192.168.1.3
+      name: myserver1
+      port: 24224
+      weight: 60
+    - host: 192.168.1.4
+      name: myserver2
+      port: 24223
+      weight: 40
+  buffer:
+    timekey: 1m
+    timekey_wait: 30s
+    timekey_use_utc: true
+  keepalive: true
+  keepalive_timeout: 20
+  time_as_integer: true
+  send_timeout: 60
+`)
+	expected := `
+  <match **>
+    @type forward
+    @id test
+    keepalive true
+    keepalive_timeout 20
+    send_timeout 60
+    time_as_integer true
+    <buffer tag,time>
+      @type file
+      path /buffers/test.*.buffer
+      retry_forever true
+      timekey 1m
+      timekey_use_utc true
+      timekey_wait 30s
+    </buffer>
+    <server>
+      host 192.168.1.3
+      name myserver1
+      port 24224
+      weight 60
+    </server>
+    <server>
+      host 192.168.1.4
+      name myserver2
+      port 24223
+      weight 40
+    </server>
+  </match>
+`
+	g := &output.ForwardOutput{}
+	require.NoError(t, yaml.Unmarshal(CONFIG, g))
+	test := render.NewOutputPluginTest(t, g)
+	test.DiffResult(expected)
+}


### PR DESCRIPTION
This PR adds support for the time_as_integer configuration parameter to the Forward Output. 
It inclused the addition of a simple test case for the Forward Output.

As specified in the fluentd 0.14 release notes ( https://www.fluentd.org/blog/fluentd-v0.14.0-has-been-released ), when this parameter is set to "true", the events are forwarded formatting the event time as an epoch integer, using second resolution. 
If false, which is the default value, the events are sent as binary data with nanosecond resolution, which crashes old Fluentd versions. 

In some occurrences, this settings can also be useful to forward events to Logstash instances,
because Logstash' "fluent" codec by default is not compatible with the nanosecond resolution binary data that comes from Fluentd. 