### PR TITLE
fix: direct map of fluentbit securitycontext options

### DIFF
--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -188,6 +188,8 @@ func newConfigMapReloader(spec *v1beta1.FluentbitSpec) corev1.Container {
 			Privileged:               spec.Security.SecurityContext.Privileged,
 			RunAsNonRoot:             spec.Security.SecurityContext.RunAsNonRoot,
 			SELinuxOptions:           spec.Security.SecurityContext.SELinuxOptions,
+			SeccompProfile:           spec.Security.SecurityContext.SeccompProfile,
+			Capabilities:             spec.Security.SecurityContext.Capabilities,
 		}
 	}
 

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -332,6 +332,7 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 				},
 			},
 			Resources: r.fluentbitSpec.BufferVolumeResources,
+			SecurityContext: r.fluentbitSpec.Security.SecurityContext,
 		}
 	}
 	return nil

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -171,7 +171,7 @@ func newConfigMapReloader(spec *v1beta1.FluentbitSpec) corev1.Container {
 	}
 
 	if spec.Security != nil {
-		c.SecurityContext = r.fluentbitSpec.Security.SecurityContext
+		c.SecurityContext = spec.Security.SecurityContext
 	}
 
 	return c

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -128,20 +128,11 @@ func (r *Reconciler) fluentbitContainer() *corev1.Container {
 		Ports:           r.generatePortsMetrics(),
 		Resources:       r.fluentbitSpec.Resources,
 		VolumeMounts:    r.generateVolumeMounts(),
-		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:                r.fluentbitSpec.Security.SecurityContext.RunAsUser,
-			RunAsNonRoot:             r.fluentbitSpec.Security.SecurityContext.RunAsNonRoot,
-			ReadOnlyRootFilesystem:   r.fluentbitSpec.Security.SecurityContext.ReadOnlyRootFilesystem,
-			AllowPrivilegeEscalation: r.fluentbitSpec.Security.SecurityContext.AllowPrivilegeEscalation,
-			Privileged:               r.fluentbitSpec.Security.SecurityContext.Privileged,
-			SELinuxOptions:           r.fluentbitSpec.Security.SecurityContext.SELinuxOptions,
-			SeccompProfile:           r.fluentbitSpec.Security.SecurityContext.SeccompProfile,
-			Capabilities:             r.fluentbitSpec.Security.SecurityContext.Capabilities,
-		},
-		Command:        args,
-		Env:            r.fluentbitSpec.EnvVars,
-		LivenessProbe:  r.fluentbitSpec.LivenessProbe,
-		ReadinessProbe: r.fluentbitSpec.ReadinessProbe,
+		SecurityContext: r.fluentbitSpec.Security.SecurityContext,
+		Command:         args,
+		Env:             r.fluentbitSpec.EnvVars,
+		LivenessProbe:   r.fluentbitSpec.LivenessProbe,
+		ReadinessProbe:  r.fluentbitSpec.ReadinessProbe,
 	}
 }
 
@@ -179,18 +170,8 @@ func newConfigMapReloader(spec *v1beta1.FluentbitSpec) corev1.Container {
 		VolumeMounts:    vm,
 	}
 
-	if spec.Security != nil && spec.Security.SecurityContext != nil {
-		c.SecurityContext = &corev1.SecurityContext{
-			RunAsUser:                spec.Security.SecurityContext.RunAsUser,
-			RunAsGroup:               spec.Security.SecurityContext.RunAsGroup,
-			ReadOnlyRootFilesystem:   spec.Security.SecurityContext.ReadOnlyRootFilesystem,
-			AllowPrivilegeEscalation: spec.Security.SecurityContext.AllowPrivilegeEscalation,
-			Privileged:               spec.Security.SecurityContext.Privileged,
-			RunAsNonRoot:             spec.Security.SecurityContext.RunAsNonRoot,
-			SELinuxOptions:           spec.Security.SecurityContext.SELinuxOptions,
-			SeccompProfile:           spec.Security.SecurityContext.SeccompProfile,
-			Capabilities:             spec.Security.SecurityContext.Capabilities,
-		}
+	if spec.Security != nil {
+		c.SecurityContext = r.fluentbitSpec.Security.SecurityContext
 	}
 
 	return c

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -331,7 +331,7 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 					MountPath: r.fluentbitSpec.BufferStorage.StoragePath,
 				},
 			},
-			Resources: r.fluentbitSpec.BufferVolumeResources,
+			Resources:       r.fluentbitSpec.BufferVolumeResources,
 			SecurityContext: r.fluentbitSpec.Security.SecurityContext,
 		}
 	}

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -168,10 +168,7 @@ func newConfigMapReloader(spec *v1beta1.FluentbitSpec) corev1.Container {
 		Resources:       spec.ConfigHotReload.Resources,
 		Args:            args,
 		VolumeMounts:    vm,
-	}
-
-	if spec.Security != nil {
-		c.SecurityContext = spec.Security.SecurityContext
+		SecurityContext: spec.Security.SecurityContext,
 	}
 
 	return c


### PR DESCRIPTION
- Send whole fluentbit SecurityContext to fluentbit, configReloader and bufferVolumeMetrics containers