### PR TITLE
fix: configcheck cleaner label selector

### DIFF
--- a/pkg/resources/configcheck/configcheck.go
+++ b/pkg/resources/configcheck/configcheck.go
@@ -46,11 +46,12 @@ type ConfigCheckCleaner struct {
 	labels client.MatchingLabels
 }
 
-func NewConfigCheckCleaner(c client.Client, component string) *ConfigCheckCleaner {
+func NewConfigCheckCleaner(c client.Client, component string, logging string) *ConfigCheckCleaner {
 	return &ConfigCheckCleaner{
 		client: c,
 		labels: client.MatchingLabels{
-			"app.kubernetes.io/component": component,
+			"app.kubernetes.io/component":  component,
+			"app.kubernetes.io/managed-by": logging,
 		},
 	}
 }

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -168,7 +168,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 		}
 
 		if result, ok := r.Logging.Status.ConfigCheckResults[hash]; ok {
-			cleaner := configcheck.NewConfigCheckCleaner(r.Client, ComponentConfigCheck)
+			cleaner := configcheck.NewConfigCheckCleaner(r.Client, ComponentConfigCheck, r.Logging.GetName())
 
 			var cleanupErrs error
 			cleanupErrs = errors.Append(cleanupErrs, cleaner.SecretCleanup(ctx, hash))

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -142,7 +142,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 
 		// Cleanup previous configcheck results
 		if result, ok := r.Logging.Status.ConfigCheckResults[hash]; ok {
-			cleaner := configcheck.NewConfigCheckCleaner(r.Client, ComponentConfigCheck)
+			cleaner := configcheck.NewConfigCheckCleaner(r.Client, ComponentConfigCheck, r.Logging.GetName())
 
 			var cleanupErrs error
 			cleanupErrs = errors.Append(cleanupErrs, cleaner.SecretCleanup(ctx, hash))


### PR DESCRIPTION
ConfigCheck cleaner was not aware of the logging resource and cleaned all configcheck secrets and pods that belonged to other logging resources. Adding the managed-by label to the cleaner filter solves this problem.