### PR TITLE
chore: resolve e2e test result conflict

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -168,6 +168,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: script-e2e-test-cluster-logs
+          name: script-e2e-test-cluster-logs-${{ matrix.kube }}
           path: build/_test
           retention-days: 5


### PR DESCRIPTION
- This PR resolves an issue with conflicting uploads that occoured in #1807 by appending the kubeversion at the end of each test result upon uploading.