### PR TITLE
 chore: use consts instead of literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ example/tls-cluster-forward/*.key
 .DS_Store
 
 go.work.sum
+
+# Ignore DevSpace cache and log folder and DevSpace configuration file
+.devspace/
+devspace.yaml

--- a/pkg/resources/fluentbit/service.go
+++ b/pkg/resources/fluentbit/service.go
@@ -39,7 +39,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 				},
 				Selector:  r.getFluentBitLabels(),
 				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: "None",
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		}, reconciler.StatePresent, nil
 	}
@@ -107,7 +107,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 				},
 				Selector:  r.getFluentBitLabels(),
 				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: "None",
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		}, reconciler.StatePresent, nil
 	}

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -74,7 +74,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 				},
 				Selector:  r.Logging.GetFluentdLabels(ComponentFluentd, *r.fluentdSpec),
 				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: "None",
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		}, reconciler.StatePresent, nil
 	}
@@ -142,7 +142,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 				},
 				Selector:  r.Logging.GetFluentdLabels(ComponentFluentd, *r.fluentdSpec),
 				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: "None",
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		}, reconciler.StatePresent, nil
 	}

--- a/pkg/resources/nodeagent/service.go
+++ b/pkg/resources/nodeagent/service.go
@@ -41,7 +41,7 @@ func (n *nodeAgentInstance) serviceMetrics() (runtime.Object, reconciler.Desired
 				},
 				Selector:  n.getFluentBitLabels(),
 				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: "None",
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		}
 		err := merge.Merge(desired, n.nodeAgent.FluentbitSpec.MetricsService)

--- a/pkg/resources/syslogng/service.go
+++ b/pkg/resources/syslogng/service.go
@@ -74,7 +74,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 				},
 				Selector:  r.Logging.GetSyslogNGLabels(ComponentSyslogNG),
 				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: "None",
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		}, reconciler.StatePresent, nil
 	}
@@ -141,7 +141,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 				},
 				Selector:  r.Logging.GetSyslogNGLabels(ComponentSyslogNG),
 				Type:      corev1.ServiceTypeClusterIP,
-				ClusterIP: "None",
+				ClusterIP: corev1.ClusterIPNone,
 			},
 		}, reconciler.StatePresent, nil
 	}


### PR DESCRIPTION
- Use consts from `corev1` package, instead of string literals.
- Added devspace components to `.gitignore`.