### PR TITLE
fix: image signing

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -133,7 +133,7 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           
-          cosign sign --yes ${images}
+          cosign sign --yes --rekor-url "https://rekor.sigstore.dev/" ${images}
 
       - name: Verify signed image with cosign
         if: ${{ inputs.publish && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
@@ -144,6 +144,7 @@ jobs:
           if [ "${{ github.repository }}" == "kube-logging/logging-operator" ]; then
             for tag in ${TAGS[@]}; do
               cosign verify "${tag}@${DIGEST}" \
+              --rekor-url "https://rekor.sigstore.dev/" \
               --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq
             done
@@ -152,6 +153,7 @@ jobs:
             for tag in "${TAGS[@]}"; do
               for version in ${versions}; do
                 cosign verify "${tag}@${DIGEST}" \
+                --rekor-url "https://rekor.sigstore.dev/" \
                 --certificate-identity "https://github.com/kube-logging/logging-operator/.github/workflows/artifacts.yaml@refs/tags/${version}" \
                 --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq && break
               done
@@ -276,7 +278,7 @@ jobs:
         if: ${{ inputs.publish && inputs.release && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
-        run: cosign sign --yes "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}"
+        run: cosign sign --yes --rekor-url "https://rekor.sigstore.dev/" "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}"
 
       - name: Verify signed chart with cosign
         if: ${{ inputs.publish && inputs.release && github.repository_owner == 'kube-logging' }} # Check if the workflow is called by the same GitHub organization
@@ -285,12 +287,14 @@ jobs:
         run: |
           if [ "${{ github.repository }}" == "kube-logging/logging-operator" ]; then
             cosign verify "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}" \
+            --rekor-url "https://rekor.sigstore.dev/" \
             --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq
           else
             versions=$(curl -s https://api.github.com/repos/kube-logging/logging-operator/releases | jq -r '.[].tag_name')
             for version in ${versions}; do
               cosign verify "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}" \
+              --rekor-url "https://rekor.sigstore.dev/" \
               --certificate-identity "https://github.com/kube-logging/logging-operator/.github/workflows/artifacts.yaml@refs/tags/${version}" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq && break
             done

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -129,7 +129,7 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           images=""
-          for tag in ${TAGS}; do
+          for tag in ${TAGS[@]}; do
             images+="${tag}@${DIGEST} "
           done
           
@@ -141,11 +141,22 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          for tag in ${TAGS}; do
-            cosign verify "${tag}@${DIGEST}" \
-            --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-          done
+          if [ "${{ github.repository }}" == "kube-logging/logging-operator" ]; then
+            for tag in ${TAGS[@]}; do
+              cosign verify "${tag}@${DIGEST}" \
+              --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq
+            done
+          else
+            versions=$(curl -s https://api.github.com/repos/kube-logging/logging-operator/releases | jq -r '.[].tag_name')
+            for tag in "${TAGS[@]}"; do
+              for version in ${versions}; do
+                cosign verify "${tag}@${DIGEST}" \
+                --certificate-identity "https://github.com/kube-logging/logging-operator/.github/workflows/artifacts.yaml@refs/tags/${version}" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq && break
+              done
+            done
+          fi
 
       - name: Set image ref
         id: image-ref
@@ -272,9 +283,18 @@ jobs:
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
-          cosign verify "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}" \
+          if [ "${{ github.repository }}" == "kube-logging/logging-operator" ]; then
+            cosign verify "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}" \
             --certificate-identity "https://github.com/${{ github.repository }}/.github/workflows/artifacts.yaml@${{ github.ref }}" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq
+          else
+            versions=$(curl -s https://api.github.com/repos/kube-logging/logging-operator/releases | jq -r '.[].tag_name')
+            for version in ${versions}; do
+              cosign verify "${{ steps.oci-chart-name.outputs.value }}@${DIGEST}" \
+              --certificate-identity "https://github.com/kube-logging/logging-operator/.github/workflows/artifacts.yaml@refs/tags/${version}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" | jq && break
+            done
+          fi
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0


### PR DESCRIPTION
- If the `artifacts.yaml` workflow was pulled in from another repository if failed to sign the image due to invalid identity.
- Added `rekor-url` flag, so signing metadata will be publicly available, and can verify our artifacts upon deploying.