### PR TITLE
fix fluentbit ipv6 listen address

### DIFF
--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -35,7 +35,7 @@ var fluentBitConfigTemplate = `
     Coro_Stack_Size    {{ .CoroStackSize }}
     {{- if .Monitor.Enabled }}
     HTTP_Server  On
-    HTTP_Listen  ${POD_IP}
+    HTTP_Listen  [::]
     HTTP_Port    {{ .Monitor.Port }}
     {{- end }}
     {{- range $key, $value := .BufferStorage }}

--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -35,7 +35,7 @@ var fluentBitConfigTemplate = `
     Coro_Stack_Size    {{ .CoroStackSize }}
     {{- if .Monitor.Enabled }}
     HTTP_Server  On
-    HTTP_Listen  0.0.0.0
+    HTTP_Listen  ${POD_IP}
     HTTP_Port    {{ .Monitor.Port }}
     {{- end }}
     {{- range $key, $value := .BufferStorage }}

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -121,16 +121,6 @@ func (r *Reconciler) fluentbitContainer() *corev1.Container {
 	if r.fluentbitSpec.ConfigHotReload != nil {
 		args = append(args, "--enable-hot-reload")
 	}
-	r.fluentbitSpec.EnvVars = append(r.fluentbitSpec.EnvVars, []corev1.EnvVar{
-		{
-			Name: "POD_IP",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "status.podIP",
-				},
-			},
-		},
-	}...)
 	return &corev1.Container{
 		Name:            containerName,
 		Image:           r.fluentbitSpec.Image.RepositoryWithTag(),

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -121,6 +121,16 @@ func (r *Reconciler) fluentbitContainer() *corev1.Container {
 	if r.fluentbitSpec.ConfigHotReload != nil {
 		args = append(args, "--enable-hot-reload")
 	}
+	r.fluentbitSpec.EnvVars = append(r.fluentbitSpec.EnvVars, []corev1.EnvVar{
+		{
+			Name: "POD_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.podIP",
+				},
+			},
+		},
+	}...)
 	return &corev1.Container{
 		Name:            containerName,
 		Image:           r.fluentbitSpec.Image.RepositoryWithTag(),


### PR DESCRIPTION
if logging-operator is deployed in IPv6 environment, fluentbit is not able to listen on http socket due the hard coded `HTTP_Listen` address. Make this dynamically set by `POD_IP` with an envVar definition