### PR TITLE
feat(chart): enable defining multiple hosttailers

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -108,16 +108,8 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | logging.eventTailer.workloadMetaOverrides | string | `nil` | workloadMetaOverrides |
 | logging.eventTailer.workloadOverrides | string | `nil` | workloadOverrides |
 | logging.eventTailer.containerOverrides | string | `nil` | containerOverrides |
-| logging.hostTailer.enabled | bool | `false` | HostTailer |
-| logging.hostTailer.name | string | `"hosttailer"` | name of HostTailer |
-| logging.hostTailer.image.repository | string | `nil` | repository of eventTailer image |
-| logging.hostTailer.image.tag | string | `nil` | tag of eventTailer image |
-| logging.hostTailer.image.pullPolicy | string | `nil` | pullPolicy of eventTailer image |
-| logging.hostTailer.image.imagePullSecrets | list | `[]` | imagePullSecrets of eventTailer image |
-| logging.hostTailer.workloadMetaOverrides | string | `nil` | workloadMetaOverrides of HostTailer |
-| logging.hostTailer.workloadOverrides | string | `nil` | workloadOverrides of HostTailer |
-| logging.hostTailer.fileTailers | list | `[]` | configure fileTailers of HostTailer example:   - name: sample-file     path: /var/log/sample-file     disabled: false     buffer_max_size:     buffer_chunk_size:     skip_long_lines:     read_from_head: false     containerOverrides:     image: |
-| logging.hostTailer.systemdTailers | list | `[]` | configure systemdTailers of HostTailer example:   - name: system-sample     disabled: false     systemdFilter: kubelet.service     maxEntries: 20     containerOverrides:     image: |
+| logging.hostTailers.enabled | bool | `false` | Enable all hostTailers |
+| logging.hostTailers.instances | list | `[]` | List of hostTailers configurations |
 | testReceiver.enabled | bool | `false` |  |
 | testReceiver.image | string | `"fluent/fluent-bit"` |  |
 | testReceiver.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -108,6 +108,16 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | logging.eventTailer.workloadMetaOverrides | string | `nil` | workloadMetaOverrides |
 | logging.eventTailer.workloadOverrides | string | `nil` | workloadOverrides |
 | logging.eventTailer.containerOverrides | string | `nil` | containerOverrides |
+| logging.hostTailer.enabled | bool | `false` | HostTailer |
+| logging.hostTailer.name | string | `"hosttailer"` | name of HostTailer |
+| logging.hostTailer.image.repository | string | `nil` | repository of eventTailer image |
+| logging.hostTailer.image.tag | string | `nil` | tag of eventTailer image |
+| logging.hostTailer.image.pullPolicy | string | `nil` | pullPolicy of eventTailer image |
+| logging.hostTailer.image.imagePullSecrets | list | `[]` | imagePullSecrets of eventTailer image |
+| logging.hostTailer.workloadMetaOverrides | string | `nil` | workloadMetaOverrides of HostTailer |
+| logging.hostTailer.workloadOverrides | string | `nil` | workloadOverrides of HostTailer |
+| logging.hostTailer.fileTailers | list | `[]` | configure fileTailers of HostTailer example:   - name: sample-file     path: /var/log/sample-file     disabled: false     buffer_max_size:     buffer_chunk_size:     skip_long_lines:     read_from_head: false     containerOverrides:     image: |
+| logging.hostTailer.systemdTailers | list | `[]` | configure systemdTailers of HostTailer example:   - name: system-sample     disabled: false     systemdFilter: kubelet.service     maxEntries: 20     containerOverrides:     image: |
 | logging.hostTailers.enabled | bool | `false` | Enable all hostTailers |
 | logging.hostTailers.instances | list | `[]` | List of hostTailers configurations |
 | testReceiver.enabled | bool | `false` |  |

--- a/charts/logging-operator/templates/logging/hosttailer.yaml
+++ b/charts/logging-operator/templates/logging/hosttailer.yaml
@@ -1,5 +1,6 @@
-{{- with .Values.logging.hostTailer }}
-{{- if and $.Values.logging.enabled .enabled }}
+{{- if and $.Values.logging.enabled $.Values.logging.hostTailers.enabled }}
+{{- range .Values.logging.hostTailers.instances }}
+{{- if .enabled }}
 ---
 apiVersion: logging-extensions.banzaicloud.io/v1alpha1
 kind: HostTailer
@@ -27,5 +28,6 @@ spec:
   image:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/logging-operator/templates/logging/hosttailers.yaml
+++ b/charts/logging-operator/templates/logging/hosttailers.yaml
@@ -1,5 +1,6 @@
-{{- with .Values.logging.hostTailer }}
-{{- if and $.Values.logging.enabled .enabled }}
+{{- if and $.Values.logging.enabled $.Values.logging.hostTailers.enabled }}
+{{- range .Values.logging.hostTailers.instances }}
+{{- if .enabled }}
 ---
 apiVersion: logging-extensions.banzaicloud.io/v1alpha1
 kind: HostTailer
@@ -27,5 +28,6 @@ spec:
   image:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -284,6 +284,47 @@ logging:
     # -- containerOverrides
     containerOverrides:
 
+  # DEPRECATED: HostTailer config will be removed, use hostTailers instead
+  hostTailer:
+    # -- HostTailer
+    enabled: false
+    # -- name of HostTailer
+    name: hosttailer
+    image:
+      # -- repository of eventTailer image
+      repository:
+      # -- tag of eventTailer image
+      tag:
+      # -- pullPolicy of eventTailer image
+      pullPolicy:
+      # -- imagePullSecrets of eventTailer image
+      imagePullSecrets: []
+    # -- workloadMetaOverrides of HostTailer
+    workloadMetaOverrides:
+    # -- workloadOverrides of HostTailer
+    workloadOverrides:
+    # -- configure fileTailers of HostTailer
+    # example:
+    #   - name: sample-file
+    #     path: /var/log/sample-file
+    #     disabled: false
+    #     buffer_max_size:
+    #     buffer_chunk_size:
+    #     skip_long_lines:
+    #     read_from_head: false
+    #     containerOverrides:
+    #     image:
+    fileTailers: []
+    # -- configure systemdTailers of HostTailer
+    # example:
+    #   - name: system-sample
+    #     disabled: false
+    #     systemdFilter: kubelet.service
+    #     maxEntries: 20
+    #     containerOverrides:
+    #     image:
+    systemdTailers: []
+
   hostTailers:
     # -- Enable all hostTailers
     enabled: false

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -284,45 +284,46 @@ logging:
     # -- containerOverrides
     containerOverrides:
 
-  hostTailer:
-    # -- HostTailer
+  hostTailers:
+    # -- Enable all hostTailers
     enabled: false
-    # -- name of HostTailer
-    name: hosttailer
-    image:
-      # -- repository of eventTailer image
-      repository:
-      # -- tag of eventTailer image
-      tag:
-      # -- pullPolicy of eventTailer image
-      pullPolicy:
-      # -- imagePullSecrets of eventTailer image
-      imagePullSecrets: []
-    # -- workloadMetaOverrides of HostTailer
-    workloadMetaOverrides:
-    # -- workloadOverrides of HostTailer
-    workloadOverrides:
-    # -- configure fileTailers of HostTailer
-    # example:
-    #   - name: sample-file
-    #     path: /var/log/sample-file
-    #     disabled: false
-    #     buffer_max_size:
-    #     buffer_chunk_size:
-    #     skip_long_lines:
-    #     read_from_head: false
-    #     containerOverrides:
-    #     image:
-    fileTailers: []
-    # -- configure systemdTailers of HostTailer
-    # example:
-    #   - name: system-sample
-    #     disabled: false
-    #     systemdFilter: kubelet.service
-    #     maxEntries: 20
-    #     containerOverrides:
-    #     image:
-    systemdTailers: []
+    # -- List of hostTailers configurations
+    instances: []
+    # - name: hosttailer
+      # -- Enable hostTailer
+      # enabled: true
+      # image:
+        # -- repository of eventTailer image
+        # repository:
+        # -- tag of eventTailer image
+        # tag:
+        # -- pullPolicy of eventTailer image
+        # pullPolicy:
+        # -- imagePullSecrets of eventTailer image
+        # imagePullSecrets: []
+      # -- workloadMetaOverrides of HostTailer
+      # workloadMetaOverrides: {}
+      # -- workloadOverrides of HostTailer
+      # workloadOverrides: {}
+      # -- configure fileTailers of HostTailer
+      # fileTailers:
+      # - name: sample-file
+      #   path: /var/log/sample-file
+      #   disabled: false
+      #   buffer_max_size:
+      #   buffer_chunk_size:
+      #   skip_long_lines:
+      #   read_from_head: false
+      #   containerOverrides:
+      #   image:
+      # -- configure systemdTailers of HostTailer
+      # systemdTailers:
+      # - name: system-sample
+      #   disabled: false
+      #   systemdFilter: kubelet.service
+      #   maxEntries: 20
+      #   containerOverrides:
+      #   image:
 
 testReceiver:
   enabled: false


### PR DESCRIPTION
Fixes: https://github.com/kube-logging/logging-operator/issues/1909

### Deprecation notice

`logging.hostTailer` is superseded by `logging.hostTailers` and will be removed in a future release

### Example

```yaml
logging:
  enabled: true
  hostTailers:
    enabled: true
    instances:
      - name: kubeauditane
        enabled: true
        workloadOverrides:
          nodeSelector:
            node-role.kubernetes.io/control-plane: "true"
          tolerations:
            - key: node-role.kubernetes.io/control-plane
              operator: Exists
              effect: NoSchedule
        fileTailers:
          - name: kube-audit
            path: /var/lib/rancher/rke2/server/logs/*.log
      
      - name: workersnodesonly
        enabled: true
        workloadOverrides:
          nodeSelector:
            node-role.kubernetes.io/worker: "true"
        fileTailers:
          - name: kube-audit
            path: /var/lib/rancher/rke2/agent/logs/*.log
```