### PR TITLE
fix: fluentd prom metrics invalid addr

### DIFF
--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -38,7 +38,7 @@ var fluentBitConfigTemplate = `
     Coro_Stack_Size    {{ .CoroStackSize }}
     {{- if .Monitor.Enabled }}
     HTTP_Server  On
-    {{- if .EnabledIPv6 }}
+    {{- if .Monitor.EnabledIPv6 }}
     HTTP_Listen  [::]
     {{- else }}
     Listen 0.0.0.0

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -60,14 +60,14 @@ type upstream struct {
 type fluentBitConfig struct {
 	Namespace string
 	Monitor   struct {
-		Enabled bool
-		Port    int32
-		Path    string
+		Enabled     bool
+		Port        int32
+		EnabledIPv6 bool
+		Path        string
 	}
 	Flush                    int32
 	Grace                    int32
 	LogLevel                 string
-	EnabledIPv6              bool
 	CoroStackSize            int32
 	Output                   map[string]string
 	ForceHotReloadAfterGrace bool
@@ -219,7 +219,6 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		Grace:                    r.fluentbitSpec.Grace,
 		ForceHotReloadAfterGrace: r.fluentbitSpec.ForceHotReloadAfterGrace,
 		LogLevel:                 r.fluentbitSpec.LogLevel,
-		EnabledIPv6:              r.fluentbitSpec.EnabledIPv6,
 		CoroStackSize:            r.fluentbitSpec.CoroStackSize,
 		Namespace:                r.Logging.Spec.ControlNamespace,
 		DisableKubernetesFilter:  disableKubernetesFilter,
@@ -236,6 +235,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 	if r.fluentbitSpec.Metrics != nil {
 		input.Monitor.Enabled = true
 		input.Monitor.Port = r.fluentbitSpec.Metrics.Port
+		input.Monitor.EnabledIPv6 = r.fluentbitSpec.EnabledIPv6
 		input.Monitor.Path = r.fluentbitSpec.Metrics.Path
 	}
 

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -67,7 +67,7 @@ var fluentdInputTemplate = `
 <source>
     @type prometheus
     @id in_prometheus6
-    bind "::"
+    bind [::]
     port {{ .Monitor.Port }}
 {{- if .Monitor.Path }}
     metrics_path {{ .Monitor.Path }}

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -58,22 +58,18 @@ var fluentdInputTemplate = `
 {{ if .Monitor.Enabled }}
 <source>
     @type prometheus
-    port {{ .Monitor.Port }}
-{{- if .Monitor.Path }}
-    metrics_path {{ .Monitor.Path }}
-{{- end }}
-</source>
-{{- if .EnabledIPv6 }}
-<source>
-    @type prometheus
+    {{- if .Monitor.EnabledIPv6 }}
     @id in_prometheus6
-    bind [::]
+    bind "::"
+    {{- else }}
+    bind "0.0.0.0"
+    {{- end }}
     port {{ .Monitor.Port }}
-{{- if .Monitor.Path }}
+    {{- if .Monitor.Path }}
     metrics_path {{ .Monitor.Path }}
-{{- end }}
+    {{- end }}
 </source>
-{{- end }}
+
 <source>
     @type prometheus_monitor
 </source>

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -27,13 +27,13 @@ import (
 )
 
 type fluentdConfig struct {
-	LogFormat   string
-	LogLevel    string
-	EnabledIPv6 bool
-	Monitor     struct {
-		Enabled bool
-		Port    int32
-		Path    string
+	LogFormat string
+	LogLevel  string
+	Monitor   struct {
+		Enabled     bool
+		Port        int32
+		EnabledIPv6 bool
+		Path        string
 	}
 	IgnoreSameLogInterval     string
 	IgnoreRepeatedLogInterval string
@@ -63,7 +63,6 @@ func (r *Reconciler) generateConfigSecret(fluentdSpec v1beta1.FluentdSpec) (map[
 		Workers:                   fluentdSpec.Workers,
 		LogFormat:                 fluentdSpec.LogFormat,
 		LogLevel:                  fluentdSpec.LogLevel,
-		EnabledIPv6:               fluentdSpec.EnabledIPv6,
 	}
 
 	input.RootDir = fluentdSpec.RootDir
@@ -74,6 +73,7 @@ func (r *Reconciler) generateConfigSecret(fluentdSpec v1beta1.FluentdSpec) (map[
 	if fluentdSpec.Metrics != nil {
 		input.Monitor.Enabled = true
 		input.Monitor.Port = fluentdSpec.Metrics.Port
+		input.Monitor.EnabledIPv6 = fluentdSpec.EnabledIPv6
 		input.Monitor.Path = fluentdSpec.Metrics.Path
 	}
 

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -63,6 +63,7 @@ func (r *Reconciler) generateConfigSecret(fluentdSpec v1beta1.FluentdSpec) (map[
 		Workers:                   fluentdSpec.Workers,
 		LogFormat:                 fluentdSpec.LogFormat,
 		LogLevel:                  fluentdSpec.LogLevel,
+		EnabledIPv6:               fluentdSpec.EnabledIPv6,
 	}
 
 	input.RootDir = fluentdSpec.RootDir


### PR DESCRIPTION
Fixes: #1870
Relates: #1890
 
- IPv6 was not wired in properly, so it had no effect.
- Once it was wired in it turned out to be faulty:

```sh
[error]: unexpected error error_class=SocketError error=#<SocketError: getaddrinfo: Name or service not known>
```
