### PR TITLE
Remove obsolete config samples for multitenant workers

### DIFF
--- a/config/samples/multitenant-routing-2/logging/tenant-infra-logging.yaml
+++ b/config/samples/multitenant-routing-2/logging/tenant-infra-logging.yaml
@@ -34,10 +34,6 @@ spec:
   loggingRef: infra
   inputTail:
     storage.type: filesystem
-  forwardOptions:
-    Workers: 0
-  syslogng_output:
-    Workers: 0
   positiondb:
     hostPath:
       path: ""

--- a/config/samples/syslog-ng-simple.yaml
+++ b/config/samples/syslog-ng-simple.yaml
@@ -5,10 +5,14 @@ metadata:
 spec:
   controlNamespace: default
   fluentbit: {}
+# The below network configurations allow fluentbit to retry indefinitely on a limited number of connections
+# to avoid overloading the aggregator (syslog-ng in this case)
 #    network:
 #      maxWorkerConnections: 2
 #    syslogng_output:
-#      Workers: 5
+#      Workers: 2
+#    forwardOptions:
+#      Retry_Limit: "no_limits"
   syslogNG:
     globalOptions:
       log_level: trace

--- a/docs/logging-route.md
+++ b/docs/logging-route.md
@@ -92,14 +92,9 @@ metadata:
   name: ops
 spec:
   loggingRef: ops
-  forwardOptions:
-    Workers: 0
-  syslogng_output:
-    Workers: 0
 ```
 > Note: 
 > - `loggingRef`s are required here
-> - `Workers: 0` is a workaround so that the processing of all tenants (outputs) don't block if one or more tenant is unavailable
 
 And finally the logging route with a populated status:
 ```


### PR DESCRIPTION
By separating inputs for the different tenants, hacking with the workers configuration is now obsolete.