### PR TITLE
Make severity configurable in PrometheusRules

### DIFF
--- a/pkg/resources/fluentbit/buffervolumeprometheusrules.go
+++ b/pkg/resources/fluentbit/buffervolumeprometheusrules.go
@@ -45,7 +45,7 @@ func (r *Reconciler) bufferVolumePrometheusRules() (runtime.Object, reconciler.D
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentbit",
-						"severity":  "warning",
+						"severity":  r.fluentbitSpec.BufferVolumeMetrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Fluentbit buffer free capacity less than 10%.`,
@@ -59,7 +59,7 @@ func (r *Reconciler) bufferVolumePrometheusRules() (runtime.Object, reconciler.D
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentbit",
-						"severity":  "critical",
+						"severity":  r.fluentbitSpec.BufferVolumeMetrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Fluentbit buffer free capacity less than 5%.`,

--- a/pkg/resources/fluentbit/prometheusrules.go
+++ b/pkg/resources/fluentbit/prometheusrules.go
@@ -43,7 +43,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					For:   prometheus_operator.Duration("10m"),
 					Labels: map[string]string{
 						"service":  "fluentbit",
-						"severity": "warning",
+						"severity": r.fluentbitSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Fluentbit too many errors.`,

--- a/pkg/resources/fluentd/buffervolumeprometheusrules.go
+++ b/pkg/resources/fluentd/buffervolumeprometheusrules.go
@@ -45,7 +45,7 @@ func (r *Reconciler) bufferVolumePrometheusRules() (runtime.Object, reconciler.D
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "warning",
+						"severity":  r.fluentdSpec.BufferVolumeMetrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Fluentd buffer free capacity less than 10%.`,
@@ -59,7 +59,7 @@ func (r *Reconciler) bufferVolumePrometheusRules() (runtime.Object, reconciler.D
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "critical",
+						"severity":  r.fluentdSpec.BufferVolumeMetrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Fluentd buffer free capacity less than 5%.`,

--- a/pkg/resources/fluentd/prometheusrules.go
+++ b/pkg/resources/fluentd/prometheusrules.go
@@ -44,7 +44,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "critical",
+						"severity":  r.fluentdSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `fluentd cannot be scraped`,
@@ -58,7 +58,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "warning",
+						"severity":  r.fluentdSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `fluentd node are failing`,
@@ -72,7 +72,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "critical",
+						"severity":  r.fluentdSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `fluentd nodes buffer queue length are critical`,
@@ -86,7 +86,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "critical",
+						"severity":  r.fluentdSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `fluentd records count are critical`,
@@ -100,7 +100,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "warning",
+						"severity":  r.fluentdSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Fluentd retry count has been "{{ $value }}" for the last 10 minutes.`,
@@ -114,7 +114,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "warning",
+						"severity":  r.fluentdSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `There have been Fluentd output error(s) for the last 10 minutes.`,
@@ -128,7 +128,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "fluentd",
-						"severity":  "warning",
+						"severity":  r.fluentdSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Fluentd buffer size is predicted to increase more than 50% in the next 10 minutes.`,

--- a/pkg/resources/syslogng/buffervolumeprometheusrules.go
+++ b/pkg/resources/syslogng/buffervolumeprometheusrules.go
@@ -45,7 +45,7 @@ func (r *Reconciler) bufferVolumePrometheusRules() (runtime.Object, reconciler.D
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "warning",
+						"severity":  r.syslogNGSpec.BufferVolumeMetrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Syslog-NG buffer free capacity less than 10%.`,
@@ -59,7 +59,7 @@ func (r *Reconciler) bufferVolumePrometheusRules() (runtime.Object, reconciler.D
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "critical",
+						"severity":  r.syslogNGSpec.BufferVolumeMetrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Syslog-NG buffer free capacity less than 5%.`,

--- a/pkg/resources/syslogng/prometheusrules.go
+++ b/pkg/resources/syslogng/prometheusrules.go
@@ -45,7 +45,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "critical",
+						"severity":  r.syslogNGSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Syslog-NG cannot be scraped`,
@@ -59,7 +59,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "warning",
+						"severity":  r.syslogNGSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `syslog-ng node are failing`,
@@ -73,7 +73,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "critical",
+						"severity":  r.syslogNGSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Syslog-NG nodes buffer queue length are critical`,
@@ -87,7 +87,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "critical",
+						"severity":  r.syslogNGSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `syslog-ng records count are critical`,
@@ -101,7 +101,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "warning",
+						"severity":  r.syslogNGSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Syslog-NG retry count has been "{{ $value }}" for the last 10 minutes.`,
@@ -115,7 +115,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "warning",
+						"severity":  r.syslogNGSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `There have been syslog-ng output error(s) for the last 10 minutes.`,
@@ -129,7 +129,7 @@ func (r *Reconciler) prometheusRules() (runtime.Object, reconciler.DesiredState,
 					Labels: map[string]string{
 						"rulegroup": ruleGroupName,
 						"service":   "syslog-ng",
-						"severity":  "warning",
+						"severity":  r.syslogNGSpec.Metrics.Severity,
 					},
 					Annotations: map[string]string{
 						"summary":     `Syslog-NG buffer size prediction warning.`,

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -62,6 +62,7 @@ type Metrics struct {
 	ServiceMonitorConfig  ServiceMonitorConfig `json:"serviceMonitorConfig,omitempty"`
 	PrometheusAnnotations bool                 `json:"prometheusAnnotations,omitempty"`
 	PrometheusRules       bool                 `json:"prometheusRules,omitempty"`
+	Severity              string               `json:"severity,omitempty"`
 }
 
 // BufferMetrics defines the service monitor endpoints


### PR DESCRIPTION
Fixes #1749 

Made changes in ```pkg/sdk/logging/api/v1beta1/common_types.go``` to add a severity metrics in the Metrics struct and made changes in fluentbit, fluentd and syslog packages prometheusrules.go and buffervolumeprometheusrules.go .