### PR TITLE
fluentbit: net.max_worker_connections

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
@@ -1653,6 +1653,8 @@ spec:
                   keepaliveMaxRecycle:
                     format: int32
                     type: integer
+                  maxWorkerConnections:
+                    type: integer
                   sourceAddress:
                     type: string
                 type: object

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -2670,6 +2670,8 @@ spec:
                       keepaliveMaxRecycle:
                         format: int32
                         type: integer
+                      maxWorkerConnections:
+                        type: integer
                       sourceAddress:
                         type: string
                     type: object
@@ -11205,6 +11207,8 @@ spec:
                               type: integer
                             keepaliveMaxRecycle:
                               format: int32
+                              type: integer
+                            maxWorkerConnections:
                               type: integer
                             sourceAddress:
                               type: string

--- a/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
@@ -4066,6 +4066,8 @@ spec:
                       keepaliveMaxRecycle:
                         format: int32
                         type: integer
+                      maxWorkerConnections:
+                        type: integer
                       sourceAddress:
                         type: string
                     type: object

--- a/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
@@ -1653,6 +1653,8 @@ spec:
                   keepaliveMaxRecycle:
                     format: int32
                     type: integer
+                  maxWorkerConnections:
+                    type: integer
                   sourceAddress:
                     type: string
                 type: object

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -2670,6 +2670,8 @@ spec:
                       keepaliveMaxRecycle:
                         format: int32
                         type: integer
+                      maxWorkerConnections:
+                        type: integer
                       sourceAddress:
                         type: string
                     type: object
@@ -11205,6 +11207,8 @@ spec:
                               type: integer
                             keepaliveMaxRecycle:
                               format: int32
+                              type: integer
+                            maxWorkerConnections:
                               type: integer
                             sourceAddress:
                               type: string

--- a/config/crd/bases/logging.banzaicloud.io_nodeagents.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_nodeagents.yaml
@@ -4066,6 +4066,8 @@ spec:
                       keepaliveMaxRecycle:
                         format: int32
                         type: integer
+                      maxWorkerConnections:
+                        type: integer
                       sourceAddress:
                         type: string
                     type: object

--- a/config/samples/syslog-ng-simple.yaml
+++ b/config/samples/syslog-ng-simple.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   controlNamespace: default
   fluentbit: {}
+#    network:
+#      maxWorkerConnections: 2
+#    syslogng_output:
+#      Workers: 5
   syslogNG:
     globalOptions:
       log_level: trace

--- a/docs/configuration/crds/v1beta1/fluentbit_types.md
+++ b/docs/configuration/crds/v1beta1/fluentbit_types.md
@@ -313,6 +313,12 @@ How many times a TCP keepalive connection can be used before being recycled
 
 Default: 0, disabled
 
+### maxWorkerConnections (int, optional) {#fluentbitnetwork-maxworkerconnections}
+
+Set maximum number of TCP connections that can be established per worker.
+
+Default: 0, unlimited
+
 ### sourceAddress (string, optional) {#fluentbitnetwork-sourceaddress}
 
 Specify network address (interface) to use for connection and data traffic.

--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -185,6 +185,9 @@ var fluentbitNetworkTemplate = `
     {{- if .Network.SourceAddress }}
     net.source_address {{ .Network.SourceAddress }}
     {{- end }}
+    {{- if .Network.MaxWorkerConnections }}
+    net.max_worker_connections {{ .Network.MaxWorkerConnections }}
+    {{- end }}
     {{- end }}
 `
 

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -125,6 +125,7 @@ type FluentbitNetwork struct {
 	KeepaliveMaxRecycleSet    bool
 	KeepaliveMaxRecycle       uint32
 	SourceAddress             string
+	MaxWorkerConnections      int
 }
 
 // https://docs.fluentbit.io/manual/pipeline/outputs/tcp-and-tls
@@ -186,6 +187,10 @@ func newFluentbitNetwork(network v1beta1.FluentbitNetwork) (result FluentbitNetw
 
 	if network.SourceAddress != "" {
 		result.SourceAddress = network.SourceAddress
+	}
+
+	if network.MaxWorkerConnections != 0 {
+		result.MaxWorkerConnections = network.MaxWorkerConnections
 	}
 	return
 }

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -175,6 +175,8 @@ type FluentbitNetwork struct {
 	KeepaliveMaxRecycle *uint32 `json:"keepaliveMaxRecycle,omitempty"`
 	// Specify network address (interface) to use for connection and data traffic. (default: disabled)
 	SourceAddress string `json:"sourceAddress,omitempty"`
+	// Set maximum number of TCP connections that can be established per worker. (default: 0, unlimited)
+	MaxWorkerConnections int `json:"maxWorkerConnections,omitempty"`
 }
 
 // GetPrometheusPortFromAnnotation gets the port value from annotation


### PR DESCRIPTION
Add support for [max_worker_connections](https://docs.fluentbit.io/manual/administration/networking#:~:text=2000-,net.max_worker_connections,-Set%20maximum%20number) to limit the number of connections against an aggregator endpoint. Should be used together with workers, which is 2 by default according to [fluentbit docs](https://docs.fluentbit.io/manual/pipeline/outputs/tcp-and-tls#:~:text=double-,Workers,-Enables%20dedicated%20thread).

```
kind: FluentbitAgent
spec:
  network:
    maxWorkerConnections: 1
  syslogng_output:
    Workers: 1
```
