### PR TITLE
fluentbit: storage.max_chunks_up

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
@@ -481,6 +481,8 @@ spec:
                     type: string
                   storage.delete_irrecoverable_chunks:
                     type: string
+                  storage.max_chunks_up:
+                    type: integer
                   storage.metrics:
                     type: string
                   storage.path:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1528,6 +1528,8 @@ spec:
                         type: string
                       storage.delete_irrecoverable_chunks:
                         type: string
+                      storage.max_chunks_up:
+                        type: integer
                       storage.metrics:
                         type: string
                       storage.path:
@@ -7954,6 +7956,8 @@ spec:
                               type: string
                             storage.delete_irrecoverable_chunks:
                               type: string
+                            storage.max_chunks_up:
+                              type: integer
                             storage.metrics:
                               type: string
                             storage.path:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_nodeagents.yaml
@@ -51,6 +51,8 @@ spec:
                         type: string
                       storage.delete_irrecoverable_chunks:
                         type: string
+                      storage.max_chunks_up:
+                        type: integer
                       storage.metrics:
                         type: string
                       storage.path:

--- a/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
@@ -481,6 +481,8 @@ spec:
                     type: string
                   storage.delete_irrecoverable_chunks:
                     type: string
+                  storage.max_chunks_up:
+                    type: integer
                   storage.metrics:
                     type: string
                   storage.path:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -1528,6 +1528,8 @@ spec:
                         type: string
                       storage.delete_irrecoverable_chunks:
                         type: string
+                      storage.max_chunks_up:
+                        type: integer
                       storage.metrics:
                         type: string
                       storage.path:
@@ -7954,6 +7956,8 @@ spec:
                               type: string
                             storage.delete_irrecoverable_chunks:
                               type: string
+                            storage.max_chunks_up:
+                              type: integer
                             storage.metrics:
                               type: string
                             storage.path:

--- a/config/crd/bases/logging.banzaicloud.io_nodeagents.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_nodeagents.yaml
@@ -51,6 +51,8 @@ spec:
                         type: string
                       storage.delete_irrecoverable_chunks:
                         type: string
+                      storage.max_chunks_up:
+                        type: integer
                       storage.metrics:
                         type: string
                       storage.path:

--- a/docs/configuration/crds/v1beta1/fluentbit_types.md
+++ b/docs/configuration/crds/v1beta1/fluentbit_types.md
@@ -353,6 +353,12 @@ When enabled, irrecoverable chunks will be deleted during runtime, and any other
 
 Default: Off
 
+### storage.max_chunks_up (int, optional) {#bufferstorage-storage.max_chunks_up}
+
+If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory. This is the setting to use to control memory usage when you enable storage.type filesystem.
+
+Default: 128
+
 ### storage.metrics (string, optional) {#bufferstorage-storage.metrics}
 
 Available in Logging operator version 4.4 and later. If the `http_server` option has been enabled in the main Service configuration section, this option registers a new endpoint where internal metrics of the storage layer can be consumed.

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -208,6 +208,8 @@ type BufferStorage struct {
 	StorageBacklogMemLimit string `json:"storage.backlog.mem_limit,omitempty"`
 	// Available in Logging operator version 4.4 and later. If the `http_server` option has been enabled in the main Service configuration section, this option registers a new endpoint where internal metrics of the storage layer can be consumed. (default:Off)
 	StorageMetrics string `json:"storage.metrics,omitempty"`
+	// If the input plugin has enabled filesystem storage type, this property sets the maximum number of Chunks that can be up in memory. This is the setting to use to control memory usage when you enable storage.type filesystem. (default: 128)
+	StorageMaxChunksUp int `json:"storage.max_chunks_up,omitempty"`
 }
 
 // HealthCheck configuration. Available in Logging operator version 4.4 and later.


### PR DESCRIPTION
Add missing option to control memory usage in persistent buffering mode.
