### PR TITLE
fix(charts,logging-operator): add empty workloadMetaOverrides field i…

### DIFF
--- a/charts/logging-operator/templates/logging/hosttailer.yaml
+++ b/charts/logging-operator/templates/logging/hosttailer.yaml
@@ -15,9 +15,11 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   enableRecreateWorkloadOnImmutableFieldChange: {{ $.Values.logging.enableRecreateWorkloadOnImmutableFieldChange }}
-  {{- with .workloadMetaOverrides }}
+  {{- if .workloadMetaOverrides }}
   workloadMetaOverrides:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml .workloadMetaOverrides | nindent 4 }}
+  {{- else }}
+  workloadMetaOverrides: {}
   {{- end }}
   {{- with .workloadOverrides }}
   workloadOverrides:


### PR DESCRIPTION
…n hosttailer if not specified

The '.spec.workloadMetaOverrides' field is required for all hosttailer resources. Unfortunately if not set the deployment via the chart fails with 'is invalid: spec.workloadMetaOverrides: Required value'. In order to mitigate this, an empty object is injected if not specified.