### PR TITLE
fix: make workload meta overrides not required

### DIFF
--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging-extensions.banzaicloud.io_hosttailers.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging-extensions.banzaicloud.io_hosttailers.yaml
@@ -2679,8 +2679,6 @@ spec:
                       type: object
                     type: array
                 type: object
-            required:
-            - workloadMetaOverrides
             type: object
           status:
             type: object

--- a/charts/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
+++ b/charts/logging-operator/crds/logging-extensions.banzaicloud.io_hosttailers.yaml
@@ -2676,8 +2676,6 @@ spec:
                       type: object
                     type: array
                 type: object
-            required:
-            - workloadMetaOverrides
             type: object
           status:
             type: object

--- a/config/crd/bases/logging-extensions.banzaicloud.io_hosttailers.yaml
+++ b/config/crd/bases/logging-extensions.banzaicloud.io_hosttailers.yaml
@@ -2676,8 +2676,6 @@ spec:
                       type: object
                     type: array
                 type: object
-            required:
-            - workloadMetaOverrides
             type: object
           status:
             type: object

--- a/pkg/sdk/extensions/api/v1alpha1/eventtailer_types.go
+++ b/pkg/sdk/extensions/api/v1alpha1/eventtailer_types.go
@@ -35,10 +35,8 @@ type _metaEventTailer = interface{} //nolint:deadcode,unused
 
 // EventTailerSpec defines the desired state of EventTailer
 type EventTailerSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
 	//+kubebuilder:validation:Required
+
 	// The resources of EventTailer will be placed into this namespace
 	ControlNamespace string `json:"controlNamespace"`
 	// Volume definition for tracking fluentbit file positions (optional)

--- a/pkg/sdk/extensions/api/v1alpha1/hosttailer_types.go
+++ b/pkg/sdk/extensions/api/v1alpha1/hosttailer_types.go
@@ -42,7 +42,6 @@ type HostTailerSpec struct {
 	// daemonset (and possibly other resource in the future) in case there is a change in an immutable field
 	// that otherwise couldn't be managed with a simple update.
 	EnableRecreateWorkloadOnImmutableFieldChange bool `json:"enableRecreateWorkloadOnImmutableFieldChange,omitempty"`
-	//+kubebuilder:validation:Required
 	// Override metadata of the created resources
 	WorkloadMetaBase *types.MetaBase `json:"workloadMetaOverrides,omitempty"`
 	// Override podSpec fields for the given daemonset


### PR DESCRIPTION
Fixes: #1834 

NOTE: This will not break this piece of code: <https://github.com/kube-logging/logging-operator/blob/e45bb86c02c76b132083d3d799bf9fa5abbc4988/pkg/resources/hosttailer/hosttailer.go#L168-L170> since `Merge()` starts with a nil check.