### PR TITLE
chore: lint dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build $GO_BUILD_FLAGS -o /usr/local/bin/manager
 
-FROM builder as debug
+FROM builder AS debug
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go install github.com/go-delve/delve/cmd/dlv@latest
 


### PR DESCRIPTION
This PR fixes the following warning:

![image](https://github.com/user-attachments/assets/9a2d6883-6763-4bbc-ab22-9865085e2c17)
