### PR TITLE
feat: protected cluster output syslogng

### DIFF
--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -2053,6 +2053,8 @@ spec:
                 required:
                 - url
                 type: object
+              protected:
+                type: boolean
               redis:
                 properties:
                   auth:

--- a/config/crd/bases/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -2053,6 +2053,8 @@ spec:
                 required:
                 - url
                 type: object
+              protected:
+                type: boolean
               redis:
                 properties:
                   auth:

--- a/docs/configuration/crds/v1beta1/logging_types.md
+++ b/docs/configuration/crds/v1beta1/logging_types.md
@@ -51,7 +51,7 @@ GlobalOutput name to flush ERROR events to
 
 ### flowConfigCheckDisabled (bool, optional) {#loggingspec-flowconfigcheckdisabled}
 
-Disable configuration check before applying new fluentd configuration. 
+Disable configuration check before applying new fluentd or syslogng configuration. 
 
 
 ### flowConfigOverride (string, optional) {#loggingspec-flowconfigoverride}

--- a/docs/configuration/crds/v1beta1/syslogng_clusteroutput_types.md
+++ b/docs/configuration/crds/v1beta1/syslogng_clusteroutput_types.md
@@ -31,6 +31,9 @@ SyslogNGClusterOutputSpec contains Kubernetes spec for SyslogNGClusterOutput
 ### enabledNamespaces ([]string, optional) {#syslogngclusteroutputspec-enablednamespaces}
 
 
+### protected (bool, optional) {#syslogngclusteroutputspec-protected}
+
+
 
 ## SyslogNGClusterOutputList
 

--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -187,7 +187,7 @@ func NewValidationReconciler(
 			flow.Status.Problems = nil
 
 			for _, ref := range flow.Spec.GlobalOutputRefs {
-				if output := resources.SyslogNG.ClusterOutputs.FindByName(ref); output != nil {
+				if output := resources.SyslogNG.ClusterOutputs.FindByName(ref); output != nil && !output.Spec.Protected {
 					flow.Status.Active = utils.BoolPointer(true)
 					output.Status.Active = utils.BoolPointer(true)
 				} else {

--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -141,23 +141,39 @@ func NewValidationReconciler(
 				flow.Status.Problems = append(flow.Status.Problems, "\"outputRefs\" field is deprecated, use \"globalOutputRefs\" and \"localOutputRefs\" instead")
 			}
 
+			hasValidOutput := false
 			for _, ref := range flow.Spec.GlobalOutputRefs {
-				if output := resources.Fluentd.ClusterOutputs.FindByName(ref); output != nil && !output.Spec.Protected {
-					flow.Status.Active = utils.BoolPointer(true)
-					output.Status.Active = utils.BoolPointer(true)
-				} else {
+				switch output := resources.Fluentd.ClusterOutputs.FindByName(ref); {
+				case output == nil:
 					flow.Status.Problems = append(flow.Status.Problems, fmt.Sprintf("dangling global output reference: %s", ref))
+					continue
+
+				case output.Spec.Protected:
+					flow.Status.Problems = append(flow.Status.Problems, fmt.Sprintf("global output reference is protected: %s", ref))
+					continue
+
+				default:
+					output.Status.Active = utils.BoolPointer(true)
+					hasValidOutput = true
 				}
 			}
 
 			for _, ref := range flow.Spec.LocalOutputRefs {
 				if output := resources.Fluentd.Outputs.FindByNamespacedName(flow.Namespace, ref); output != nil {
-					flow.Status.Active = utils.BoolPointer(true)
 					output.Status.Active = utils.BoolPointer(true)
+					hasValidOutput = true
 				} else {
 					flow.Status.Problems = append(flow.Status.Problems, fmt.Sprintf("dangling local output reference: %s", ref))
 				}
 			}
+
+			// Check if the flow has become dangling with no valid outputs
+			if hasValidOutput {
+				flow.Status.Active = utils.BoolPointer(true)
+			} else {
+				flow.Status.Problems = append(flow.Status.Problems, "flow has become dangling with no valid outputs")
+			}
+
 			flow.Status.ProblemsCount = len(flow.Status.Problems)
 		}
 
@@ -186,23 +202,39 @@ func NewValidationReconciler(
 			flow.Status.Active = utils.BoolPointer(false)
 			flow.Status.Problems = nil
 
+			hasValidOutput := false
 			for _, ref := range flow.Spec.GlobalOutputRefs {
-				if output := resources.SyslogNG.ClusterOutputs.FindByName(ref); output != nil && !output.Spec.Protected {
-					flow.Status.Active = utils.BoolPointer(true)
-					output.Status.Active = utils.BoolPointer(true)
-				} else {
+				switch output := resources.SyslogNG.ClusterOutputs.FindByName(ref); {
+				case output == nil:
 					flow.Status.Problems = append(flow.Status.Problems, fmt.Sprintf("dangling global output reference: %s", ref))
+					continue
+
+				case output.Spec.Protected:
+					flow.Status.Problems = append(flow.Status.Problems, fmt.Sprintf("global output reference is protected: %s", ref))
+					continue
+
+				default:
+					output.Status.Active = utils.BoolPointer(true)
+					hasValidOutput = true
 				}
 			}
 
 			for _, ref := range flow.Spec.LocalOutputRefs {
 				if output := resources.SyslogNG.Outputs.FindByNamespacedName(flow.Namespace, ref); output != nil {
-					flow.Status.Active = utils.BoolPointer(true)
 					output.Status.Active = utils.BoolPointer(true)
+					hasValidOutput = true
 				} else {
 					flow.Status.Problems = append(flow.Status.Problems, fmt.Sprintf("dangling local output reference: %s", ref))
 				}
 			}
+
+			// Check if the flow has become dangling with no valid outputs
+			if hasValidOutput {
+				flow.Status.Active = utils.BoolPointer(true)
+			} else {
+				flow.Status.Problems = append(flow.Status.Problems, "flow has become dangling with no valid outputs")
+			}
+
 			flow.Status.ProblemsCount = len(flow.Status.Problems)
 		}
 

--- a/pkg/resources/model/system.go
+++ b/pkg/resources/model/system.go
@@ -271,7 +271,7 @@ func FlowForFlow(flow v1beta1.Flow, clusterOutputs ClusterOutputs, outputs Outpu
 	for _, outputRef := range flow.Spec.GlobalOutputRefs {
 		if clusterOutput := clusterOutputs.FindByName(outputRef); clusterOutput != nil {
 			if clusterOutput.Spec.Protected {
-				errs = errors.Append(errs, errors.WrapIff(err, "referenced clusteroutput is protected %s", outputRef))
+				errs = errors.Append(errs, errors.Errorf("referenced clusteroutput is protected %s", outputRef))
 				continue
 			}
 			outputID := fmt.Sprintf("%s:clusteroutput:%s:%s", flowID, clusterOutput.Namespace, clusterOutput.Name)

--- a/pkg/resources/model/system.go
+++ b/pkg/resources/model/system.go
@@ -271,7 +271,7 @@ func FlowForFlow(flow v1beta1.Flow, clusterOutputs ClusterOutputs, outputs Outpu
 	for _, outputRef := range flow.Spec.GlobalOutputRefs {
 		if clusterOutput := clusterOutputs.FindByName(outputRef); clusterOutput != nil {
 			if clusterOutput.Spec.Protected {
-				errs = errors.Append(errs, errors.Errorf("referenced clusteroutput is protected %s", outputRef))
+				errs = errors.Append(errs, errors.Errorf("referenced clusteroutput is protected: %s", outputRef))
 				continue
 			}
 			outputID := fmt.Sprintf("%s:clusteroutput:%s:%s", flowID, clusterOutput.Namespace, clusterOutput.Name)

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -42,7 +42,7 @@ type _metaLoggingSpec interface{} //nolint:deadcode,unused
 type LoggingSpec struct {
 	// Reference to the logging system. Each of the `loggingRef`s can manage a fluentbit daemonset and a fluentd statefulset.
 	LoggingRef string `json:"loggingRef,omitempty"`
-	// Disable configuration check before applying new fluentd configuration.
+	// Disable configuration check before applying new fluentd or syslogng configuration.
 	FlowConfigCheckDisabled bool `json:"flowConfigCheckDisabled,omitempty"`
 	// Whether to skip invalid Flow and ClusterFlow resources
 	SkipInvalidResources bool `json:"skipInvalidResources,omitempty"`

--- a/pkg/sdk/logging/api/v1beta1/syslogng_clusteroutput_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_clusteroutput_types.go
@@ -48,6 +48,7 @@ type SyslogNGClusterOutput struct {
 // SyslogNGClusterOutputSpec contains Kubernetes spec for SyslogNGClusterOutput
 type SyslogNGClusterOutputSpec struct {
 	SyslogNGOutputSpec `json:",inline"`
+	Protected          bool     `json:"protected,omitempty"`
 	EnabledNamespaces  []string `json:"enabledNamespaces,omitempty"`
 }
 

--- a/pkg/sdk/logging/model/syslogng/config/flow.go
+++ b/pkg/sdk/logging/model/syslogng/config/flow.go
@@ -41,7 +41,7 @@ func validateClusterOutputs(clusterOutputRefs map[string]clusterOutputInfo, flow
 			return errors.Append(err, errors.Errorf("cluster output reference %s for flow %s cannot be found", ref, flow))
 		}
 		if flowKind == syslogNGFlowKind && clusterOutputRefs[ref].protected {
-			return errors.Append(err, errors.Errorf("referenced clusteroutput is protected %s", ref))
+			return errors.Append(err, errors.Errorf("referenced clusteroutput is protected: %s", ref))
 		}
 		return err
 	})

--- a/pkg/sdk/logging/model/syslogng/config/flow.go
+++ b/pkg/sdk/logging/model/syslogng/config/flow.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/secret"
 	"github.com/siliconbrain/go-seqs/seqs"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/config/model"
@@ -32,16 +31,23 @@ import (
 	filter "github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
 )
 
-func validateClusterOutputs(clusterOutputRefs map[string]types.NamespacedName, flow string, globalOutputRefs []string) error {
+const (
+	syslogNGFlowKind = "SyslogNGFlow"
+)
+
+func validateClusterOutputs(clusterOutputRefs map[string]clusterOutputInfo, flow string, globalOutputRefs []string, flowKind string) error {
 	return seqs.SeededReduce(seqs.FromSlice(globalOutputRefs), nil, func(err error, ref string) error {
 		if _, ok := clusterOutputRefs[ref]; !ok {
 			return errors.Append(err, errors.Errorf("cluster output reference %s for flow %s cannot be found", ref, flow))
+		}
+		if flowKind == syslogNGFlowKind && clusterOutputRefs[ref].protected {
+			return errors.Append(err, errors.Errorf("referenced clusteroutput is protected %s", ref))
 		}
 		return err
 	})
 }
 
-func renderClusterFlow(logging string, clusterOutputRefs map[string]types.NamespacedName, sourceName string, f v1beta1.SyslogNGClusterFlow, secretLoaderFactory SecretLoaderFactory) render.Renderer {
+func renderClusterFlow(logging string, clusterOutputRefs map[string]clusterOutputInfo, sourceName string, f v1beta1.SyslogNGClusterFlow, secretLoaderFactory SecretLoaderFactory) render.Renderer {
 	baseName := fmt.Sprintf("clusterflow_%s_%s", f.Namespace, f.Name)
 	matchName := fmt.Sprintf("%s_match", baseName)
 	filterDefs := seqs.MapWithIndex(seqs.FromSlice(f.Spec.Filters), func(idx int, flt v1beta1.SyslogNGFilter) render.Renderer {
@@ -63,8 +69,8 @@ func renderClusterFlow(logging string, clusterOutputRefs map[string]types.Namesp
 			seqs.ToSlice(seqs.Map(seqs.FromSlice(f.Spec.GlobalOutputRefs), func(ref string) destination {
 				return destination{
 					Logging:          logging,
-					renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].Namespace, ref),
-					Namespace:        clusterOutputRefs[ref].Namespace,
+					renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].ref.Namespace, ref),
+					Namespace:        clusterOutputRefs[ref].ref.Namespace,
 					Name:             ref,
 					Scope:            Global,
 					metricsProbes:    f.Spec.OutputMetrics,
@@ -74,7 +80,7 @@ func renderClusterFlow(logging string, clusterOutputRefs map[string]types.Namesp
 	)
 }
 
-func renderFlow(logging string, clusterOutputRefs map[string]types.NamespacedName, sourceName string, keyDelim string, f v1beta1.SyslogNGFlow, secretLoaderFactory SecretLoaderFactory) render.Renderer {
+func renderFlow(logging string, clusterOutputRefs map[string]clusterOutputInfo, sourceName string, keyDelim string, f v1beta1.SyslogNGFlow, secretLoaderFactory SecretLoaderFactory) render.Renderer {
 	baseName := fmt.Sprintf("flow_%s_%s", f.Namespace, f.Name)
 	matchName := fmt.Sprintf("%s_match", baseName)
 	nsFilterName := fmt.Sprintf("%s_ns_filter", baseName)
@@ -104,8 +110,8 @@ func renderFlow(logging string, clusterOutputRefs map[string]types.NamespacedNam
 				seqs.Map(seqs.FromSlice(f.Spec.GlobalOutputRefs), func(ref string) destination {
 					return destination{
 						Logging:          logging,
-						renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].Namespace, ref),
-						Namespace:        clusterOutputRefs[ref].Namespace,
+						renderedDestName: clusterOutputDestName(clusterOutputRefs[ref].ref.Namespace, ref),
+						Namespace:        clusterOutputRefs[ref].ref.Namespace,
 						Name:             ref,
 						Scope:            Global,
 						metricsProbes:    f.Spec.OutputMetrics,


### PR DESCRIPTION
- Adds protected flag for `SyslogNGClusterOutput` Kinds
- Fixes an issue with the protected flag on Fluentd, which created config-secret despite the flow was faulty

Fixes: #1731 