### PR TITLE
chore(ci): update go-test-coverage to utilize source-dir parameter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,10 @@ jobs:
         run: make generate-test-coverage
 
       - name: Test Coverage
-        uses: vladopajic/go-test-coverage@f5435e92b0a4496013d599a34389f4fbd9985a01 # v2.12.1
+        uses: vladopajic/go-test-coverage@992aa9921a42c39d1fe0015d32593f0820589586 # v2.13.0
         with:
           config: ./.testcoverage.yml
+          source-dir: ./
 
   lint:
     name: Lint

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -110,9 +110,11 @@ jobs:
 #          SHARD: ${{ matrix.SHARD }}
 #          SHARDS: ${{ matrix.SHARDS }}
 
-      # This is a workaround as the action does not support setting working directory
       - name: Run coverage report
-        run: make test-e2e-coverage-report-ci
+        uses: vladopajic/go-test-coverage@992aa9921a42c39d1fe0015d32593f0820589586 # v2.13.0
+        with:
+          profile: ./build/_test_coverage/coverage_e2e.out
+          source-dir: ./
 
       - name: Archive Test Results
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CONTROLLER_GEN_VERSION := 0.17.2
 GOLANGCI_LINT_VERSION := 1.64.6
 
 # renovate: datasource=go depName=github.com/vladopajic/go-test-coverage/v2 versioning=semver
-GO_TEST_COVERAGE_VERSION := 2.12.1
+GO_TEST_COVERAGE_VERSION := 2.13.0
 
 # renovate: datasource=github-releases depName=norwoodj/helm-docs versioning=semver
 HELM_DOCS_VERSION = 1.14.2


### PR DESCRIPTION
This is a proper fix instead of the workaround introduced in ae06c5711abbf49a24a5abdfcc5b0d67b06472a0