### PR TITLE
Log format compatibility

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1063,6 +1063,8 @@ spec:
                       type: string
                     type: array
                 type: object
+              enableDockerParserCompatibilityForCRI:
+                type: boolean
               enableRecreateWorkloadOnImmutableFieldChange:
                 type: boolean
               errorOutputRef:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -1063,6 +1063,8 @@ spec:
                       type: string
                     type: array
                 type: object
+              enableDockerParserCompatibilityForCRI:
+                type: boolean
               enableRecreateWorkloadOnImmutableFieldChange:
                 type: boolean
               errorOutputRef:

--- a/config/samples/containerd-log.yaml
+++ b/config/samples/containerd-log.yaml
@@ -22,12 +22,12 @@ spec:
   filters:
     # for debugging
     - stdout: {}
-    # automatic configuration should be overridden
-    - concat:
-        key: "log"
-    - parser:
-        key_name: "log"
-
+    # With `enableDockerParserCompatibilityForCRI: true` key and key_name are
+    # set to "log" otherwise these are set to "message" if the runtime is CRI
+    #- concat:
+    #    key: log
+    #- parser:
+    #    key_name: log
   match:
     - select: {}
   localOutputRefs:

--- a/config/samples/containerd-log.yaml
+++ b/config/samples/containerd-log.yaml
@@ -9,27 +9,10 @@ kind: Logging
 metadata:
   name: containerd
 spec:
+  enableDockerParserCompatibilityForCRI: true
   fluentd: {}
   controlNamespace: default
-  fluentbit:
-    inputTail:
-      Parser: cri-log-key
-    # Parser that populates `log` instead of `message` to enable the kubernetes filter's Merge_Log feature to parse json automatically
-    # Indentation is important
-    customParsers: |
-                    [PARSER]
-                        Name cri-log-key
-                        Format regex
-                        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
-                        Time_Key    time
-                        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    # Required key remap if one wants to rely on the existing auto-detected log key in the fluentd parser and concat filter
-    # otherwise should be omitted
-    filterModify:
-      - rules:
-        - Rename:
-            key: log
-            value: message
+  fluentbit: {}
 ---
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: Flow
@@ -37,7 +20,14 @@ metadata:
   name: all
 spec:
   filters:
+    # for debugging
     - stdout: {}
+    # automatic configuration should be overridden
+    - concat:
+        key: "log"
+    - parser:
+        key_name: "log"
+
   match:
     - select: {}
   localOutputRefs:

--- a/docs/configuration/crds/v1beta1/logging_types.md
+++ b/docs/configuration/crds/v1beta1/logging_types.md
@@ -34,6 +34,11 @@ Namespace for cluster wide configuration resources like ClusterFlow and ClusterO
 Default flow for unmatched logs. This Flow configuration collects all logs that didn't matched any other Flow. 
 
 
+### enableDockerParserCompatibilityForCRI (bool, optional) {#loggingspec-enabledockerparsercompatibilityforcri}
+
+EnableDockerParserCompatibilityForCRI enables a log parser that is compatible with the docker parser. This has the following benefits: - automatic json log parsing using the Merge_Log feature - downstream parsers can use the `log` field instead of `message` as they did with the docker runtime - the `concat` and `parser` filters are automatically set back to use the `log` field 
+
+
 ### enableRecreateWorkloadOnImmutableFieldChange (bool, optional) {#loggingspec-enablerecreateworkloadonimmutablefieldchange}
 
 EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future) in case there is a change in an immutable field that otherwise couldn't be managed with a simple update. 

--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -17,6 +17,7 @@ package fluentbit
 const BaseConfigName = "fluent-bit.conf"
 const UpstreamConfigName = "upstream.conf"
 const CustomParsersConfigName = "custom-parsers.conf"
+const CRIParserConfigName = "cri-log-parser.conf"
 const StockConfigPath = "/fluent-bit/etc"
 const StockBinPath = "/fluent-bit/bin/fluent-bit"
 const OperatorConfigPath = "/fluent-bit/etc-operator"
@@ -223,4 +224,13 @@ var upstreamConfigTemplate = `
     Host {{.Host}}
     Port {{.Port}}
 {{- end}}
+`
+
+var criParserConfig = `
+[PARSER]
+    Name cri-log-compatibility
+    Format regex
+    Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 `

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -286,8 +286,11 @@ func (r *Reconciler) statusUpdate(ctx context.Context, patchBase client.Patch, r
 }
 
 func (r *Reconciler) reconcileDrain(ctx context.Context) (*reconcile.Result, error) {
-	if r.fluentdSpec.DisablePvc || !r.fluentdSpec.Scaling.Drain.Enabled {
-		r.Log.Info("fluentd buffer draining is disabled")
+	if !r.fluentdSpec.Scaling.Drain.Enabled {
+		return nil, nil
+	}
+	if r.fluentdSpec.DisablePvc && r.fluentdSpec.Scaling.Drain.Enabled {
+		r.Log.Info("fluentd buffer draining cannot be enabled because PVC for the statefulSet is disabled")
 		return nil, nil
 	}
 

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -88,6 +88,7 @@ type LoggingSpec struct {
 	// This has the following benefits:
 	// - automatic json log parsing using the Merge_Log feature
 	// - downstream parsers can use the `log` field instead of `message` as they did with the docker runtime
+	// - the `concat` and `parser` filters are automatically set back to use the `log` field
 	EnableDockerParserCompatibilityForCRI bool `json:"enableDockerParserCompatibilityForCRI,omitempty"`
 }
 

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -84,6 +84,11 @@ type LoggingSpec struct {
 	// in case there is a change in an immutable field
 	// that otherwise couldn't be managed with a simple update.
 	EnableRecreateWorkloadOnImmutableFieldChange bool `json:"enableRecreateWorkloadOnImmutableFieldChange,omitempty"`
+	// EnableDockerParserCompatibilityForCRI enables a log parser that is compatible with the docker parser.
+	// This has the following benefits:
+	// - automatic json log parsing using the Merge_Log feature
+	// - downstream parsers can use the `log` field instead of `message` as they did with the docker runtime
+	EnableDockerParserCompatibilityForCRI bool `json:"enableDockerParserCompatibilityForCRI,omitempty"`
 }
 
 type ConfigCheckStrategy string

--- a/pkg/sdk/logging/model/filter/concat.go
+++ b/pkg/sdk/logging/model/filter/concat.go
@@ -125,7 +125,11 @@ func (c *Concat) ToDirective(secretLoader secret.SecretLoader, id string) (types
 	}
 	concatConfig := c.DeepCopy()
 	if concatConfig.Key == "" {
-		concatConfig.Key = types.GetLogKey()
+		if logKeyProvider, ok := secretLoader.(types.LogKeyProvider); ok {
+			concatConfig.Key = logKeyProvider.GetLogKey()
+		} else {
+			concatConfig.Key = types.GetLogKey()
+		}
 	}
 	if params, err := types.NewStructToStringMapper(secretLoader).StringsMap(concatConfig); err != nil {
 		return nil, err

--- a/pkg/sdk/logging/model/filter/parser.go
+++ b/pkg/sdk/logging/model/filter/parser.go
@@ -19,6 +19,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/secret"
+
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/types"
 )
 
@@ -341,7 +342,11 @@ func (p *ParserConfig) ToDirective(secretLoader secret.SecretLoader, id string) 
 	parserConfig := p.DeepCopy()
 
 	if parserConfig.KeyName == "" {
-		parserConfig.KeyName = types.GetLogKey()
+		if logKeyProvider, ok := secretLoader.(types.LogKeyProvider); ok {
+			parserConfig.KeyName = logKeyProvider.GetLogKey()
+		} else {
+			parserConfig.KeyName = types.GetLogKey()
+		}
 	}
 	if params, err := types.NewStructToStringMapper(secretLoader).StringsMap(parserConfig); err != nil {
 		return nil, err

--- a/pkg/sdk/logging/model/types/types.go
+++ b/pkg/sdk/logging/model/types/types.go
@@ -23,6 +23,10 @@ import (
 
 var ContainerRuntime = "containerd"
 
+type LogKeyProvider interface {
+	GetLogKey() string
+}
+
 func GetLogKey() string {
 	switch ContainerRuntime {
 	case "docker":

--- a/pkg/sdk/logging/plugins/plugin.go
+++ b/pkg/sdk/logging/plugins/plugin.go
@@ -19,6 +19,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/secret"
+
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/types"
 )


### PR DESCRIPTION
Add support for the automatic configuration of docker compatible log parsing with the CRI log format. 

This has the following benefits:
- automatic json log parsing can happen using the Merge_Log Fluent Bit kubernetes filter
- downstream parsers can use the `log` field instead of `message` as they did with the docker runtime
- the `concat` and `parser` filters are automatically set back to use the `log` field instead of `message`

The example in the PR demonstrates a working configuration:
```
apiVersion: logging.banzaicloud.io/v1beta1
kind: Logging
metadata:
  name: containerd
spec:
  enableDockerParserCompatibilityForCRI: true
```

After this, fluentbit can be configured through either the Logging or the FluentbitAgent resource. (Fluentbit configured through the `nodeAgents` field of the Logging resource is not supported, since nodeAgents are deprecated)

Example log line produced:
```
{
  "log": "2024-08-12T14:19:29.672991171Z stderr F [2024/08/12 14:19:29] [ info] [input:tail:tail.0] inotify_fs_add(): inode=2939617 watch_fd=17 name=/var/log/containers/containerd-fluentd-0_default_fluentd-e46f1fcb1b63e7458fc43c079b7455f8e1305e551939ca128361a9574a194ed7.log",
  "kubernetes": {
    "pod_name": "containerd-fluentbit-mchwz",
    "namespace_name": "default",
    "pod_id": "22f86078-26f1-4202-bbc7-1dd5ddce20ec",
    "labels": {
      "app.kubernetes.io/instance": "containerd",
      "app.kubernetes.io/managed-by": "containerd",
      "app.kubernetes.io/name": "fluentbit",
      "controller-revision-hash": "6bb6f7f5f4",
      "pod-template-generation": "2"
    },
    "annotations": {
      "checksum/cri-log-parser.conf": "d902a0ee964e9398e637b581be851cdf50ab2846e82003d2f5e2feef82bef95d",
      "checksum/fluent-bit.conf": "dc9727d915c447b414dc05df2d9a6f23246cdca345309eb3107cc16ae8369b53"
    },
    "host": "logging",
    "container_name": "fluent-bit",
    "docker_id": "5cf032406344fdf41d76ce4489ee6f3ca092e9207ec49ab6209cc2bcf950e593",
    "container_image": "fluent/fluent-bit:3.0.4"
  }
}
```
