### PR TITLE
fluentd-configcheck: disable inherited antiaffinity rules

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -272,7 +272,7 @@ func (r *Reconciler) newCheckPod(hashKey string, fluentdSpec v1beta1.FluentdSpec
 	}
 	if fluentdSpec.Affinity != nil && fluentdSpec.Affinity.PodAntiAffinity != nil {
 		r.Log.Info("pod anti-affinity has been disabled to avoid blocking configcheck pods accidentally")
-		fluentdSpec.Affinity.PodAntiAffinity = nil
+		pod.Spec.Affinity.PodAntiAffinity = nil
 	}
 	if fluentdSpec.ConfigCheckAnnotations != nil {
 		pod.Annotations = fluentdSpec.ConfigCheckAnnotations

--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -270,6 +270,10 @@ func (r *Reconciler) newCheckPod(hashKey string, fluentdSpec v1beta1.FluentdSpec
 			DNSConfig:          fluentdSpec.DNSConfig,
 		},
 	}
+	if fluentdSpec.Affinity != nil && fluentdSpec.Affinity.PodAntiAffinity != nil {
+		r.Log.Info("pod anti-affinity has been disabled to avoid blocking configcheck pods accidentally")
+		fluentdSpec.Affinity.PodAntiAffinity = nil
+	}
 	if fluentdSpec.ConfigCheckAnnotations != nil {
 		pod.Annotations = fluentdSpec.ConfigCheckAnnotations
 	}


### PR DESCRIPTION
Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>

Fixes https://github.com/kube-logging/logging-operator/issues/814