### PR TITLE
chore(CI): Use AWS ECR location for trivy DBs

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -162,6 +162,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:1
         with:
           input: image
           format: sarif
@@ -275,6 +278,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:1
         with:
           scan-type: config
           scan-ref: charts/${{ steps.chart-name.outputs.value }}


### PR DESCRIPTION
Use AWS ECR mirror so CI won't fail with TOOMANYREQUESTS for the default one.

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>
