### PR TITLE
fix(ci-e2e): make sure e2e tests are not cached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ test-e2e-nodeps:
 		KIND_IMAGE="$(KIND_IMAGE)" \
 		PROJECT_DIR="$(PWD)" \
 		E2E_TEST_COV_DIR=${TEST_COV_DIR} \
-		go test -v -timeout ${E2E_TEST_TIMEOUT} ./${E2E_TEST}/...
+		go test -count=1 -v -timeout ${E2E_TEST_TIMEOUT} ./${E2E_TEST}/...
 		go tool covdata textfmt -i=${TEST_COV_DIR}/covdatafiles -o ${TEST_COV_DIR}/coverage_e2e.out
 	@echo "--- E2E test coverage report"
 	go tool covdata percent -i=${TEST_COV_DIR}/covdatafiles


### PR DESCRIPTION
The CI could fail if the e2e tests were cached, since no coverage files would be created.

eg.: https://github.com/kube-logging/logging-operator/actions/runs/14020628629/job/39252238195?pr=1988