### PR TITLE
Enable kubernetes namespace labels added to the metadata by default

### DIFF
--- a/docs/configuration/crds/v1beta1/fluentbit_types.md
+++ b/docs/configuration/crds/v1beta1/fluentbit_types.md
@@ -723,6 +723,7 @@ Configurable TTL for K8s cached namespace metadata. (15m)
 
 Include Kubernetes namespace labels on every record 
 
+Default: On
 
 ### Regex_Parser (string, optional) {#filterkubernetes-regex_parser}
 

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -97,8 +97,8 @@ func TestFluentdAggregator_NamespaceLabel(t *testing.T) {
 						Keepalive: utils.BoolPointer(false),
 					},
 					FilterKubernetes: v1beta1.FilterKubernetes{
-						// Namespace labels enrichment must be enabled explicitly for now
-						NamespaceLabels: "On",
+						// Namespace labels enrichment is enabled by default starting with version 4.9
+						// NamespaceLabels: "On",
 					},
 				},
 				FluentdSpec: &v1beta1.FluentdSpec{

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -333,7 +333,7 @@ type FilterKubernetes struct {
 	// Include Kubernetes resource annotations in the extra metadata. (default:On)
 	Annotations string `json:"Annotations,omitempty"`
 	// Include Kubernetes namespace labels on every record
-	NamespaceLabels string `json:"namespace_labels,omitempty"`
+	NamespaceLabels string `json:"namespace_labels,omitempty" plugin:"default:On"`
 	// Include Kubernetes namespace annotations on every record
 	NamespaceAnnotations string `json:"namespace_annotations,omitempty"`
 	// Configurable TTL for K8s cached namespace metadata. (15m)


### PR DESCRIPTION
Signed-off-by: Peter Wilcsinszky <peter.wilcsinszky@axoflow.com>