### PR TITLE
chore: replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -122,8 +122,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/sdk/go.mod
+++ b/pkg/sdk/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/cisco-open/operator-tools v0.36.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.34.1
@@ -23,6 +22,7 @@ require (
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
 	sigs.k8s.io/controller-runtime v0.18.4
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -81,5 +81,4 @@ require (
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/pkg/sdk/go.sum
+++ b/pkg/sdk/go.sum
@@ -29,8 +29,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=

--- a/pkg/sdk/logging/model/filter/concat_test.go
+++ b/pkg/sdk/logging/model/filter/concat_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestConcat(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/dedot_test.go
+++ b/pkg/sdk/logging/model/filter/dedot_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestDedot(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/detect_exceptions_test.go
+++ b/pkg/sdk/logging/model/filter/detect_exceptions_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestDetectExceptions(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/elasticsearch_genid_test.go
+++ b/pkg/sdk/logging/model/filter/elasticsearch_genid_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestElasticsearchGenId(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/enhance_k8s_test.go
+++ b/pkg/sdk/logging/model/filter/enhance_k8s_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestEnahnceK8s(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/geoip_test.go
+++ b/pkg/sdk/logging/model/filter/geoip_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestGeoIP(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/grep_test.go
+++ b/pkg/sdk/logging/model/filter/grep_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestGrepRegexp(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/kube_events_timestamp_test.go
+++ b/pkg/sdk/logging/model/filter/kube_events_timestamp_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestKubeEventsTimestamp(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/parser_test.go
+++ b/pkg/sdk/logging/model/filter/parser_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestParser(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/prometheus_test.go
+++ b/pkg/sdk/logging/model/filter/prometheus_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestPrometheus(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/record_modifier_test.go
+++ b/pkg/sdk/logging/model/filter/record_modifier_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestRecordModifier(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/record_transformer_test.go
+++ b/pkg/sdk/logging/model/filter/record_transformer_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestRecordTransformer(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/stdout_test.go
+++ b/pkg/sdk/logging/model/filter/stdout_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestStdOut(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/sumologic_test.go
+++ b/pkg/sdk/logging/model/filter/sumologic_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestSumoLogic(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/tagnormaliser_test.go
+++ b/pkg/sdk/logging/model/filter/tagnormaliser_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestTagNormaliser(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/throttle_test.go
+++ b/pkg/sdk/logging/model/filter/throttle_test.go
@@ -17,10 +17,10 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestThrottle(t *testing.T) {

--- a/pkg/sdk/logging/model/filter/useragent_test.go
+++ b/pkg/sdk/logging/model/filter/useragent_test.go
@@ -17,8 +17,8 @@ package filter_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"

--- a/pkg/sdk/logging/model/output/aws_elasticsearch_test.go
+++ b/pkg/sdk/logging/model/output/aws_elasticsearch_test.go
@@ -17,8 +17,8 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"

--- a/pkg/sdk/logging/model/output/azurestore_test.go
+++ b/pkg/sdk/logging/model/output/azurestore_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestAzureStore(t *testing.T) {

--- a/pkg/sdk/logging/model/output/cloudwatch_test.go
+++ b/pkg/sdk/logging/model/output/cloudwatch_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TesCloudWatch(t *testing.T) {

--- a/pkg/sdk/logging/model/output/datadog_test.go
+++ b/pkg/sdk/logging/model/output/datadog_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestDatadog(t *testing.T) {

--- a/pkg/sdk/logging/model/output/elasticsearch_test.go
+++ b/pkg/sdk/logging/model/output/elasticsearch_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestElasticSearch(t *testing.T) {

--- a/pkg/sdk/logging/model/output/file_test.go
+++ b/pkg/sdk/logging/model/output/file_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestFileOutputConfig(t *testing.T) {

--- a/pkg/sdk/logging/model/output/format_test.go
+++ b/pkg/sdk/logging/model/output/format_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestFormatSingleValueConfig(t *testing.T) {

--- a/pkg/sdk/logging/model/output/forward_test.go
+++ b/pkg/sdk/logging/model/output/forward_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestForward(t *testing.T) {

--- a/pkg/sdk/logging/model/output/gcs_test.go
+++ b/pkg/sdk/logging/model/output/gcs_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestGCS(t *testing.T) {

--- a/pkg/sdk/logging/model/output/gelf_test.go
+++ b/pkg/sdk/logging/model/output/gelf_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestGELFOutputConfig(t *testing.T) {

--- a/pkg/sdk/logging/model/output/http_test.go
+++ b/pkg/sdk/logging/model/output/http_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestHTTP(t *testing.T) {

--- a/pkg/sdk/logging/model/output/kafka_test.go
+++ b/pkg/sdk/logging/model/output/kafka_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestKafka(t *testing.T) {

--- a/pkg/sdk/logging/model/output/kinesis_firehose_test.go
+++ b/pkg/sdk/logging/model/output/kinesis_firehose_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestKinesisFirehose(t *testing.T) {

--- a/pkg/sdk/logging/model/output/kinesis_stream_test.go
+++ b/pkg/sdk/logging/model/output/kinesis_stream_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestKinesisStream(t *testing.T) {

--- a/pkg/sdk/logging/model/output/logdna_test.go
+++ b/pkg/sdk/logging/model/output/logdna_test.go
@@ -17,9 +17,9 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
+	"sigs.k8s.io/yaml"
 )
 
 func TestLogDNAOutput(t *testing.T) {

--- a/pkg/sdk/logging/model/output/logz_test.go
+++ b/pkg/sdk/logging/model/output/logz_test.go
@@ -17,8 +17,8 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"

--- a/pkg/sdk/logging/model/output/loki_test.go
+++ b/pkg/sdk/logging/model/output/loki_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestLoki(t *testing.T) {

--- a/pkg/sdk/logging/model/output/mattermost_test.go
+++ b/pkg/sdk/logging/model/output/mattermost_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestMattermost(t *testing.T) {

--- a/pkg/sdk/logging/model/output/newrelic_test.go
+++ b/pkg/sdk/logging/model/output/newrelic_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestNewRelic(t *testing.T) {

--- a/pkg/sdk/logging/model/output/opensearch_test.go
+++ b/pkg/sdk/logging/model/output/opensearch_test.go
@@ -17,8 +17,8 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"

--- a/pkg/sdk/logging/model/output/oss_test.go
+++ b/pkg/sdk/logging/model/output/oss_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestOSS(t *testing.T) {

--- a/pkg/sdk/logging/model/output/redis_test.go
+++ b/pkg/sdk/logging/model/output/redis_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestRedis(t *testing.T) {

--- a/pkg/sdk/logging/model/output/relabel_test.go
+++ b/pkg/sdk/logging/model/output/relabel_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestRelabel(t *testing.T) {

--- a/pkg/sdk/logging/model/output/s3_test.go
+++ b/pkg/sdk/logging/model/output/s3_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestS3(t *testing.T) {

--- a/pkg/sdk/logging/model/output/splunk_hec_test.go
+++ b/pkg/sdk/logging/model/output/splunk_hec_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestSplunkHEC(t *testing.T) {

--- a/pkg/sdk/logging/model/output/sqs_test.go
+++ b/pkg/sdk/logging/model/output/sqs_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestSQSOutputConfig(t *testing.T) {

--- a/pkg/sdk/logging/model/output/sumologic_test.go
+++ b/pkg/sdk/logging/model/output/sumologic_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestSumologic(t *testing.T) {

--- a/pkg/sdk/logging/model/output/syslog_test.go
+++ b/pkg/sdk/logging/model/output/syslog_test.go
@@ -17,10 +17,10 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestSyslogOutputConfig(t *testing.T) {

--- a/pkg/sdk/logging/model/output/vmware_log_intelligence_test.go
+++ b/pkg/sdk/logging/model/output/vmware_log_intelligence_test.go
@@ -17,9 +17,9 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"
+	"sigs.k8s.io/yaml"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/sdk/logging/model/output/vmware_loginsight_test.go
+++ b/pkg/sdk/logging/model/output/vmware_loginsight_test.go
@@ -17,8 +17,8 @@ package output_test
 import (
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/render"

--- a/pkg/sdk/logging/model/syslogng/config/go.sum
+++ b/pkg/sdk/logging/model/syslogng/config/go.sum
@@ -23,8 +23,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=


### PR DESCRIPTION
The `github.com/ghodss/yaml` package is no longer actively maintained. There are numerous inquiries about the project's status on its issue tracker: https://github.com/ghodss/yaml/issues. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained.

Since we only use `github.com/ghodss/yaml` in tests, this PR does not introduce any changes that affect users.