### PR TITLE
fix: change rdkafka_options format from section to hash

### DIFF
--- a/pkg/sdk/logging/model/output/kafka_test.go
+++ b/pkg/sdk/logging/model/output/kafka_test.go
@@ -77,7 +77,7 @@ rdkafka_options:
   ssl.ca.location: /etc/ssl/certs/ca-certificates.crt
   ssl.certificate.location: /etc/ssl/certs/tls.crt
   ssl.key.location: /etc/ssl/certs/tls.key
-  ssl.key.password: password 
+  ssl.key.password: password
 format:
   type: json
 buffer:
@@ -91,6 +91,7 @@ buffer:
     @id test
     brokers kafka-headless.kafka.svc.cluster.local:29092
     default_topic topic
+    rdkafka_options {"sasl.mechanisms":"PLAIN","sasl.username":"user","security.protocol":"SASL_SSL","ssl.ca.location":"/etc/ssl/certs/ca-certificates.crt","ssl.certificate.location":"/etc/ssl/certs/tls.crt","ssl.key.location":"/etc/ssl/certs/tls.key","ssl.key.password":"password"}
     ssl_verify_hostname false
     <buffer tag,time>
       @type file
@@ -100,15 +101,6 @@ buffer:
       timekey_use_utc true
       timekey_wait 30s
     </buffer>
-    <rdkafka_options>
-      sasl.mechanisms PLAIN
-      sasl.username user
-      security.protocol SASL_SSL
-      ssl.ca.location /etc/ssl/certs/ca-certificates.crt
-      ssl.certificate.location /etc/ssl/certs/tls.crt
-      ssl.key.location /etc/ssl/certs/tls.key
-      ssl.key.password password
-    </rdkafka_options>
     <format>
       @type json
     </format>


### PR DESCRIPTION
Issue #2017 provides a detailed description of the problem with generating the Fluentd configuration file when using the `rdkafka_options` parameter in `ClusterOutput`/`Output`.

After fixing the configuration file format, the `logging-operator-fluentd-configcheck` pod no longer shows a warning when validating the Fluentd configuration

```
...
<match **>
      @type copy
      <store>
        @type "rdkafka2"
        @id clusterflow:logging-system:opensearch:clusteroutput:logging-system:opensearch
        brokers "broker:9092"
        default_topic "default"
        topic_key "$.kubernetes.namespace_name"
        rdkafka_options {"sasl.mechanisms":"PLAIN","sasl.username":"user","security.protocol":"SASL_SSL","ssl.ca.location":"/etc/ssl/certs/ca-certificates.crt","ssl.certificate.location":"/etc/ssl/certs/tls.crt","ssl.key.location":"/etc/ssl/certs/tls.key","ssl.key.password":"password"}
        <buffer $.kubernetes.namespace_name>
          @type "file"
          chunk_limit_size 1000000
          disable_chunk_backup true
          flush_interval 1s
          flush_mode interval
          flush_thread_count 2
          overflow_action drop_oldest_chunk
          path "/buffers/clusterflow:logging-system:opensearch:clusteroutput:logging-system:opensearch.*.buffer"
          retry_forever false
          retry_max_interval 30
          retry_timeout 1h
          retry_type exponential_backoff
          timekey 10s
          timekey_use_utc true
          timekey_wait 1s
        </buffer>
        <format>
          @type "json"
        </format>
      </store>
    </match>
 ...
 2025-04-18 10:45:09 +0000 [info]: finished dry run mode
```
This PR fixes: #2017 