### PR TITLE
Cleanup warnings

### DIFF
--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
@@ -52,6 +53,14 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
+
+var fluentbitWarning sync.Once
+var promCrdWarning sync.Once
+
+func init() {
+	fluentbitWarning = sync.Once{}
+	promCrdWarning = sync.Once{}
+}
 
 // NewLoggingReconciler returns a new LoggingReconciler instance
 func NewLoggingReconciler(client client.Client, eventRecorder record.EventRecorder, log logr.Logger) *LoggingReconciler {
@@ -100,18 +109,26 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
+	var missingCRDs []string
+
 	if err := r.Client.List(ctx, &v1.ServiceMonitorList{}); err == nil {
 		//nolint:staticcheck
 		ctx = context.WithValue(ctx, resources.ServiceMonitorKey, true)
 	} else {
-		log.Info("WARNING ServiceMonitor is not supported in the cluster")
+		missingCRDs = append(missingCRDs, "ServiceMonitor")
 	}
 
 	if err := r.Client.List(ctx, &v1.PrometheusRuleList{}); err == nil {
 		//nolint:staticcheck
 		ctx = context.WithValue(ctx, resources.PrometheusRuleKey, true)
 	} else {
-		log.Info("WARNING PrometheusRule is not supported in the cluster")
+		missingCRDs = append(missingCRDs, "PrometheusRule")
+	}
+
+	if len(missingCRDs) > 0 {
+		promCrdWarning.Do(func() {
+			log.Info(fmt.Sprintf("WARNING Prometheus Operator CRDs (%s) are not supported in the cluster", strings.Join(missingCRDs, ",")))
+		})
 	}
 
 	if err := logging.SetDefaults(); err != nil {
@@ -225,7 +242,9 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	case 0:
 		// check for legacy definition
 		if logging.Spec.FluentbitSpec != nil {
-			log.Info("WARNING fluentbit definition inside the Logging resource is deprecated and will be removed in the next major release")
+			fluentbitWarning.Do(func() {
+				log.Info("WARNING fluentbit definition inside the Logging resource is deprecated and will be removed in the next major release")
+			})
 			nameProvider := fluentbit.NewLegacyFluentbitNameProvider(&logging)
 			reconcilers = append(reconcilers, fluentbit.New(
 				r.Client,

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -573,9 +573,8 @@ func SetupLoggingWithManager(mgr ctrl.Manager, logger logr.Logger) *ctrl.Builder
 		Watches(&loggingv1beta1.FluentdConfig{}, requestMapper).
 		Watches(&loggingv1beta1.SyslogNGConfig{}, requestMapper)
 
-	// TODO remove with the next major release
+	// Deprecated: Node agents are deprecated and no longer maintained actively
 	if os.Getenv("ENABLE_NODEAGENT_CRD") != "" {
-		logger.Info("processing NodeAgent CRDs is explicitly disabled (enable: ENABLE_NODEAGENT_CRD=1)")
 		builder.Watches(&loggingv1beta1.NodeAgent{}, requestMapper)
 	}
 

--- a/docs/configuration/crds/v1beta1/fluentbit_types.md
+++ b/docs/configuration/crds/v1beta1/fluentbit_types.md
@@ -577,9 +577,9 @@ Default: On
 
 ### Buffer_Size (string, optional) {#filterkubernetes-buffer_size}
 
-Set the buffer size for HTTP client when reading responses from Kubernetes API server. The value must be according to the Unit Size specification. A value of 0 results in no limit, and the buffer will expand as-needed. Note that if pod specifications exceed the buffer limit, the API response will be discarded when retrieving metadata, and some kubernetes metadata will fail to be injected to the logs. If this value is empty we will set it "0".
+Set the buffer size for HTTP client when reading responses from Kubernetes API server. The value must be according to the Unit Size specification. A value of 0 results in no limit, and the buffer will expand as-needed. Note that if pod specifications exceed the buffer limit, the API response will be discarded when retrieving metadata, and some kubernetes metadata will fail to be injected to the logs. If this value is empty we will set it "0". (default:"0") 
 
-Default: "0"
+Default: 0
 
 ### Cache_Use_Docker_Id (string, optional) {#filterkubernetes-cache_use_docker_id}
 

--- a/docs/configuration/crds/v1beta1/loggingroute_types.md
+++ b/docs/configuration/crds/v1beta1/loggingroute_types.md
@@ -60,7 +60,7 @@ Enumerate all loggings with all the destination namespaces expanded
 
 ## LoggingRoute
 
-LoggingRoute (experimental)
+LoggingRoute
 Connects a log collector with log aggregators from other logging domains and routes relevant logs based on watch namespaces
 
 ###  (metav1.TypeMeta, required) {#loggingroute-}

--- a/docs/logging-route.md
+++ b/docs/logging-route.md
@@ -1,7 +1,5 @@
 ## Logging Route
 
-> Warning: Experimental feature
-
 A _Logging Route_ is responsible to define a global rule that instructs `FluentbitAgent` resources that belongs to the same
 `Logging` resource to route logs to different target `Logging` aggregators (fluentd or syslog-ng).
 

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -112,8 +112,6 @@ Cons:
 
 ### Hard multi-tenancy with a logging route
 
-> Warning: Experimental feature
-
 With the introduction of a `LoggingRoute` resource, it is now possible to route logs based on namespaces to different aggregators.
 
 A _logging route_ connects a collector (fluentbit) of one logging resource with the aggregators of other logging resources.

--- a/main.go
+++ b/main.go
@@ -221,6 +221,7 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+
 }
 
 func detectContainerRuntime(ctx context.Context, c client.Reader) error {

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -207,12 +207,6 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 	disableKubernetesFilter := r.fluentbitSpec.DisableKubernetesFilter != nil && *r.fluentbitSpec.DisableKubernetesFilter
 
 	if !disableKubernetesFilter {
-		if r.fluentbitSpec.FilterKubernetes.BufferSize == "" {
-			r.logger.Info("Notice: If the Buffer_Size value is empty we will set it 0. For more information: https://github.com/fluent/fluent-bit/issues/2111")
-			r.fluentbitSpec.FilterKubernetes.BufferSize = "0"
-		} else if r.fluentbitSpec.FilterKubernetes.BufferSize != "0" {
-			r.logger.Info("Notice: If the kubernetes filter buffer_size parameter is underestimated it can cause log loss. For more information: https://github.com/fluent/fluent-bit/issues/2111")
-		}
 		if r.fluentbitSpec.FilterKubernetes.K8SLoggingExclude == "" {
 			r.fluentbitSpec.FilterKubernetes.K8SLoggingExclude = "On"
 		}

--- a/pkg/resources/model/repository.go
+++ b/pkg/resources/model/repository.go
@@ -301,8 +301,8 @@ func (r LoggingResourceRepository) SyslogNGOutputsInNamespaceFor(ctx context.Con
 }
 
 func (r LoggingResourceRepository) NodeAgentsFor(ctx context.Context, logging v1beta1.Logging) ([]v1beta1.NodeAgent, error) {
+	// Deprecated: Node agents are deprecated and no longer maintained actively
 	if os.Getenv("ENABLE_NODEAGENT_CRD") == "" {
-		r.Logger.Info("processing NodeAgent CRDs is explicitly disabled (enable: ENABLE_NODEAGENT_CRD=1)")
 		return nil, nil
 	}
 

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -291,7 +291,7 @@ type FilterKubernetes struct {
 	// Match filtered records (default:kube.*)
 	Match string `json:"Match,omitempty" plugin:"default:kubernetes.*"`
 	// Set the buffer size for HTTP client when reading responses from Kubernetes API server. The value must be according to the Unit Size specification. A value of 0 results in no limit, and the buffer will expand as-needed. Note that if pod specifications exceed the buffer limit, the API response will be discarded when retrieving metadata, and some kubernetes metadata will fail to be injected to the logs. If this value is empty we will set it "0". (default:"0")
-	BufferSize string `json:"Buffer_Size,omitempty"`
+	BufferSize string `json:"Buffer_Size,omitempty" plugin:"default:0"`
 	// API Server end-point.
 	KubeURL string `json:"Kube_URL,omitempty" plugin:"default:https://kubernetes.default.svc:443"`
 	//	CA certificate file (default:/var/run/secrets/kubernetes.io/serviceaccount/ca.crt)

--- a/pkg/sdk/logging/api/v1beta1/loggingroute_types.go
+++ b/pkg/sdk/logging/api/v1beta1/loggingroute_types.go
@@ -65,7 +65,7 @@ type Tenant struct {
 // +kubebuilder:printcolumn:name="Notices",type="integer",JSONPath=".status.noticesCount",description="Number of notices"
 // +kubebuilder:storageversion
 
-// LoggingRoute (experimental)
+// LoggingRoute
 // Connects a log collector with log aggregators from other logging domains and routes relevant logs based on watch namespaces
 type LoggingRoute struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Keep meaningful warnings, but show them only once to avoid redundant log messages