### PR TITLE
chore: migrate to v2 golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,39 @@
-linters-settings:
+version: "2"
+run:
+  timeout: 10m
+  allow-parallel-runners: true
+
+formatters:
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/kube-logging/logging-operator)
+    goimports:
+      local-prefixes:
+        - github.com/kube-logging/logging-operator
+    gofmt:
+      simplify: true
+    gofumpt:
+      extra-rules: false
+
+linters:
+  settings:
+    misspell:
+      locale: US
     revive:
-        min-confidence: 0.9
+      confidence: 0.9
     gocyclo:
-        min-complexity: 15
-
-
-issues:
-  exclude-dirs:
-    - .gen
-    - client
-  exclude:
-        - if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
-        - "`if` block ends with a `return` statement, so drop this `else` and outdent its block"
-        - "missing the call to method parallel"
+      min-complexity: 15
+  enable:
+    - bodyclose
+    - errcheck
+    - ineffassign
+    - misspell
+    - nolintlint
+    - revive
+    - unconvert
+    - unparam
+    - unused
+    - whitespace

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 CONTROLLER_GEN_VERSION := 0.17.2
 
 # renovate: datasource=github-releases depName=golangci/golangci-lint versioning=semver
-GOLANGCI_LINT_VERSION := 1.64.8
+GOLANGCI_LINT_VERSION := 2.0.2
 
 # renovate: datasource=go depName=github.com/vladopajic/go-test-coverage/v2 versioning=semver
 GO_TEST_COVERAGE_VERSION := 2.13.0
@@ -284,7 +284,7 @@ ${ENVTEST_BINARY_ASSETS}_${ENVTEST_K8S_VERSION}: | ${SETUP_ENVTEST} ${ENVTEST_BI
 ${GOLANGCI_LINT}: ${GOLANGCI_LINT}_${GOLANGCI_LINT_VERSION}_${GOVERSION} | ${BIN}
 	ln -sf $(notdir $<) $@
 
-${GOLANGCI_LINT}_${GOLANGCI_LINT_VERSION}_${GOVERSION}: IMPORT_PATH := github.com/golangci/golangci-lint/cmd/golangci-lint
+${GOLANGCI_LINT}_${GOLANGCI_LINT_VERSION}_${GOVERSION}: IMPORT_PATH := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 ${GOLANGCI_LINT}_${GOLANGCI_LINT_VERSION}_${GOVERSION}: VERSION := v${GOLANGCI_LINT_VERSION}
 ${GOLANGCI_LINT}_${GOLANGCI_LINT_VERSION}_${GOVERSION}: | ${BIN}
 	${go_install_binary}

--- a/controllers/extensions/eventtailer_controller.go
+++ b/controllers/extensions/eventtailer_controller.go
@@ -56,7 +56,7 @@ func (r *EventTailerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	eventTailer := loggingextensionsv1alpha1.EventTailer{}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &eventTailer); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &eventTailer); err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}

--- a/controllers/extensions/hosttailer_controller.go
+++ b/controllers/extensions/hosttailer_controller.go
@@ -54,7 +54,7 @@ func (r *HostTailerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	hosttailer := loggingextensionsv1alpha1.HostTailer{}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &hosttailer); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &hosttailer); err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -111,7 +111,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	log.V(1).Info("reconciling")
 
 	var logging loggingv1beta1.Logging
-	if err := r.Client.Get(ctx, req.NamespacedName, &logging); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &logging); err != nil {
 		// If object is not found, return without error.
 		// Created objects are automatically garbage collected.
 		// For additional cleanup logic use finalizers.
@@ -120,14 +120,14 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var missingCRDs []string
 
-	if err := r.Client.List(ctx, &v1.ServiceMonitorList{}); err == nil {
+	if err := r.List(ctx, &v1.ServiceMonitorList{}); err == nil {
 		//nolint:staticcheck
 		ctx = context.WithValue(ctx, resources.ServiceMonitorKey, true)
 	} else {
 		missingCRDs = append(missingCRDs, "ServiceMonitor")
 	}
 
-	if err := r.Client.List(ctx, &v1.PrometheusRuleList{}); err == nil {
+	if err := r.List(ctx, &v1.PrometheusRuleList{}); err == nil {
 		//nolint:staticcheck
 		ctx = context.WithValue(ctx, resources.PrometheusRuleKey, true)
 	} else {
@@ -384,7 +384,7 @@ func (r *LoggingReconciler) syslogNGConfigFinalizer(ctx context.Context, logging
 
 func (r *LoggingReconciler) dynamicDefaults(ctx context.Context, log logr.Logger, syslogNGSpec *loggingv1beta1.SyslogNGSpec) {
 	nodes := corev1.NodeList{}
-	if err := r.Client.List(ctx, &nodes); err != nil {
+	if err := r.List(ctx, &nodes); err != nil {
 		log.Error(err, "listing nodes")
 	}
 	if syslogNGSpec != nil && syslogNGSpec.MaxConnections == 0 {

--- a/controllers/logging/loggingroute_controller.go
+++ b/controllers/logging/loggingroute_controller.go
@@ -49,7 +49,7 @@ type LoggingRouteReconciler struct {
 // Reconcile routes between logging domains
 func (r *LoggingRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var loggingRoute loggingv1beta1.LoggingRoute
-	if err := r.Client.Get(ctx, req.NamespacedName, &loggingRoute); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &loggingRoute); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/docs/configuration/crds/v1beta1/fluentd_types.md
+++ b/docs/configuration/crds/v1beta1/fluentd_types.md
@@ -228,7 +228,7 @@ ExtraVolume defines the fluentd extra volumes
 
 ## FluentdScaling
 
-FluentdScaling enables configuring the scaling behaviour of the fluentd statefulset
+FluentdScaling enables configuring the scaling behavior of the fluentd statefulset
 
 ### drain (FluentdDrainConfig, optional) {#fluentdscaling-drain}
 

--- a/docs/configuration/plugins/filters/elasticsearch_genid.md
+++ b/docs/configuration/plugins/filters/elasticsearch_genid.md
@@ -64,7 +64,7 @@ You can specify keys which are record in events for hash generation seed. This p
 
 ### separator (string, optional) {#elasticsearchgenid-separator}
 
-You can specify separator charactor to creating seed for hash generation. 
+You can specify separator character to creating seed for hash generation. 
 
 
 ### use_entire_record (bool, optional) {#elasticsearchgenid-use_entire_record}

--- a/docs/configuration/plugins/filters/parser.md
+++ b/docs/configuration/plugins/filters/parser.md
@@ -127,7 +127,7 @@ If true, keep time field in the record.
 
 ### keys (string, optional) {#parse section-keys}
 
-Names for fields on each line. (seperated by coma) 
+Names for fields on each line. (separated by coma) 
 
 
 ### label_delimiter (string, optional) {#parse section-label_delimiter}

--- a/main.go
+++ b/main.go
@@ -257,7 +257,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }
 
 // Extends sigs.k8s.io/controller-runtime@v0.17.2/pkg/manager/signals/signal.go with

--- a/pkg/resources/configcheck/configcheck.go
+++ b/pkg/resources/configcheck/configcheck.go
@@ -34,7 +34,7 @@ func WithHashLabel(accessor v1.Object, hash string) {
 	accessor.SetLabels(l)
 }
 
-func hasHashLabel(accessor v1.Object, hash string) (has bool, match bool) {
+func hasHashLabel(accessor v1.Object, hash string) (has bool, match bool) { //nolint: unparam
 	l := accessor.GetLabels()
 	var val string
 	val, has = l[HashLabel]

--- a/pkg/resources/eventtailer/clusterrolebinding.go
+++ b/pkg/resources/eventtailer/clusterrolebinding.go
@@ -17,22 +17,21 @@ package eventtailer
 import (
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	rbacv1 "k8s.io/api/rbac/v1"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ClusterRoleBinding resource for reconciler
 func (e *EventTailer) ClusterRoleBinding() (runtime.Object, reconciler.DesiredState, error) {
-	clusterRoleBinding := v1.ClusterRoleBinding{
+	clusterRoleBinding := rbacv1.ClusterRoleBinding{
 		ObjectMeta: e.clusterObjectMeta(),
-		Subjects: []v1.Subject{
+		Subjects: []rbacv1.Subject{
 			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      e.Name(),
 				Namespace: e.customResource.Spec.ControlNamespace,
 			},
 		},
-		RoleRef: v1.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",
 			Name:     e.Name(),

--- a/pkg/resources/eventtailer/helpers.go
+++ b/pkg/resources/eventtailer/helpers.go
@@ -20,16 +20,16 @@ import (
 	"github.com/cisco-open/operator-tools/pkg/types"
 	"github.com/cisco-open/operator-tools/pkg/utils"
 	config "github.com/kube-logging/logging-operator/pkg/sdk/extensions/extensionsconfig"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Name .
 func (e *EventTailer) Name() string {
-	return fmt.Sprintf("%v-%v", e.customResource.ObjectMeta.Name, config.EventTailer.TailerAffix)
+	return fmt.Sprintf("%v-%v", e.customResource.Name, config.EventTailer.TailerAffix)
 }
 
-func (e *EventTailer) objectMeta() v1.ObjectMeta {
-	meta := v1.ObjectMeta{
+func (e *EventTailer) objectMeta() metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{
 		Name:            e.Name(),
 		Namespace:       e.customResource.Spec.ControlNamespace,
 		Labels:          e.selectorLabels(),
@@ -38,8 +38,8 @@ func (e *EventTailer) objectMeta() v1.ObjectMeta {
 	return meta
 }
 
-func (e *EventTailer) clusterObjectMeta() v1.ObjectMeta {
-	meta := v1.ObjectMeta{
+func (e *EventTailer) clusterObjectMeta() metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{
 		Name:            e.Name(),
 		Labels:          e.selectorLabels(),
 		OwnerReferences: e.ownerReferences(),
@@ -47,13 +47,13 @@ func (e *EventTailer) clusterObjectMeta() v1.ObjectMeta {
 	return meta
 }
 
-func (e *EventTailer) ownerReferences() []v1.OwnerReference {
-	ownerReferences := []v1.OwnerReference{
+func (e *EventTailer) ownerReferences() []metav1.OwnerReference {
+	ownerReferences := []metav1.OwnerReference{
 		{
-			APIVersion: e.customResource.TypeMeta.APIVersion,
-			Kind:       e.customResource.TypeMeta.Kind,
-			Name:       e.customResource.ObjectMeta.Name,
-			UID:        e.customResource.ObjectMeta.UID,
+			APIVersion: e.customResource.APIVersion,
+			Kind:       e.customResource.Kind,
+			Name:       e.customResource.Name,
+			UID:        e.customResource.UID,
 			Controller: utils.BoolPointer(true),
 		},
 	}

--- a/pkg/resources/eventtailer/statefulset.go
+++ b/pkg/resources/eventtailer/statefulset.go
@@ -47,7 +47,6 @@ func (e *EventTailer) StatefulSet() (runtime.Object, reconciler.DesiredState, er
 }
 
 func (e *EventTailer) statefulSetSpec() *appsv1.StatefulSetSpec {
-
 	if e.customResource.Spec.Image != nil {
 		if repositoryWithTag := e.customResource.Spec.Image.RepositoryWithTag(); repositoryWithTag != "" {
 			if e.customResource.Spec.ContainerBase == nil {
@@ -60,7 +59,7 @@ func (e *EventTailer) statefulSetSpec() *appsv1.StatefulSetSpec {
 		if e.customResource.Spec.ContainerBase == nil {
 			e.customResource.Spec.ContainerBase = &types.ContainerBase{}
 		}
-		e.customResource.Spec.ContainerBase.PullPolicy = corev1.PullPolicy(e.customResource.Spec.ContainerBase.PullPolicy)
+		e.customResource.Spec.ContainerBase.PullPolicy = corev1.PullPolicy(e.customResource.Spec.ContainerBase.PullPolicy) //nolint: unconvert
 	}
 
 	var imagePullSecrets []corev1.LocalObjectReference

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -306,7 +306,6 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		inputTail.DockerMode = ""
 		inputTail.DockerModeFlush = ""
 		inputTail.DockerModeParser = ""
-
 	} else if len(inputTail.ParserN) > 0 {
 		input.Input.ParserN = inputTail.ParserN
 		inputTail.ParserN = nil

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -38,7 +38,6 @@ const (
 )
 
 func (r *Reconciler) daemonSet() (runtime.Object, reconciler.DesiredState, error) {
-
 	labels := util.MergeLabels(r.fluentbitSpec.Labels, r.getFluentBitLabels())
 	meta := r.FluentbitObjectMeta(fluentbitDaemonSetName)
 	meta.Annotations = util.MergeLabels(meta.Annotations, r.fluentbitSpec.DaemonSetAnnotations)

--- a/pkg/resources/fluentbit/tenants.go
+++ b/pkg/resources/fluentbit/tenants.go
@@ -124,8 +124,7 @@ func (r *Reconciler) configureOutputsForTenants(ctx context.Context, tenants []v
 	return errs
 }
 
-func (r *Reconciler) configureInputsForTenants(tenants []v1beta1.Tenant, input *fluentBitConfig) error {
-	var errs error
+func (r *Reconciler) configureInputsForTenants(tenants []v1beta1.Tenant, input *fluentBitConfig) error { //nolint: unparam
 	for _, t := range tenants {
 		allNamespaces := len(t.Namespaces) == 0
 		tenantValues := maps.Clone(input.Input.Values)
@@ -150,7 +149,7 @@ func (r *Reconciler) configureInputsForTenants(tenants []v1beta1.Tenant, input *
 	}
 	// the regex will work only if we cut the prefix off. fluentbit doesn't care about the content, just the length
 	input.KubernetesFilter["Kube_Tag_Prefix"] = `kubernetes.0000000000.var.log.containers.`
-	return errs
+	return nil
 }
 
 func hashFromTenantName(input string) string {

--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -226,7 +226,7 @@ func (r *Reconciler) newCheckSecret(hashKey string, fluentdSpec v1beta1.FluentdS
 	}, nil
 }
 
-func (r *Reconciler) newCheckSecretAppConfig(hashKey string, fluentdSpec v1beta1.FluentdSpec) (*corev1.Secret, error) {
+func (r *Reconciler) newCheckSecretAppConfig(hashKey string, fluentdSpec v1beta1.FluentdSpec) (*corev1.Secret, error) { //nolint: unparam
 	data := make(map[string][]byte)
 
 	if fluentdSpec.CompressConfigFile {
@@ -245,14 +245,14 @@ func (r *Reconciler) newCheckSecretAppConfig(hashKey string, fluentdSpec v1beta1
 }
 
 func (r *Reconciler) newCheckOutputSecret(hashKey string) (*corev1.Secret, error) {
-	obj, _, err := r.outputSecret(r.secrets, OutputSecretPath)
+	obj, _, err := r.outputSecret(r.secrets)
 	if err != nil {
 		return nil, err
 	}
 	if secret, ok := obj.(*corev1.Secret); ok {
 		secret.ObjectMeta = r.FluentdObjectMeta(fmt.Sprintf("fluentd-configcheck-output-%s", hashKey), ComponentConfigCheck)
-		secret.ObjectMeta.Labels = utils.MergeLabels(
-			secret.ObjectMeta.Labels,
+		secret.Labels = utils.MergeLabels(
+			secret.Labels,
 			map[string]string{"logging.banzaicloud.io/watch": "enabled"},
 		)
 		return secret, nil
@@ -261,9 +261,8 @@ func (r *Reconciler) newCheckOutputSecret(hashKey string) (*corev1.Secret, error
 }
 
 func (r *Reconciler) newCheckPod(hashKey string, fluentdSpec v1beta1.FluentdSpec) *corev1.Pod {
-
 	volumes := r.volumesCheckPod(hashKey, fluentdSpec)
-	container := r.containerCheckPod(hashKey, fluentdSpec)
+	container := r.containerCheckPod(fluentdSpec)
 	initContainer := r.initContainerCheckPod(fluentdSpec)
 
 	pod := &corev1.Pod{
@@ -364,7 +363,7 @@ func (r *Reconciler) volumesCheckPod(hashKey string, fluentdSpec v1beta1.Fluentd
 	return v
 }
 
-func (r *Reconciler) containerCheckPod(hashKey string, fluentdSpec v1beta1.FluentdSpec) []corev1.Container {
+func (r *Reconciler) containerCheckPod(fluentdSpec v1beta1.FluentdSpec) []corev1.Container {
 	var containerArgs []string
 
 	switch r.Logging.Spec.ConfigCheck.Strategy {

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -212,7 +212,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 		}
 	}
 	// Prepare output secret
-	outputSecret, outputSecretDesiredState, err := r.outputSecret(r.secrets, OutputSecretPath)
+	outputSecret, outputSecretDesiredState, err := r.outputSecret(r.secrets)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to create output secret")
 	}

--- a/pkg/resources/fluentd/outputsecret.go
+++ b/pkg/resources/fluentd/outputsecret.go
@@ -50,18 +50,18 @@ func (r *Reconciler) markSecrets(secrets *secret.MountSecrets) ([]runtime.Object
 			return nil, reconciler.StatePresent, errors.WrapIfWithDetails(
 				err, "failed to load secret", "secret", secret.Name, "namespace", secret.Namespace)
 		}
-		if secretItem.ObjectMeta.Annotations == nil {
-			secretItem.ObjectMeta.Annotations = make(map[string]string)
+		if secretItem.Annotations == nil {
+			secretItem.Annotations = make(map[string]string)
 		}
-		secretItem.ObjectMeta.Annotations[annotationKey] = "watched"
+		secretItem.Annotations[annotationKey] = "watched"
 		markedSecrets = append(markedSecrets, secretItem)
 	}
 
 	return markedSecrets, reconciler.StatePresent, nil
 }
 
-func (r *Reconciler) outputSecret(secrets *secret.MountSecrets, mountPath string) (runtime.Object, reconciler.DesiredState, error) {
-	// Initialise output secret
+func (r *Reconciler) outputSecret(secrets *secret.MountSecrets) (runtime.Object, reconciler.DesiredState, error) { //nolint: unparam
+	// Initialize output secret
 	fluentOutputSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      r.Logging.QualifiedName(OutputSecretName),
@@ -77,8 +77,8 @@ func (r *Reconciler) outputSecret(secrets *secret.MountSecrets, mountPath string
 			fluentOutputSecret.Data[secret.MappedKey] = secret.Value
 		}
 	}
-	fluentOutputSecret.ObjectMeta.Labels = utils.MergeLabels(
-		fluentOutputSecret.ObjectMeta.Labels,
+	fluentOutputSecret.Labels = utils.MergeLabels(
+		fluentOutputSecret.Labels,
 		map[string]string{"logging.banzaicloud.io/watch": "enabled"},
 	)
 

--- a/pkg/resources/hosttailer/helpers.go
+++ b/pkg/resources/hosttailer/helpers.go
@@ -28,10 +28,10 @@ import (
 func (h *HostTailer) ownerReferences() []v1.OwnerReference {
 	ownerReferences := []v1.OwnerReference{
 		{
-			APIVersion: h.customResource.TypeMeta.APIVersion,
-			Kind:       h.customResource.TypeMeta.Kind,
-			Name:       h.customResource.ObjectMeta.Name,
-			UID:        h.customResource.ObjectMeta.UID,
+			APIVersion: h.customResource.APIVersion,
+			Kind:       h.customResource.Kind,
+			Name:       h.customResource.Name,
+			UID:        h.customResource.UID,
 			Controller: utils.BoolPointer(true),
 		},
 	}
@@ -54,7 +54,7 @@ func (h *HostTailer) selectorLabels() map[string]string {
 func (h *HostTailer) objectMeta() v1.ObjectMeta {
 	meta := v1.ObjectMeta{
 		Name:            h.Name(""),
-		Namespace:       h.customResource.ObjectMeta.Namespace,
+		Namespace:       h.customResource.Namespace,
 		Labels:          h.selectorLabels(),
 		OwnerReferences: h.ownerReferences(),
 	}

--- a/pkg/resources/hosttailer/hosttailer.go
+++ b/pkg/resources/hosttailer/hosttailer.go
@@ -85,7 +85,7 @@ func (h *HostTailer) RegisterWatches(*builder.Builder) {
 
 // Name returns generated name string
 func (h *HostTailer) Name(suffix string) string {
-	strs := []string{h.customResource.ObjectMeta.Name, config.HostTailer.TailerAffix}
+	strs := []string{h.customResource.Name, config.HostTailer.TailerAffix}
 	if suffix != "" {
 		strs = append(strs, suffix)
 	}

--- a/pkg/resources/kubetool/volumebuilder.go
+++ b/pkg/resources/kubetool/volumebuilder.go
@@ -47,7 +47,7 @@ func (v *VolumeBuilder) WithVolumeSource(volumeSource corev1.VolumeSource) *Volu
 // WithEmptyDir .
 func (v *VolumeBuilder) WithEmptyDir(emptyDir corev1.EmptyDirVolumeSource) *VolumeBuilder {
 	if v != nil {
-		v.VolumeSource.EmptyDir = &emptyDir
+		v.EmptyDir = &emptyDir
 	}
 	return v
 }
@@ -55,7 +55,7 @@ func (v *VolumeBuilder) WithEmptyDir(emptyDir corev1.EmptyDirVolumeSource) *Volu
 // WithHostPath .
 func (v *VolumeBuilder) WithHostPath(hostPath corev1.HostPathVolumeSource) *VolumeBuilder {
 	if v != nil {
-		v.VolumeSource.HostPath = &hostPath
+		v.HostPath = &hostPath
 	}
 	return v
 }

--- a/pkg/resources/model/repository.go
+++ b/pkg/resources/model/repository.go
@@ -343,7 +343,6 @@ func (r LoggingResourceRepository) FluentbitsFor(ctx context.Context, logging v1
 	return res, nil
 }
 func (r LoggingResourceRepository) handleMultipleDetachedFluentdObjects(list []v1beta1.FluentdConfig, logging v1beta1.Logging) []v1beta1.FluentdConfig {
-
 	r.Logger.Info("multiple detached Fluentd CRDs found")
 
 	var excessFluentds []v1beta1.FluentdConfig
@@ -384,7 +383,6 @@ func (r LoggingResourceRepository) FluentdConfigFor(ctx context.Context, logging
 	}
 }
 func (r LoggingResourceRepository) handleMultipleDetachedSyslogNGObjects(list []v1beta1.SyslogNGConfig, logging v1beta1.Logging) []v1beta1.SyslogNGConfig {
-
 	r.Logger.Info("multiple detached SyslogNG CRDs found")
 
 	var excessSyslogNGs []v1beta1.SyslogNGConfig

--- a/pkg/resources/nodeagent/configsecret.go
+++ b/pkg/resources/nodeagent/configsecret.go
@@ -138,7 +138,6 @@ func (n *nodeAgentInstance) configSecret() (runtime.Object, reconciler.DesiredSt
 		inputTail.DockerMode = ""
 		inputTail.DockerModeFlush = ""
 		inputTail.DockerModeParser = ""
-
 	} else if len(inputTail.ParserN) > 0 {
 		fluentbitInput.ParserN = inputTail.ParserN
 		inputTail.ParserN = nil
@@ -150,7 +149,7 @@ func (n *nodeAgentInstance) configSecret() (runtime.Object, reconciler.DesiredSt
 	}
 	fluentbitInput.Values = fluentbitInputValues
 
-	disableKubernetesFilter := n.nodeAgent.FluentbitSpec.DisableKubernetesFilter != nil && *n.nodeAgent.FluentbitSpec.DisableKubernetesFilter == true
+	disableKubernetesFilter := n.nodeAgent.FluentbitSpec.DisableKubernetesFilter != nil && *n.nodeAgent.FluentbitSpec.DisableKubernetesFilter
 
 	if !disableKubernetesFilter {
 		if n.nodeAgent.FluentbitSpec.FilterKubernetes.BufferSize == "" {

--- a/pkg/resources/nodeagent/daemonset.go
+++ b/pkg/resources/nodeagent/daemonset.go
@@ -214,7 +214,7 @@ func (n *nodeAgentInstance) generateVolume() (v []corev1.Volume) {
 			},
 		}
 		if util.PointerToBool(n.nodeAgent.FluentbitSpec.EnableUpstream) {
-			volume.VolumeSource.Secret.Items = append(volume.VolumeSource.Secret.Items, corev1.KeyToPath{
+			volume.Secret.Items = append(volume.Secret.Items, corev1.KeyToPath{
 				Key:  UpstreamConfigName,
 				Path: UpstreamConfigName,
 			})

--- a/pkg/resources/nodeagent/nodeagent.go
+++ b/pkg/resources/nodeagent/nodeagent.go
@@ -138,7 +138,6 @@ func NodeAgentFluentbitDefaults(userDefined v1beta1.NodeAgentConfig) (*v1beta1.N
 		if err != nil {
 			return nil, err
 		}
-
 	}
 	if userDefined.FluentbitSpec.LivenessDefaultCheck == nil || *userDefined.FluentbitSpec.LivenessDefaultCheck {
 		if userDefined.Profile != "windows" {
@@ -150,7 +149,6 @@ func NodeAgentFluentbitDefaults(userDefined v1beta1.NodeAgentConfig) (*v1beta1.N
 	}
 
 	if userDefined.FluentbitSpec.Metrics != nil {
-
 		programDefault.FluentbitSpec.Metrics = &v1beta1.Metrics{
 			Interval: "15s",
 			Timeout:  "5s",
@@ -256,7 +254,7 @@ func (n *nodeAgentInstance) getFluentBitLabels() map[string]string {
 	return util.MergeLabels(n.nodeAgent.Metadata.Labels, map[string]string{
 		"app.kubernetes.io/name":     "fluentbit",
 		"app.kubernetes.io/instance": n.name,
-	}, generateLoggingRefLabels(n.logging.ObjectMeta.GetName()))
+	}, generateLoggingRefLabels(n.logging.GetName()))
 }
 
 func (n *nodeAgentInstance) getServiceAccount() string {
@@ -276,7 +274,6 @@ type Reconciler struct {
 	Logging     *v1beta1.Logging
 	fluentdSpec *v1beta1.FluentdSpec
 	*reconciler.GenericResourceReconciler
-	configs             map[string][]byte
 	agents              map[string]v1beta1.NodeAgentConfig
 	fluentdDataProvider loggingdataprovider.LoggingDataProvider
 }
@@ -285,10 +282,10 @@ type Reconciler struct {
 func New(client client.Client, logger logr.Logger, logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, agents map[string]v1beta1.NodeAgentConfig, opts reconciler.ReconcilerOpts, fluentdDataProvider loggingdataprovider.LoggingDataProvider) *Reconciler {
 	return &Reconciler{
 		Logging:                   logging,
+		fluentdSpec:               fluentdSpec,
 		GenericResourceReconciler: reconciler.NewGenericReconciler(client, logger, opts),
 		agents:                    agents,
 		fluentdDataProvider:       fluentdDataProvider,
-		fluentdSpec:               fluentdSpec,
 	}
 }
 
@@ -334,7 +331,6 @@ func (r *Reconciler) processAgent(ctx context.Context, name string, userDefinedA
 		if err != nil {
 			return nil, err
 		}
-
 	}
 	err = merge.Merge(NodeAgentFluentbitDefaults, &userDefinedAgent)
 	if err != nil {

--- a/pkg/resources/nodeagent/service.go
+++ b/pkg/resources/nodeagent/service.go
@@ -82,7 +82,7 @@ func (n *nodeAgentInstance) monitorServiceMetrics() (runtime.Object, reconciler.
 					TLSConfig:            n.nodeAgent.FluentbitSpec.Metrics.ServiceMonitorConfig.TLSConfig,
 				}},
 				Selector: v12.LabelSelector{
-					MatchLabels: util.MergeLabels(n.getFluentBitLabels(), generateLoggingRefLabels(n.logging.ObjectMeta.GetName())),
+					MatchLabels: util.MergeLabels(n.getFluentBitLabels(), generateLoggingRefLabels(n.logging.GetName())),
 				},
 				NamespaceSelector: v1.NamespaceSelector{MatchNames: []string{n.logging.Spec.ControlNamespace}},
 				SampleLimit:       &SampleLimit,

--- a/pkg/resources/syslogng/configcheck.go
+++ b/pkg/resources/syslogng/configcheck.go
@@ -163,7 +163,7 @@ func (r *Reconciler) configCheck(ctx context.Context) (*ConfigCheckResult, error
 	return &ConfigCheckResult{}, nil
 }
 
-func (r *Reconciler) newCheckSecret(hashKey string) (*corev1.Secret, error) {
+func (r *Reconciler) newCheckSecret(hashKey string) (*corev1.Secret, error) { //nolint: unparam
 	meta := r.SyslogNGObjectMeta(configCheckResourceName(hashKey), ComponentConfigCheck)
 	meta.Labels = utils.MergeLabels(
 		meta.Labels,
@@ -178,14 +178,14 @@ func (r *Reconciler) newCheckSecret(hashKey string) (*corev1.Secret, error) {
 }
 
 func (r *Reconciler) newCheckOutputSecret(hashKey string) (*corev1.Secret, error) {
-	obj, _, err := r.outputSecret(r.secrets, OutputSecretPath)
+	obj, _, err := r.outputSecret(r.secrets)
 	if err != nil {
 		return nil, err
 	}
 	if secret, ok := obj.(*corev1.Secret); ok {
 		secret.ObjectMeta = r.SyslogNGObjectMeta(fmt.Sprintf("syslog-ng-configcheck-output-%s", hashKey), ComponentConfigCheck)
-		secret.ObjectMeta.Labels = utils.MergeLabels(
-			secret.ObjectMeta.Labels,
+		secret.Labels = utils.MergeLabels(
+			secret.Labels,
 			map[string]string{"logging.banzaicloud.io/watch": "enabled"},
 		)
 

--- a/pkg/resources/syslogng/configsecret.go
+++ b/pkg/resources/syslogng/configsecret.go
@@ -28,8 +28,8 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 			configKey: []byte(r.config),
 		},
 	}
-	secret.ObjectMeta.Labels = utils.MergeLabels(
-		secret.ObjectMeta.Labels,
+	secret.Labels = utils.MergeLabels(
+		secret.Labels,
 		map[string]string{"logging.banzaicloud.io/watch": "enabled"},
 	)
 

--- a/pkg/resources/syslogng/outputsecret.go
+++ b/pkg/resources/syslogng/outputsecret.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (r *Reconciler) markSecrets(secrets *secret.MountSecrets) ([]runtime.Object, reconciler.DesiredState, error) {
+func (r *Reconciler) markSecrets(secrets *secret.MountSecrets) ([]runtime.Object, reconciler.DesiredState, error) { //nolint: unparam
 	var loggingRef string
 	if r.Logging.Spec.LoggingRef != "" {
 		loggingRef = r.Logging.Spec.LoggingRef
@@ -46,25 +46,25 @@ func (r *Reconciler) markSecrets(secrets *secret.MountSecrets) ([]runtime.Object
 			return nil, reconciler.StatePresent, errors.WrapIfWithDetails(
 				err, "failed to load secret", "secret", secret.Name, "namespace", secret.Namespace)
 		}
-		if secretItem.ObjectMeta.Annotations == nil {
-			secretItem.ObjectMeta.Annotations = make(map[string]string)
+		if secretItem.Annotations == nil {
+			secretItem.Annotations = make(map[string]string)
 		}
-		secretItem.ObjectMeta.Annotations[annotationKey] = "watched"
+		secretItem.Annotations[annotationKey] = "watched"
 		markedSecrets = append(markedSecrets, secretItem)
 	}
 	return markedSecrets, reconciler.StatePresent, nil
 }
 
-func (r *Reconciler) outputSecret(secrets *secret.MountSecrets, mountPath string) (runtime.Object, reconciler.DesiredState, error) {
-	// Initialise output secret
+func (r *Reconciler) outputSecret(secrets *secret.MountSecrets) (runtime.Object, reconciler.DesiredState, error) { //nolint: unparam
+	// Initialize output secret
 	syslogNGOutputSecret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      r.Logging.QualifiedName(outputSecretName),
 			Namespace: r.Logging.Spec.ControlNamespace,
 		},
 	}
-	syslogNGOutputSecret.ObjectMeta.Labels = utils.MergeLabels(
-		syslogNGOutputSecret.ObjectMeta.Labels,
+	syslogNGOutputSecret.Labels = utils.MergeLabels(
+		syslogNGOutputSecret.Labels,
 		map[string]string{"logging.banzaicloud.io/watch": "enabled"},
 	)
 	if syslogNGOutputSecret.Data == nil {

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -250,7 +250,6 @@ func (r *Reconciler) syslogNGMetricsSidecarContainer() *corev1.Container {
 				},
 			},
 		}
-
 	}
 	return nil
 }
@@ -297,7 +296,6 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 }
 
 func generateReadinessCheck(spec *v1beta1.SyslogNGSpec) *corev1.Probe {
-
 	if spec.ReadinessDefaultCheck.BufferFreeSpace || spec.ReadinessDefaultCheck.BufferFileNumber {
 		check := []string{"/bin/sh", "-c"}
 		bash := []string{}

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -183,7 +183,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*reconcile.Result, error) {
 		}
 	}
 	// Prepare output secret
-	outputSecret, outputSecretDesiredState, err := r.outputSecret(r.secrets, OutputSecretPath)
+	outputSecret, outputSecretDesiredState, err := r.outputSecret(r.secrets)
 	if err != nil {
 		return nil, errors.WrapIf(err, "failed to create output secret")
 	}

--- a/pkg/sdk/logging/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_types.go
@@ -143,7 +143,7 @@ func (f *FluentdSpec) GetFluentdMetricsPath() string {
 }
 
 func (f *FluentdSpec) SetDefaults() error {
-	if f != nil { // nolint:nestif
+	if f != nil { //nolint:nestif
 		if f.FluentdPvcSpec != nil {
 			return errors.New("`fluentdPvcSpec` field is deprecated, use: `bufferStorageVolume`")
 		}
@@ -444,7 +444,7 @@ func (e *ExtraVolume) ApplyVolumeForPodSpec(spec *corev1.PodSpec) error {
 
 // +kubebuilder:object:generate=true
 
-// FluentdScaling enables configuring the scaling behaviour of the fluentd statefulset
+// FluentdScaling enables configuring the scaling behavior of the fluentd statefulset
 type FluentdScaling struct {
 	Replicas            int                `json:"replicas,omitempty"`
 	PodManagementPolicy string             `json:"podManagementPolicy,omitempty"`

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -20,7 +20,6 @@ import (
 
 	util "github.com/cisco-open/operator-tools/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -266,7 +265,7 @@ func (logging *Logging) WatchAllNamespaces() bool {
 }
 
 func FluentBitDefaults(fluentbitSpec *FluentbitSpec) error {
-	if fluentbitSpec != nil { // nolint:nestif
+	if fluentbitSpec != nil { //nolint:nestif
 		// Set default value for DisableVarLibDockerContainers to false (meaning volume is mounted by default)
 		if fluentbitSpec.DisableVarLibDockerContainers == nil {
 			fluentbitSpec.DisableVarLibDockerContainers = util.BoolPointer(false)
@@ -299,15 +298,15 @@ func FluentBitDefaults(fluentbitSpec *FluentbitSpec) error {
 			fluentbitSpec.CoroStackSize = 24576
 		}
 		if fluentbitSpec.Resources.Limits == nil {
-			fluentbitSpec.Resources.Limits = v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("100M"),
-				v1.ResourceCPU:    resource.MustParse("200m"),
+			fluentbitSpec.Resources.Limits = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("100M"),
+				corev1.ResourceCPU:    resource.MustParse("200m"),
 			}
 		}
 		if fluentbitSpec.Resources.Requests == nil {
-			fluentbitSpec.Resources.Requests = v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("50M"),
-				v1.ResourceCPU:    resource.MustParse("100m"),
+			fluentbitSpec.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("50M"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 			}
 		}
 		if fluentbitSpec.InputTail.Path == "" {
@@ -357,15 +356,15 @@ func FluentBitDefaults(fluentbitSpec *FluentbitSpec) error {
 			fluentbitSpec.BufferVolumeImage.PullPolicy = "IfNotPresent"
 		}
 		if fluentbitSpec.BufferVolumeResources.Limits == nil {
-			fluentbitSpec.BufferVolumeResources.Limits = v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("100M"),
-				v1.ResourceCPU:    resource.MustParse("100m"),
+			fluentbitSpec.BufferVolumeResources.Limits = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("100M"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 			}
 		}
 		if fluentbitSpec.BufferVolumeResources.Requests == nil {
-			fluentbitSpec.BufferVolumeResources.Requests = v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("20M"),
-				v1.ResourceCPU:    resource.MustParse("2m"),
+			fluentbitSpec.BufferVolumeResources.Requests = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("20M"),
+				corev1.ResourceCPU:    resource.MustParse("2m"),
 			}
 		}
 		if fluentbitSpec.BufferVolumeLivenessProbe == nil {
@@ -384,10 +383,10 @@ func FluentBitDefaults(fluentbitSpec *FluentbitSpec) error {
 		}
 
 		if fluentbitSpec.Security.SecurityContext == nil {
-			fluentbitSpec.Security.SecurityContext = &v1.SecurityContext{}
+			fluentbitSpec.Security.SecurityContext = &corev1.SecurityContext{}
 		}
 		if fluentbitSpec.Security.PodSecurityContext == nil {
-			fluentbitSpec.Security.PodSecurityContext = &v1.PodSecurityContext{}
+			fluentbitSpec.Security.PodSecurityContext = &corev1.PodSecurityContext{}
 		}
 		if fluentbitSpec.Metrics != nil {
 			if fluentbitSpec.Metrics.Path == "" {
@@ -415,9 +414,9 @@ func FluentBitDefaults(fluentbitSpec *FluentbitSpec) error {
 		}
 		if fluentbitSpec.LivenessProbe == nil {
 			if fluentbitSpec.LivenessDefaultCheck {
-				fluentbitSpec.LivenessProbe = &v1.Probe{
-					ProbeHandler: v1.ProbeHandler{
-						HTTPGet: &v1.HTTPGetAction{
+				fluentbitSpec.LivenessProbe = &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
 							Path: fluentbitSpec.Metrics.Path,
 							Port: intstr.IntOrString{
 								IntVal: fluentbitSpec.Metrics.Port,
@@ -538,7 +537,7 @@ func init() {
 	SchemeBuilder.Register(&Logging{}, &LoggingList{})
 }
 
-func persistentVolumeModePointer(mode v1.PersistentVolumeMode) *v1.PersistentVolumeMode {
+func persistentVolumeModePointer(mode corev1.PersistentVolumeMode) *corev1.PersistentVolumeMode {
 	return &mode
 }
 
@@ -577,7 +576,7 @@ func (l *Logging) GetFluentdLabels(component string, f FluentdSpec) map[string]s
 			"app.kubernetes.io/name":      "fluentd",
 			"app.kubernetes.io/component": component,
 		},
-		GenerateLoggingRefLabels(l.ObjectMeta.GetName()),
+		GenerateLoggingRefLabels(l.GetName()),
 	)
 }
 
@@ -614,7 +613,7 @@ func (l *Logging) GetSyslogNGLabels(component string) map[string]string {
 			"app.kubernetes.io/name":      "syslog-ng",
 			"app.kubernetes.io/component": component,
 		},
-		GenerateLoggingRefLabels(l.ObjectMeta.GetName()),
+		GenerateLoggingRefLabels(l.GetName()),
 	)
 }
 

--- a/pkg/sdk/logging/model/filter/elasticsearch_genid.go
+++ b/pkg/sdk/logging/model/filter/elasticsearch_genid.go
@@ -73,7 +73,7 @@ type ElasticsearchGenId struct {
 	RecordKeys string `json:"record_keys,omitempty"`
 	// You can specify to use entire record in events for hash generation seed.
 	UseEntireRecord bool `json:"use_entire_record,omitempty"`
-	// You can specify separator charactor to creating seed for hash generation.
+	// You can specify separator character to creating seed for hash generation.
 	Separator string `json:"separator,omitempty"`
 	// You can specify hash algorithm. Support algorithms md5, sha1, sha256, sha512. Default: sha1
 	HashType string `json:"hash_type,omitempty"`

--- a/pkg/sdk/logging/model/filter/parser.go
+++ b/pkg/sdk/logging/model/filter/parser.go
@@ -72,7 +72,7 @@ type ParseSection struct {
 	Expression string `json:"expression,omitempty"`
 	// Specify time field for event time. If the event doesn't have this field, current time is used.
 	TimeKey string `json:"time_key,omitempty"`
-	// Names for fields on each line. (seperated by coma)
+	// Names for fields on each line. (separated by coma)
 	Keys string `json:"keys,omitempty"`
 	//  Specify null value pattern.
 	NullValuePattern string `json:"null_value_pattern,omitempty"`

--- a/pkg/sdk/logging/model/output/loki.go
+++ b/pkg/sdk/logging/model/output/loki.go
@@ -128,7 +128,7 @@ func (l *LokiOutput) ToDirective(secretLoader secret.SecretLoader, id string) (t
 			Id:        id,
 		},
 	}
-	if l.ConfigureKubernetesLabels != nil && *l.ConfigureKubernetesLabels { // nolint:nestif
+	if l.ConfigureKubernetesLabels != nil && *l.ConfigureKubernetesLabels { //nolint:nestif
 		if l.Labels == nil {
 			l.Labels = Label{}
 		}
@@ -154,7 +154,7 @@ func (l *LokiOutput) ToDirective(secretLoader secret.SecretLoader, id string) (t
 		if l.IncludeThreadLabel == nil {
 			l.IncludeThreadLabel = util.BoolPointer(true)
 		}
-		// Prevent meta configuration from marshalling
+		// Prevent meta configuration from marshaling
 		l.ConfigureKubernetesLabels = nil
 	}
 	if params, err := types.NewStructToStringMapper(secretLoader).StringsMap(l); err != nil {

--- a/pkg/sdk/logging/model/output/newrelic.go
+++ b/pkg/sdk/logging/model/output/newrelic.go
@@ -84,7 +84,7 @@ func (c *NewRelicOutputConfig) ToDirective(secretLoader secret.SecretLoader, id 
 	} else {
 		newrelic.Params = params
 	}
-	if err := c.validateKeys(newrelic, secretLoader); err != nil {
+	if err := c.validateKeys(); err != nil {
 		return nil, err
 	}
 	if c.Buffer == nil {
@@ -105,12 +105,12 @@ func (c *NewRelicOutputConfig) ToDirective(secretLoader secret.SecretLoader, id 
 	return newrelic, nil
 }
 
-func (c *NewRelicOutputConfig) validateKeys(newrelic *types.OutputPlugin, secretLoader secret.SecretLoader) error {
+func (c *NewRelicOutputConfig) validateKeys() error {
 	if c.APIKey != nil && c.LicenseKey != nil {
 		return errors.New("api_key and license_key cannot be set simultaneously")
 	}
 	if c.APIKey == nil && c.LicenseKey == nil {
-		return errors.New("Either api_key or license_key must be configured")
+		return errors.New("either api_key or license_key must be configured")
 	}
 	return nil
 }

--- a/pkg/sdk/logging/model/output/vmware_log_intelligence.go
+++ b/pkg/sdk/logging/model/output/vmware_log_intelligence.go
@@ -89,7 +89,7 @@ type LogIntelligenceHeaders struct {
 
 // logIntelligenceHeadersOut is used to convert the input LogIntelligenceHeaders to a fluentd
 // output that uses the correct key names for the VMware Log Intelligence plugin. This allows the
-// Ouput to accept the config is snake_case (as other output plugins do) but output the fluentd
+// Output to accept the config is snake_case (as other output plugins do) but output the fluentd
 // <headers> config with the proper key names (ie. content_type -> Content-Type)
 type logIntelligenceHeadersOut struct {
 	// Authorization Bearer token for http request to VMware Log Intelligence

--- a/pkg/sdk/logging/model/render/fluent.go
+++ b/pkg/sdk/logging/model/render/fluent.go
@@ -42,7 +42,7 @@ func (f *FluentRender) RenderDirectives(directives []types.Directive, indent int
 		}
 		meta := d.GetPluginMeta()
 		if meta.Directive == "" {
-			return fmt.Errorf("Directive must have a name %s", meta)
+			return fmt.Errorf("directive must have a name %s", meta)
 		}
 		f.indentedf(indent, "<%s%s>", meta.Directive, tag(meta.Tag))
 		if meta.Type != "" {
@@ -79,9 +79,9 @@ func (f *FluentRender) indentedf(indent int, format string, values ...interface{
 	in := fmt.Sprintf(format, values...)
 	for _, line := range strings.Split(in, "\n") {
 		if line != "" {
-			fmt.Fprint(f.Out, indentString+line+"\n")
+			fmt.Fprint(f.Out, indentString+line+"\n") //nolint: errcheck
 		} else {
-			fmt.Fprintln(f.Out, "")
+			fmt.Fprintln(f.Out, "") //nolint: errcheck
 		}
 	}
 }

--- a/pkg/sdk/logging/model/syslogng/output/openobserve.go
+++ b/pkg/sdk/logging/model/syslogng/output/openobserve.go
@@ -84,5 +84,4 @@ func (o *OpenobserveOutput) BeforeRender() {
 	if o.Stream == "" {
 		o.Stream = "default"
 	}
-
 }

--- a/pkg/sdk/logging/model/types/builder.go
+++ b/pkg/sdk/logging/model/types/builder.go
@@ -50,7 +50,7 @@ func (s *SystemBuilder) RegisterFlow(f *Flow) error {
 
 // Check if we need to register a flow at all?
 func (s *SystemBuilder) RegisterErrorFlow(f *Flow) error {
-	if f.PluginMeta.Tag != "@ERROR" && f.FlowID != "@ERROR" {
+	if f.Tag != "@ERROR" && f.FlowID != "@ERROR" {
 		return errors.New("you can only register Error flow with @ERROR label")
 	}
 	for _, e := range s.flows {

--- a/pkg/sdk/logging/model/types/flow.go
+++ b/pkg/sdk/logging/model/types/flow.go
@@ -108,7 +108,7 @@ func (f *Flow) WithOutputs(output ...Output) *Flow {
 }
 
 func NewFlow(matches []FlowMatch, id, name, namespace, flowLabel string, includeLabelInRouter *bool) (*Flow, error) {
-	var addRoute bool = true
+	addRoute := true
 	if flowLabel == "" {
 		var err error
 		flowLabel, err = calculateFlowLabel(matches, name, namespace)

--- a/pkg/sdk/logging/model/types/stringmaps.go
+++ b/pkg/sdk/logging/model/types/stringmaps.go
@@ -126,7 +126,7 @@ func (s *StructToStringMapper) processField(field reflect.StructField, value ref
 		value = value.Elem()
 	}
 
-	switch value.Kind() { // nolint:exhaustive
+	switch value.Kind() { //nolint:exhaustive
 	case reflect.String, reflect.Int, reflect.Bool:
 		val := fmt.Sprintf("%v", value.Interface())
 		if (isPointer && isNil) || (!isPointer && val == "") {
@@ -143,7 +143,7 @@ func (s *StructToStringMapper) processField(field reflect.StructField, value ref
 	case reflect.Slice:
 		switch actual := value.Interface().(type) {
 		case []string, []int:
-			if value.Len() > 0 { // nolint:nestif
+			if value.Len() > 0 { //nolint:nestif
 				b, err := json.Marshal(actual)
 				if err != nil {
 					return errors.WrapIff(err, "can't marshal field %q with value %v as json", name, actual)
@@ -168,7 +168,7 @@ func (s *StructToStringMapper) processField(field reflect.StructField, value ref
 			}
 		}
 	case reflect.Map:
-		if mapStringString, ok := value.Interface().(map[string]string); ok { // nolint:nestif
+		if mapStringString, ok := value.Interface().(map[string]string); ok { //nolint:nestif
 			if len(mapStringString) > 0 {
 				b, err := json.Marshal(mapStringString)
 				if err != nil {

--- a/pkg/webhook/podhandler/podhandler.go
+++ b/pkg/webhook/podhandler/podhandler.go
@@ -140,11 +140,9 @@ func (p *PodHandler) podHandlerHelper(podToModify *corev1.Pod, sideCars []corev1
 			p.Log.Info(duplicateValuesMsg)
 			rv := admission.Denied(duplicateValuesMsg)
 			return &rv
-
 		} else {
 			podToModify.Spec.Containers = append(podToModify.Spec.Containers, sideCar)
 			podToModify.Spec.Containers[idx].VolumeMounts = append(podToModify.Spec.Containers[idx].VolumeMounts, volumeMounts...)
-
 		}
 	}
 
@@ -158,8 +156,8 @@ func (p *PodHandler) podHandlerHelper(podToModify *corev1.Pod, sideCars []corev1
 			return &rv
 		} else {
 			podToModify.Spec.Volumes = append(podToModify.Spec.Volumes, volume)
-
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
- Migrates golangci-lint to v2.
- Adds sensible default linters.
- Fixes linter errors.