### PR TITLE
feat(chart): aggregated view clusterrole

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -55,6 +55,9 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | http.service | object | `{"annotations":{},"clusterIP":"None","labels":{},"type":"ClusterIP"}` | Service definition for query http service. |
 | rbac.enabled | bool | `true` | Create rbac service account and roles. |
 | rbac.retainOnDelete | bool | `false` | Keep the operators RBAC resources after the operator is deleted to allow removing pending finalizers. |
+| rbac.createAggregatedViewClusterRole | bool | `false` | Create ClusterRole that extend the existing view ClusterRole to interact with logging-operator CRDs # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles |
+| rbac.createAggregatedEditClusterRole | bool | `true` | Create ClusterRole that extend the existing edit ClusterRole to interact with logging-operator CRDs # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles |
+| rbac.createAggregatedAdminClusterRole | bool | `true` | Create ClusterRole that extend the existing admin ClusterRole to interact with logging-operator CRDs # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles |
 | monitoring.serviceMonitor.enabled | bool | `false` | Create a Prometheus Operator ServiceMonitor object. |
 | monitoring.serviceMonitor.additionalLabels | object | `{}` |  |
 | monitoring.serviceMonitor.metricRelabelings | list | `[]` |  |

--- a/charts/logging-operator/templates/userrole.yaml
+++ b/charts/logging-operator/templates/userrole.yaml
@@ -1,12 +1,17 @@
 {{- if .Values.rbac.enabled }}
+{{- if or .Values.rbac.createAggregatedEditClusterRole .Values.rbac.createAggregatedAdminClusterRole }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "logging-operator.fullname" . }}-edit
   labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- if .Values.rbac.createAggregatedEditClusterRole }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- end }}
+    {{- if .Values.rbac.createAggregatedAdminClusterRole }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
 {{ include "logging-operator.labels" . | indent 4 }}
 rules:
 - apiGroups:
@@ -37,4 +42,34 @@ rules:
   - patch
   - update
   - watch
+{{- end }}
+{{- if .Values.rbac.createAggregatedViewClusterRole }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "logging-operator.fullname" . }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+{{ include "logging-operator.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - logging.banzaicloud.io
+  resources:
+  - flows
+  - outputs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - logging.banzaicloud.io
+  resources:
+  - syslogngflows
+  - syslogngoutputs
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 {{- end }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -67,9 +67,17 @@ rbac:
   enabled: true
   # -- Keep the operators RBAC resources after the operator is deleted to allow removing pending finalizers.
   retainOnDelete: false
-
   # specify service account manually
   # serviceAccountName: custom
+  # -- Create ClusterRole that extend the existing view ClusterRole to interact with logging-operator CRDs
+  ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
+  createAggregatedViewClusterRole: false
+  # -- Create ClusterRole that extend the existing edit ClusterRole to interact with logging-operator CRDs
+  ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
+  createAggregatedEditClusterRole: true
+  # -- Create ClusterRole that extend the existing admin ClusterRole to interact with logging-operator CRDs
+  ## Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
+  createAggregatedAdminClusterRole: true
 
 monitoring:
   serviceMonitor:


### PR DESCRIPTION
- Introduce `rbac.createAggregatedEditClusterRole` and `rbac.createAggregatedAdminClusterRole` to control the deployment of existing `edit` and `admin` aggregated cluster roles. Defaults to `true` to retain current behavior.
- Introduce `rbac.createAggregatedViewClusterRole` to control the deployment of a new `view` aggregated cluster role. Defaults to `false` to retain current behavior.
