### PR TITLE
fix: change q_out_size attribute in disk_buffer parameter to qout_size in SyslogNGClusterOutput/SyslogNGOutput

### DIFF
--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -73,7 +73,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -357,7 +357,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -625,7 +625,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -674,7 +674,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -936,7 +936,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1206,7 +1206,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1447,7 +1447,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1514,7 +1514,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1632,7 +1632,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2038,7 +2038,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2125,7 +2125,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2215,7 +2215,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2329,7 +2329,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2693,7 +2693,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2933,7 +2933,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -3136,7 +3136,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -73,7 +73,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -357,7 +357,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -625,7 +625,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -674,7 +674,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -936,7 +936,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1206,7 +1206,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1447,7 +1447,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1514,7 +1514,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1632,7 +1632,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2038,7 +2038,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2123,7 +2123,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2213,7 +2213,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2327,7 +2327,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2691,7 +2691,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2931,7 +2931,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -3134,7 +3134,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -70,7 +70,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -354,7 +354,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -622,7 +622,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -671,7 +671,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -933,7 +933,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1203,7 +1203,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1444,7 +1444,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1511,7 +1511,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1629,7 +1629,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2035,7 +2035,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2122,7 +2122,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2212,7 +2212,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2326,7 +2326,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2690,7 +2690,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2930,7 +2930,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -3133,7 +3133,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -70,7 +70,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -354,7 +354,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -622,7 +622,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -671,7 +671,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -933,7 +933,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1203,7 +1203,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1444,7 +1444,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1511,7 +1511,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1629,7 +1629,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2035,7 +2035,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2120,7 +2120,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2210,7 +2210,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2324,7 +2324,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2688,7 +2688,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2928,7 +2928,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -3131,7 +3131,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:

--- a/config/crd/bases/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -70,7 +70,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -354,7 +354,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -622,7 +622,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -671,7 +671,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -933,7 +933,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1203,7 +1203,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1444,7 +1444,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1511,7 +1511,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1629,7 +1629,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2035,7 +2035,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2122,7 +2122,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2212,7 +2212,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2326,7 +2326,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2690,7 +2690,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2930,7 +2930,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -3133,7 +3133,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:

--- a/config/crd/bases/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -70,7 +70,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -354,7 +354,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -622,7 +622,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -671,7 +671,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -933,7 +933,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1203,7 +1203,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1444,7 +1444,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1511,7 +1511,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -1629,7 +1629,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2035,7 +2035,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2120,7 +2120,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2210,7 +2210,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2324,7 +2324,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2688,7 +2688,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -2928,7 +2928,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:
@@ -3131,7 +3131,7 @@ spec:
                       mem_buf_size:
                         format: int64
                         type: integer
-                      q_out_size:
+                      qout_size:
                         format: int64
                         type: integer
                       reliable:

--- a/docs/configuration/plugins/syslogng-outputs/disk_buffer.md
+++ b/docs/configuration/plugins/syslogng-outputs/disk_buffer.md
@@ -39,7 +39,7 @@ Use this option if the option reliable() is set to no. This option contains the 
 Use this option if the option reliable() is set to yes. This option contains the size of the messages in bytes that is used in the memory part of the disk buffer. 
 
 
-### q_out_size (*int64, optional) {#diskbuffer-q_out_size}
+### qout_size (*int64, optional) {#diskbuffer-qout_size}
 
 The number of messages stored in the output buffer of the destination. 
 

--- a/docs/configuration/plugins/syslogng/outputs/disk_buffer.md
+++ b/docs/configuration/plugins/syslogng/outputs/disk_buffer.md
@@ -15,43 +15,43 @@ Documentation: https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-
 
 ### disk_buf_size (int64, required) {#diskbuffer-disk_buf_size}
 
-This is a required option. The maximum size of the disk-buffer in bytes. The minimum value is 1048576 bytes. 
+This is a required option. The maximum size of the disk-buffer in bytes. The minimum value is 1048576 bytes.
 
 Default: -
 
 ### reliable (bool, required) {#diskbuffer-reliable}
 
-If set to yes, syslog-ng OSE cannot lose logs in case of reload/restart, unreachable destination or syslog-ng OSE crash. This solution provides a slower, but reliable disk-buffer option. 
+If set to yes, syslog-ng OSE cannot lose logs in case of reload/restart, unreachable destination or syslog-ng OSE crash. This solution provides a slower, but reliable disk-buffer option.
 
 Default: -
 
 ### compaction (*bool, optional) {#diskbuffer-compaction}
 
-Prunes the unused space in the LogMessage representation 
+Prunes the unused space in the LogMessage representation
 
 Default: -
 
 ### dir (string, optional) {#diskbuffer-dir}
 
-Description: Defines the folder where the disk-buffer files are stored. 
+Description: Defines the folder where the disk-buffer files are stored.
 
 Default: -
 
 ### mem_buf_length (*int64, optional) {#diskbuffer-mem_buf_length}
 
-Use this option if the option reliable() is set to no. This option contains the number of messages stored in overflow queue. 
+Use this option if the option reliable() is set to no. This option contains the number of messages stored in overflow queue.
 
 Default: -
 
 ### mem_buf_size (*int64, optional) {#diskbuffer-mem_buf_size}
 
-Use this option if the option reliable() is set to yes. This option contains the size of the messages in bytes that is used in the memory part of the disk buffer. 
+Use this option if the option reliable() is set to yes. This option contains the size of the messages in bytes that is used in the memory part of the disk buffer.
 
 Default: -
 
-### q_out_size (*int64, optional) {#diskbuffer-q_out_size}
+### qout_size (*int64, optional) {#diskbuffer-qout_size}
 
-The number of messages stored in the output buffer of the destination. 
+The number of messages stored in the output buffer of the destination.
 
 Default: -
 

--- a/docs/syslogng-quickstart.md
+++ b/docs/syslogng-quickstart.md
@@ -505,7 +505,7 @@ All syslog-ng outputs support buffering to disk.
   disk_buf_size:   # required; the maximum size of the disk-buffer in bytes
   mem_buf_length:  # the number of messages stored in overflow queue
   mem_buf_size:    # the size of messages in bytes that is used in the memory part of the disk buffer
-  q_out_size:      # the number of messages stored in the output buffer of the destination
+  qout_size:      # the number of messages stored in the output buffer of the destination
 ```
 
 For more details, see [the official docs](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/disk-buffer).

--- a/pkg/sdk/logging/model/syslogng/output/disk_buffer.go
+++ b/pkg/sdk/logging/model/syslogng/output/disk_buffer.go
@@ -45,5 +45,5 @@ type DiskBuffer struct {
 	// Use this option if the option reliable() is set to yes. This option contains the size of the messages in bytes that is used in the memory part of the disk buffer.
 	MemBufSize *int64 `json:"mem_buf_size,omitempty"`
 	// The number of messages stored in the output buffer of the destination.
-	QOutSize *int64 `json:"q_out_size,omitempty"`
+	QOutSize *int64 `json:"qout_size,omitempty"`
 }


### PR DESCRIPTION
Issue #2021 provides a detailed description of the problem with generating the Axosyslog configuration file when using the `q_out_size` attribute in `disk_buffer` parameter in `SyslogNGClusterOutput`/`SyslogNGOutput`.

After fixing the configuration file format (rename `q_out_size` to `qout_size`), the `configcheck` pod no longer shows a warning when validating the Axosyslog configuration

```
...
@version: current

@include "scl.conf"

source "main_input" {
    channel {
        source {
            network(flags("no-parse") port(601) transport("tcp") max-connections(100) log-iw-size(10000));
        };
        parser {
            json-parser(prefix("json."));
        };
    };
};

destination "clusteroutput_cattle-logging-system_loki-cluster-output" {
    loki(auth(insecure()) labels(
        "cluster" => "internal"
        "type" => "vault-audit-log"
    ) url("loki.loki.svc.cluster.local:9100") disk_buffer(disk_buf_size(5368709120) reliable(yes) compaction(yes) dir("/buffers") qout_size(1000)) batch-timeout(10000) persist_name("clusteroutput_cattle-logging-system_loki-cluster-output") timestamp("msg"));
};

log {
    source("main_input");
    log {
        destination("clusteroutput_cattle-logging-system_loki-cluster-output");
    };
};
...
Setting current version as config version; version='4.7'
```
This PR fixes: #2021