### PR TITLE
feat: add image and chart signing

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -137,10 +137,15 @@ jobs:
 
       - name: Verify signed image with cosign
         if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          cosign verify "${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}" \
+          for tag in ${TAGS}; do
+            cosign verify "${tag}@${DIGEST}" \
             --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+          done
 
       - name: Set image ref
         id: image-ref
@@ -230,31 +235,6 @@ jobs:
           helm package charts/${{ steps.chart-name.outputs.value }} --version ${{ steps.version.outputs.value }} --app-version ${{ steps.version.outputs.value }}
           echo "package=${{ steps.chart-name.outputs.value }}-${{ steps.version.outputs.value }}.tgz" >> "$GITHUB_OUTPUT"
 
-      - name: Sign chart with GitHub OIDC Token
-        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
-        env:
-          PACKAGE: ${{ steps.build.outputs.package }}
-        run: |
-          cosign sign-blob --yes $PACKAGE \
-            --bundle "$PACKAGE.cosign.bundle"
-
-      - name: Verify signed chart with cosign
-        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
-        env:
-          PACKAGE: ${{ steps.build.outputs.package }}
-        run: |
-          cosign verify-blob $PACKAGE \
-            --bundle "$PACKAGE.cosign.bundle" \
-            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-
-      - name: Upload bundle as artifact
-        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        with:
-          name: "[${{ github.job }}] Cosign bundle"
-          path: ${{ steps.build.outputs.package }}.cosign.bundle
-
       - name: Upload chart as artifact
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
@@ -270,10 +250,28 @@ jobs:
         if: inputs.publish && inputs.release
 
       - name: Helm push
-        run: helm push ${{ steps.build.outputs.package }} oci://${{ steps.oci-registry-name.outputs.value }}
+        id: push
+        run: |
+          helm push ${{ steps.build.outputs.package }} oci://${{ steps.oci-registry-name.outputs.value }} &> push-metadata.txt
+          echo "digest=$(awk '/Digest: /{print $2}' push-metadata.txt)" >> "$GITHUB_OUTPUT"
         env:
           HELM_REGISTRY_CONFIG: ~/.docker/config.json
         if: inputs.publish && inputs.release
+
+      - name: Sign chart with GitHub OIDC Token
+        if: ${{ inputs.publish && inputs.release && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: cosign sign --yes "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}"
+
+      - name: Verify signed chart with cosign
+        if: ${{ inputs.publish && inputs.release && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          cosign verify "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}" \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # 0.24.0

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -248,6 +248,13 @@ jobs:
             --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
+      - name: Upload bundle as artifact
+        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: "[${{ github.job }}] Cosign bundle"
+          path: ${{ steps.build.outputs.package }}.cosign.bundle
+
       - name: Upload chart as artifact
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -135,6 +135,13 @@ jobs:
           
           cosign sign --yes ${images}
 
+      - name: Verify signed image with cosign
+        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        run: |
+          cosign verify "${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}" \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
       - name: Set image ref
         id: image-ref
         run: echo "value=${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
@@ -227,7 +234,19 @@ jobs:
         if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
         env:
           PACKAGE: ${{ steps.build.outputs.package }}
-        run: cosign sign-blob --yes $PACKAGE
+        run: |
+          cosign sign-blob --yes $PACKAGE \
+            --bundle "$PACKAGE.cosign.bundle"
+
+      - name: Verify signed chart with cosign
+        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        env:
+          PACKAGE: ${{ steps.build.outputs.package }}
+        run: |
+          cosign verify-blob $PACKAGE \
+            --bundle "$PACKAGE.cosign.bundle" \
+            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
       - name: Upload chart as artifact
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -66,6 +66,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2.9.1
 
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+
       - name: Set image name
         id: image-name
         run: echo "value=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
@@ -87,7 +90,6 @@ jobs:
             org.opencontainers.image.title=Logging operator
             org.opencontainers.image.authors=Kube logging authors
             org.opencontainers.image.documentation=https://kube-logging.dev/docs/
-
 
       # Multiple exporters are not supported yet
       # See https://github.com/moby/buildkit/pull/2760
@@ -119,6 +121,19 @@ jobs:
           cache-to: type=gha,mode=max
           outputs: ${{ steps.build-output.outputs.value }},name=target,annotation-index.org.opencontainers.image.description=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.description'] }}
           # push: ${{ inputs.publish }}
+
+      - name: Sign image with GitHub OIDC Token
+        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          
+          cosign sign --yes ${images}
 
       - name: Set image ref
         id: image-ref
@@ -176,6 +191,9 @@ jobs:
         with:
           version: v3.12.0
 
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+
       - name: Set chart name
         id: chart-name
         run: echo "value=${{ github.event.repository.name }}" >> "$GITHUB_OUTPUT"
@@ -204,6 +222,12 @@ jobs:
         run: |
           helm package charts/${{ steps.chart-name.outputs.value }} --version ${{ steps.version.outputs.value }} --app-version ${{ steps.version.outputs.value }}
           echo "package=${{ steps.chart-name.outputs.value }}-${{ steps.version.outputs.value }}.tgz" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart with GitHub OIDC Token
+        if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
+        env:
+          PACKAGE: ${{ steps.build.outputs.package }}
+        run: cosign sign-blob --yes $PACKAGE
 
       - name: Upload chart as artifact
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3


### PR DESCRIPTION
Sets up image and chart signing.

Test run: https://github.com/kube-logging/logging-operator/actions/runs/11258053466

### Docs for image and chart verification

#### Overview

- Images and charts are signed with GitHub Actions OIDC token upon merging to main and releases, ensuring a seamless verification process for `Logging-operator` users.
- In case of both images and charts the digest is signed, which is a unique identifier of the artifacts. This ensures the integrity and authenticity of the artifacts.

#### image verification

`cosign verify "ghcr.io/kube-logging/logging-operator@{sha256-IMAGE-DIGEST}" \
            --certificate-identity "https://github.com/ghcr.io/kube-logging/logging-operator/.github/workflows/artifacts.yaml@{refs/heads/main || refs/tags/<tag_name>}" \
            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"`

#### chart verification

`cosign verify "ghcr.io/kube-logging/logging-operator@{sha256-CHART-DIGEST}" \
            --certificate-identity "https://github.com/ghcr.io/kube-logging/logging-operator/.github/workflows/artifacts.yaml@{refs/heads/main || refs/tags/<tag_name>}" \
            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"`
