### PR TITLE
Allow specifying alternate journal fields

### DIFF
--- a/pkg/sdk/extensions/api/v1alpha1/systemdtailer.go
+++ b/pkg/sdk/extensions/api/v1alpha1/systemdtailer.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/extensions/api/tailer"
 	config "github.com/kube-logging/logging-operator/pkg/sdk/extensions/extensionsconfig"
@@ -43,7 +44,11 @@ func (s SystemdTailer) Command(Name string) []string {
 		"-p", fmt.Sprintf("max_entries=%d", s.MaxEntries),
 	}
 	if s.SystemdFilter != "" {
-		command = append(command, "-p", fmt.Sprintf("systemd_filter=_SYSTEMD_UNIT=%s", s.SystemdFilter))
+		// check if filter includes journal field, if not default to _SYSTEMD_UNIT
+		if !strings.Contains(s.SystemdFilter, "=") {
+			s.SystemdFilter = fmt.Sprintf("_SYSTEMD_UNIT=%s", s.SystemdFilter)
+		}
+		command = append(command, "-p", fmt.Sprintf("systemd_filter=%s", s.SystemdFilter))
 	}
 	command = append(command,
 		"-o", "file",


### PR DESCRIPTION
PR for issue https://github.com/kube-logging/logging-operator/issues/1809.

This changes the semantics of field `systemdFilter` to allow specifying a journal field. If none is specified, the behavior reverts to the default of assuming `_SYSTEMD_UNIT`. 