### PR TITLE
feat: add option to cleanup stuck finalizers

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -53,6 +53,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | http.port | int | `8080` | HTTP listen port number. |
 | http.service | object | `{"annotations":{},"clusterIP":"None","labels":{},"type":"ClusterIP"}` | Service definition for query http service. |
 | rbac.enabled | bool | `true` | Create rbac service account and roles. |
+| rbac.retainOnDelete | bool | `false` | Keep the operators RBAC resources after the operator is deleted to allow removing pending finalizers. |
 | monitoring.serviceMonitor.enabled | bool | `false` | Create a Prometheus Operator ServiceMonitor object. |
 | monitoring.serviceMonitor.additionalLabels | object | `{}` |  |
 | monitoring.serviceMonitor.metricRelabelings | list | `[]` |  |

--- a/charts/logging-operator/templates/clusterrole.yaml
+++ b/charts/logging-operator/templates/clusterrole.yaml
@@ -4,6 +4,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "logging-operator.fullname" . }}
+  annotations:
+  {{- if .Values.rbac.retainOnDelete }}
+    "helm.sh/resource-policy": keep
+  {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/charts/logging-operator/templates/clusterrolebinding.yaml
+++ b/charts/logging-operator/templates/clusterrolebinding.yaml
@@ -4,6 +4,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "logging-operator.fullname" . }}
+  annotations:
+  {{- if .Values.rbac.retainOnDelete }}
+    "helm.sh/resource-policy": keep
+  {{- end }}
   labels:
 {{ include "logging-operator.labels" . | indent 4 }}
 subjects:
@@ -14,5 +18,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "logging-operator.fullname" . }}
-
-  {{- end }}
+{{- end }}

--- a/charts/logging-operator/templates/serviceaccount.yaml
+++ b/charts/logging-operator/templates/serviceaccount.yaml
@@ -7,8 +7,11 @@ metadata:
   namespace: {{ include "logging-operator.namespace" . }}
   labels:
 {{ include "logging-operator.labels" . | indent 4 }}
-{{- with .Values.serviceAccount.annotations }}
   annotations:
+  {{- if .Values.rbac.retainOnDelete }}
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
 {{ toYaml . | indent 4 }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -60,6 +60,8 @@ http:
 rbac:
   # -- Create rbac service account and roles.
   enabled: true
+  # -- Keep the operators RBAC resources after the operator is deleted to allow removing pending finalizers.
+  retainOnDelete: false
 
   # specify service account manually
   # serviceAccountName: custom

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -51,8 +51,12 @@ import (
 	syslogngconfig "github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/config"
 	loggingmodeltypes "github.com/kube-logging/logging-operator/pkg/sdk/logging/model/types"
 
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	loggingv1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+const (
+	SyslogNGConfigFinalizer = "syslogngconfig.logging.banzaicloud.io/finalizer"
+	FluentdConfigFinalizer  = "fluentdconfig.logging.banzaicloud.io/finalizer"
 )
 
 var fluentbitWarning sync.Once
@@ -323,12 +327,10 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *LoggingReconciler) fluentdConfigFinalizer(ctx context.Context, logging *loggingv1beta1.Logging, externalFluentd *loggingv1beta1.FluentdConfig) (bool, error) {
-	fluentdConfigFinalizer := "fluentdconfig.logging.banzaicloud.io/finalizer"
-
 	if logging.DeletionTimestamp.IsZero() {
-		if externalFluentd != nil && !controllerutil.ContainsFinalizer(logging, fluentdConfigFinalizer) {
+		if externalFluentd != nil && !controllerutil.ContainsFinalizer(logging, FluentdConfigFinalizer) {
 			r.Log.Info("adding fluentdconfig finalizer")
-			controllerutil.AddFinalizer(logging, fluentdConfigFinalizer)
+			controllerutil.AddFinalizer(logging, FluentdConfigFinalizer)
 			if err := r.Update(ctx, logging); err != nil {
 				return true, err
 			}
@@ -339,9 +341,9 @@ func (r *LoggingReconciler) fluentdConfigFinalizer(ctx context.Context, logging 
 		return false, errors.New(msg)
 	}
 
-	if controllerutil.ContainsFinalizer(logging, fluentdConfigFinalizer) && externalFluentd == nil {
+	if controllerutil.ContainsFinalizer(logging, FluentdConfigFinalizer) && externalFluentd == nil {
 		r.Log.Info("removing fluentdconfig finalizer")
-		controllerutil.RemoveFinalizer(logging, fluentdConfigFinalizer)
+		controllerutil.RemoveFinalizer(logging, FluentdConfigFinalizer)
 		if err := r.Update(ctx, logging); err != nil {
 			return true, err
 		}
@@ -351,12 +353,10 @@ func (r *LoggingReconciler) fluentdConfigFinalizer(ctx context.Context, logging 
 }
 
 func (r *LoggingReconciler) syslogNGConfigFinalizer(ctx context.Context, logging *loggingv1beta1.Logging, externalSyslogNG *loggingv1beta1.SyslogNGConfig) (bool, error) {
-	syslogNGConfigFinalizer := "syslogngconfig.logging.banzaicloud.io/finalizer"
-
 	if logging.DeletionTimestamp.IsZero() {
-		if externalSyslogNG != nil && !controllerutil.ContainsFinalizer(logging, syslogNGConfigFinalizer) {
+		if externalSyslogNG != nil && !controllerutil.ContainsFinalizer(logging, SyslogNGConfigFinalizer) {
 			r.Log.Info("adding syslogngconfig finalizer")
-			controllerutil.AddFinalizer(logging, syslogNGConfigFinalizer)
+			controllerutil.AddFinalizer(logging, SyslogNGConfigFinalizer)
 			if err := r.Update(ctx, logging); err != nil {
 				return true, err
 			}
@@ -367,9 +367,9 @@ func (r *LoggingReconciler) syslogNGConfigFinalizer(ctx context.Context, logging
 		return false, errors.New(msg)
 	}
 
-	if controllerutil.ContainsFinalizer(logging, syslogNGConfigFinalizer) && externalSyslogNG == nil {
+	if controllerutil.ContainsFinalizer(logging, SyslogNGConfigFinalizer) && externalSyslogNG == nil {
 		r.Log.Info("removing syslogngconfig finalizer")
-		controllerutil.RemoveFinalizer(logging, syslogNGConfigFinalizer)
+		controllerutil.RemoveFinalizer(logging, SyslogNGConfigFinalizer)
 		if err := r.Update(ctx, logging); err != nil {
 			return true, err
 		}
@@ -378,7 +378,7 @@ func (r *LoggingReconciler) syslogNGConfigFinalizer(ctx context.Context, logging
 	return false, nil
 }
 
-func (r *LoggingReconciler) dynamicDefaults(ctx context.Context, log logr.Logger, syslogNGSpec *v1beta1.SyslogNGSpec) {
+func (r *LoggingReconciler) dynamicDefaults(ctx context.Context, log logr.Logger, syslogNGSpec *loggingv1beta1.SyslogNGSpec) {
 	nodes := corev1.NodeList{}
 	if err := r.Client.List(ctx, &nodes); err != nil {
 		log.Error(err, "listing nodes")


### PR DESCRIPTION
## Overview

This PR aims to address the issue raised in #1859.

### Problem

The issue arises because Helm does not guarantee a precise order in which it deletes resources. Although this order can be influenced via hooks and weights, there are limitations. For example, hooks may not work as expected in ArgoCD environments.

### Proposed Solution

- Added a new flag to the operator service: `finalizer-cleanup`. This flag should be used in conjunction with `.Values.rbac.retainOnDelete`.
- When both options are set and `helm uninstall` is executed:
  1. Helm will retain the operator's service account as well as its cluster role and cluster role binding. This is necessary because Helm uninstalls resources in an unpredictable order.
  2. The operator will attempt to free up its managed logging resources by removing finalizers, which would otherwise remain stuck.

### How to Use This Feature

Since this problem was observed when the operator was uninstalled via `helm uninstall`, the feature has been implemented to be enabled by modifying the chart:

```sh
helm install logging-operator ./charts/logging-operator/ --set rbac.retainOnDelete=true --set extraArgs='{"-enable-leader-election=true","-finalizer-cleanup=true"}'
```
