### PR TITLE
fix: added missing log section inside system config 

### DIFF
--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -34,7 +34,9 @@ var fluentdInputTemplate = `
 <system>
   rpc_endpoint 127.0.0.1:24444
   {{- if .LogFormat }}
-  format {{ .LogFormat }}
+  <log>
+    format {{ .LogFormat }}
+  </log>
   {{- end }}
   log_level {{ .LogLevel }}
   workers {{ .Workers }}


### PR DESCRIPTION
The new feature logFormat text | json did not work as expected.

This is caused by a misconfiguration inside the system config section. This pull request fix the issue.

For further information see https://docs.fluentd.org/deployment/system-config#less-than-log-greater-than-section