### PR TITLE
Prepare for release 4.11

### DIFF
--- a/e2e/common/helpers.go
+++ b/e2e/common/helpers.go
@@ -125,7 +125,7 @@ func LoggingInfra(
 			ControlNamespace: nsInfra,
 			FluentdSpec: &v1beta1.FluentdSpec{
 				Image: v1beta1.ImageSpec{
-					Tag: "v1.16-4.9-base",
+					Tag: "v1.16-4.11-base",
 				},
 				DisablePvc: true,
 				Resources: v12.ResourceRequirements{

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -103,7 +103,7 @@ func TestFluentdAggregator_NamespaceLabel(t *testing.T) {
 				},
 				FluentdSpec: &v1beta1.FluentdSpec{
 					Image: v1beta1.ImageSpec{
-						Tag: "v1.16-4.9-base",
+						Tag: "v1.16-4.11-base",
 					},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -91,7 +91,7 @@ func TestFluentdAggregator_MultiWorker(t *testing.T) {
 				},
 				FluentdSpec: &v1beta1.FluentdSpec{
 					Image: v1beta1.ImageSpec{
-						Tag: "v1.16-4.9-base",
+						Tag: "v1.16-4.11-base",
 					},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
@@ -259,7 +259,7 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 				},
 				FluentdSpec: &v1beta1.FluentdSpec{
 					Image: v1beta1.ImageSpec{
-						Tag: "v1.16-4.9-base",
+						Tag: "v1.16-4.11-base",
 					},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{

--- a/e2e/volumedrain/volumedrain_test.go
+++ b/e2e/volumedrain/volumedrain_test.go
@@ -89,7 +89,7 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 				},
 				FluentdSpec: &v1beta1.FluentdSpec{
 					Image: v1beta1.ImageSpec{
-						Tag: "v1.16-4.9-base",
+						Tag: "v1.16-4.11-base",
 					},
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -179,7 +179,7 @@ const (
 	DefaultFluentbitConfigReloaderImageRepository = "ghcr.io/kube-logging/config-reloader"
 	DefaultFluentbitConfigReloaderImageTag        = "v0.0.6"
 	DefaultFluentdImageRepository                 = "ghcr.io/kube-logging/fluentd"
-	DefaultFluentdImageTag                        = "v1.16-4.10-full"
+	DefaultFluentdImageTag                        = "v1.16-4.11-full"
 	DefaultFluentdBufferStorageVolumeName         = "fluentd-buffer"
 	DefaultFluentdDrainWatchImageRepository       = "ghcr.io/kube-logging/fluentd-drain-watch"
 	DefaultFluentdDrainWatchImageTag              = "v0.2.3"

--- a/pkg/sdk/logging/api/v1beta1/syslogng_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_types.go
@@ -34,7 +34,7 @@ type _metaSyslogNGSpec interface{} //nolint:deadcode,unused
 
 const (
 	defaultSyslogngImageRepository    = "ghcr.io/axoflow/axosyslog"
-	defaultSyslogngImageTag           = "4.8.1-1"
+	defaultSyslogngImageTag           = "4.8.1"
 	configReloaderImageRepository     = "ghcr.io/kube-logging/syslogng-reload"
 	configReloaderImageTag            = "v1.5.0"
 	prometheusExporterImageRepository = "ghcr.io/axoflow/axosyslog-metrics-exporter"


### PR DESCRIPTION
- **chore: prepare for release with bumping fluentd image version**
- **chore: use moving image tag for axosyslog**
