### PR TITLE
fix: add missing roles to grant the use of scc to workloads

### DIFF
--- a/charts/logging-operator/templates/clusterrole.yaml
+++ b/charts/logging-operator/templates/clusterrole.yaml
@@ -244,6 +244,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
   - telemetry.kube-logging.dev
   resources:
   - bridges

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -239,6 +239,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
   - telemetry.kube-logging.dev
   resources:
   - bridges

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -101,6 +101,7 @@ type LoggingReconciler struct {
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=*
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=anyuid;privileged,verbs=use
 
 // Reconcile logging resources
 func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Example configuration needed to run on Openshift:
```
  fluentbit:
    security:
      createOpenShiftSCC: true
      roleBasedAccessControlCreate: true
      securityContext:
        privileged: true
        runAsUser: 0
```