### PR TITLE
Revert "expose fluentd metrics also on IPv6"

### DIFF
--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -64,15 +64,6 @@ var fluentdInputTemplate = `
 {{- end }}
 </source>
 <source>
-    @type prometheus
-    @id in_prometheus6
-    bind "::"
-    port {{ .Monitor.Port }}
-{{- if .Monitor.Path }}
-    metrics_path {{ .Monitor.Path }}
-{{- end }}
-</source>
-<source>
     @type prometheus_monitor
 </source>
 <source>


### PR DESCRIPTION
This reverts commit 386eaf0f3364caab3192c92e46882fca8c71ee97.

Fixes the issue reported in #1890 

IPv6 is available in version 5.0 of the logging operator