### PR TITLE
syslogng: render go templates in metrics-probe label values

### DIFF
--- a/config/samples/syslog-ng-custom-metrics.yaml
+++ b/config/samples/syslog-ng-custom-metrics.yaml
@@ -19,7 +19,13 @@ spec:
   outputMetrics:
     - key: custom_output
       labels:
-        destination: "{{.Destination.Name}}"
+        # destination, output_name, output_namespace, output_scope (local/global) and logging are automatically populated
+        #
+        # set any of the above to empty if it needs to be left out completely:
+        # destination: ""
+        #
+        # value can be a go template which can access .Destination.Name, .Destination.Namespace. .Destination.Scope, .Destination.Logging:
+        # destination: "{{ .Destination.Name }}"
         flow: all1
   localOutputRefs:
     - http
@@ -35,7 +41,6 @@ spec:
   outputMetrics:
     - key: custom_output
       labels:
-        destination: "{{.Destination.Name}}"
         flow: all2
   globalOutputRefs:
     - http2

--- a/config/samples/syslog-ng-custom-metrics.yaml
+++ b/config/samples/syslog-ng-custom-metrics.yaml
@@ -19,6 +19,7 @@ spec:
   outputMetrics:
     - key: custom_output
       labels:
+        destination: "{{.Destination.Name}}"
         flow: all1
   localOutputRefs:
     - http
@@ -34,6 +35,7 @@ spec:
   outputMetrics:
     - key: custom_output
       labels:
+        destination: "{{.Destination.Name}}"
         flow: all2
   globalOutputRefs:
     - http2

--- a/pkg/sdk/logging/model/syslogng/config/config_test.go
+++ b/pkg/sdk/logging/model/syslogng/config/config_test.go
@@ -251,7 +251,8 @@ log {
     log {
         parser {
             metrics-probe(key("example") labels(
-                "logging" => "test"
+                "destination" => "test-syslog-out-global"
+				"logging" => "test"
 				"output_name" => "test-syslog-out-global"
 				"output_namespace" => "config-test"
 				"output_scope" => "global"
@@ -262,6 +263,7 @@ log {
     log {
         parser {
             metrics-probe(key("example") labels(
+				"destination" => "test-syslog-out"
 				"logging" => "test"
                 "output_name" => "test-syslog-out"
 				"output_namespace" => "default"

--- a/pkg/sdk/logging/model/syslogng/config/flow.go
+++ b/pkg/sdk/logging/model/syslogng/config/flow.go
@@ -62,11 +62,11 @@ func renderClusterFlow(logging string, clusterOutputRefs map[string]types.Namesp
 			)),
 			seqs.ToSlice(seqs.Map(seqs.FromSlice(f.Spec.GlobalOutputRefs), func(ref string) destination {
 				return destination{
-					logging:          logging,
+					Logging:          logging,
 					renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].Namespace, ref),
 					Namespace:        clusterOutputRefs[ref].Namespace,
 					Name:             ref,
-					scope:            Global,
+					Scope:            Global,
 					metricsProbes:    f.Spec.OutputMetrics,
 				}
 			})),
@@ -103,21 +103,21 @@ func renderFlow(logging string, clusterOutputRefs map[string]types.NamespacedNam
 			seqs.ToSlice(seqs.Concat(
 				seqs.Map(seqs.FromSlice(f.Spec.GlobalOutputRefs), func(ref string) destination {
 					return destination{
-						logging:          logging,
+						Logging:          logging,
 						renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].Namespace, ref),
 						Namespace:        clusterOutputRefs[ref].Namespace,
 						Name:             ref,
-						scope:            Global,
+						Scope:            Global,
 						metricsProbes:    f.Spec.OutputMetrics,
 					}
 				}),
 				seqs.Map(seqs.FromSlice(f.Spec.LocalOutputRefs), func(ref string) destination {
 					return destination{
-						logging:          logging,
+						Logging:          logging,
 						renderedDestName: outputDestName(f.Namespace, ref),
 						Namespace:        f.Namespace,
 						Name:             ref,
-						scope:            Local,
+						Scope:            Local,
 						metricsProbes:    f.Spec.OutputMetrics,
 					}
 				}),

--- a/pkg/sdk/logging/model/syslogng/config/flow.go
+++ b/pkg/sdk/logging/model/syslogng/config/flow.go
@@ -64,8 +64,8 @@ func renderClusterFlow(logging string, clusterOutputRefs map[string]types.Namesp
 				return destination{
 					logging:          logging,
 					renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].Namespace, ref),
-					namespace:        clusterOutputRefs[ref].Namespace,
-					name:             ref,
+					Namespace:        clusterOutputRefs[ref].Namespace,
+					Name:             ref,
 					scope:            Global,
 					metricsProbes:    f.Spec.OutputMetrics,
 				}
@@ -105,8 +105,8 @@ func renderFlow(logging string, clusterOutputRefs map[string]types.NamespacedNam
 					return destination{
 						logging:          logging,
 						renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].Namespace, ref),
-						namespace:        clusterOutputRefs[ref].Namespace,
-						name:             ref,
+						Namespace:        clusterOutputRefs[ref].Namespace,
+						Name:             ref,
 						scope:            Global,
 						metricsProbes:    f.Spec.OutputMetrics,
 					}
@@ -115,8 +115,8 @@ func renderFlow(logging string, clusterOutputRefs map[string]types.NamespacedNam
 					return destination{
 						logging:          logging,
 						renderedDestName: outputDestName(f.Namespace, ref),
-						namespace:        f.Namespace,
-						name:             ref,
+						Namespace:        f.Namespace,
+						Name:             ref,
 						scope:            Local,
 						metricsProbes:    f.Spec.OutputMetrics,
 					}

--- a/pkg/sdk/logging/model/syslogng/config/log.go
+++ b/pkg/sdk/logging/model/syslogng/config/log.go
@@ -34,11 +34,11 @@ const (
 )
 
 type destination struct {
-	logging          string
+	Logging          string
 	renderedDestName string
 	Namespace        string
 	Name             string
-	scope            refScope
+	Scope            refScope
 	metricsProbes    []filter.MetricsProbe
 }
 
@@ -72,10 +72,23 @@ func destinationLogPath(dest destination) render.Renderer {
 		if m.Labels == nil {
 			m.Labels = make(filter.ArrowMap)
 		}
-		m.Labels["output_name"] = dest.Name
-		m.Labels["output_namespace"] = dest.Namespace
-		m.Labels["output_scope"] = string(dest.scope)
-		m.Labels["logging"] = dest.logging
+		if v, ok := m.Labels["destination"]; !ok || v != "" {
+			// syslog-ng terminology for output
+			m.Labels["destination"] = dest.Name
+		}
+		if v, ok := m.Labels["output_name"]; !ok || v != "" {
+			// logging-operator terminology for output
+			m.Labels["output_name"] = dest.Name
+		}
+		if v, ok := m.Labels["output_namespace"]; !ok || v != "" {
+			m.Labels["output_namespace"] = dest.Namespace
+		}
+		if v, ok := m.Labels["output_scope"]; !ok || v != "" {
+			m.Labels["output_scope"] = string(dest.Scope)
+		}
+		if v, ok := m.Labels["logging"]; !ok || v != "" {
+			m.Labels["logging"] = dest.Logging
+		}
 		metricsProbesRenderer = append(metricsProbesRenderer, renderDriver(Field{
 			Value: reflect.ValueOf(m),
 		}, nil))

--- a/pkg/sdk/logging/model/syslogng/config/log.go
+++ b/pkg/sdk/logging/model/syslogng/config/log.go
@@ -15,9 +15,12 @@
 package config
 
 import (
+	"bytes"
 	"reflect"
+	"text/template"
 
 	"github.com/siliconbrain/go-seqs/seqs"
+	"golang.org/x/exp/maps"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/config/render"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
@@ -33,8 +36,8 @@ const (
 type destination struct {
 	logging          string
 	renderedDestName string
-	namespace        string
-	name             string
+	Namespace        string
+	Name             string
 	scope            refScope
 	metricsProbes    []filter.MetricsProbe
 }
@@ -63,11 +66,14 @@ func destinationLogPath(dest destination) render.Renderer {
 	}
 	metricsProbesRenderer := make([]render.Renderer, len(dest.metricsProbes))
 	for _, m := range dest.metricsProbes {
+		m.Labels = renderLabelGoTemplates(m.Labels, struct {
+			Destination destination
+		}{dest})
 		if m.Labels == nil {
 			m.Labels = make(filter.ArrowMap)
 		}
-		m.Labels["output_name"] = dest.name
-		m.Labels["output_namespace"] = dest.namespace
+		m.Labels["output_name"] = dest.Name
+		m.Labels["output_namespace"] = dest.Namespace
 		m.Labels["output_scope"] = string(dest.scope)
 		m.Labels["logging"] = dest.logging
 		metricsProbesRenderer = append(metricsProbesRenderer, renderDriver(Field{
@@ -79,4 +85,21 @@ func destinationLogPath(dest destination) render.Renderer {
 		parserDefStmt("", render.AllOf(metricsProbesRenderer...)),
 		parenDefStmt("destination", render.Literal(dest.renderedDestName))),
 	)
+}
+
+func renderLabelGoTemplates(labels filter.ArrowMap, values any) filter.ArrowMap {
+	for k, v := range maps.Clone(labels) {
+		tpl, err := template.New("label").Parse(v)
+		if err != nil {
+			continue
+		}
+
+		output := new(bytes.Buffer)
+		err = tpl.Execute(output, values)
+		if err != nil {
+			continue
+		}
+		labels[k] = output.String()
+	}
+	return labels
 }


### PR DESCRIPTION
This PR adds flexibility in what label keys should be used automatically for output metrics, also adds the ability to use go templates that receives the destination information (name, namespace, scope:local/global and the logging name) to be used as needed. Example:
```
apiVersion: logging.banzaicloud.io/v1beta1
kind: SyslogNGClusterFlow
metadata:
  name: all
spec:
  match: {}
  outputMetrics:
    - key: custom_output
      labels:
        flow: all
        # define your own label for output name
        my-key-for-the-output: "{{ .Destination.Name }}"
        # do not add the output_name label to the metric
        output_name: ""
  globalOutputRefs:
    - http
```