### PR TITLE
Add support for Loki tenant-id to SyslogNGClusterOutput/SyslogNGOutput

### DIFF
--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -1468,6 +1468,8 @@ spec:
                     type: integer
                   template:
                     type: string
+                  tenant-id:
+                    type: string
                   time_reopen:
                     type: integer
                   timestamp:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -1468,6 +1468,8 @@ spec:
                     type: integer
                   template:
                     type: string
+                  tenant-id:
+                    type: string
                   time_reopen:
                     type: integer
                   timestamp:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -1465,6 +1465,8 @@ spec:
                     type: integer
                   template:
                     type: string
+                  tenant-id:
+                    type: string
                   time_reopen:
                     type: integer
                   timestamp:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -1465,6 +1465,8 @@ spec:
                     type: integer
                   template:
                     type: string
+                  tenant-id:
+                    type: string
                   time_reopen:
                     type: integer
                   timestamp:

--- a/config/crd/bases/logging.banzaicloud.io_syslogngclusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_syslogngclusteroutputs.yaml
@@ -1465,6 +1465,8 @@ spec:
                     type: integer
                   template:
                     type: string
+                  tenant-id:
+                    type: string
                   time_reopen:
                     type: integer
                   timestamp:

--- a/config/crd/bases/logging.banzaicloud.io_syslogngoutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_syslogngoutputs.yaml
@@ -1465,6 +1465,8 @@ spec:
                     type: integer
                   template:
                     type: string
+                  tenant-id:
+                    type: string
                   time_reopen:
                     type: integer
                   timestamp:

--- a/docs/configuration/plugins/syslogng-outputs/loki.md
+++ b/docs/configuration/plugins/syslogng-outputs/loki.md
@@ -88,7 +88,7 @@ Template for customizing the log message format.
 
 ### tenant-id (string, optional) {#lokioutput-tenant-id}
 
-Sets the tenant ID for multi-tenant scenarios. See [syslog-ng docs](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-http-nonjava/reference-destination-http-nonjava/#persist-name) for more information. 
+Sets the tenant ID for multi-tenant scenarios. See [syslog-ng docs](https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-loki/#tenant-id) for more information. 
 
 
 ### time_reopen (int, optional) {#lokioutput-time_reopen}

--- a/docs/configuration/plugins/syslogng-outputs/loki.md
+++ b/docs/configuration/plugins/syslogng-outputs/loki.md
@@ -86,6 +86,11 @@ The number of times syslog-ng OSE attempts to send a message to this destination
 Template for customizing the log message format. 
 
 
+### tenant-id (string, optional) {#lokioutput-tenant-id}
+
+Sets the tenant ID for multi-tenant scenarios. See [syslog-ng docs](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-http-nonjava/reference-destination-http-nonjava/#persist-name) for more information. 
+
+
 ### time_reopen (int, optional) {#lokioutput-time_reopen}
 
 The time to wait in seconds before a dead connection is reestablished.

--- a/pkg/sdk/logging/model/syslogng/config/output_tests/loki_test.go
+++ b/pkg/sdk/logging/model/syslogng/config/output_tests/loki_test.go
@@ -191,6 +191,29 @@ func TestLokiOutputTable(t *testing.T) {
 };
 `,
 		},
+		{
+			name: "test_tenant",
+			output: v1beta1.SyslogNGOutput{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-loki-out",
+				},
+				Spec: v1beta1.SyslogNGOutputSpec{
+					Loki: &output.LokiOutput{
+						URL:          "test.local",
+						BatchLines:   2000,
+						BatchTimeout: 10,
+						Workers:      3,
+						LogFIFOSize:  1000,
+						TenantID: "test-tenant",
+					},
+				},
+			},
+			config: `destination "output_default_test-loki-out" {
+	loki(url("test.local") batch-lines(2000) batch-timeout(10) workers(3) persist_name("output_default_test-loki-out") log-fifo-size(1000) tenant-id("test-tenant"));
+};
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sdk/logging/model/syslogng/output/loki.go
+++ b/pkg/sdk/logging/model/syslogng/output/loki.go
@@ -93,4 +93,7 @@ type LokiOutput struct {
 	Timestamp string `json:"timestamp,omitempty"`
 	// Template for customizing the log message format.
 	Template string `json:"template,omitempty"`
+	// Sets the tenant ID for multi-tenant scenarios.
+	// See [syslog-ng docs](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-http-nonjava/reference-destination-http-nonjava/#persist-name) for more information.
+	TenantID string `json:"tenant-id,omitempty"`
 }

--- a/pkg/sdk/logging/model/syslogng/output/loki.go
+++ b/pkg/sdk/logging/model/syslogng/output/loki.go
@@ -94,6 +94,6 @@ type LokiOutput struct {
 	// Template for customizing the log message format.
 	Template string `json:"template,omitempty"`
 	// Sets the tenant ID for multi-tenant scenarios.
-	// See [syslog-ng docs](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-http-nonjava/reference-destination-http-nonjava/#persist-name) for more information.
+	// See [syslog-ng docs](https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-loki/#tenant-id) for more information.
 	TenantID string `json:"tenant-id,omitempty"`
 }


### PR DESCRIPTION
The Loki destination plugin in AxoSyslog allows setting the tenant value for the events being sent via the [tenant-id()](https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-loki/#tenant-id) option.

Adding this parameter to `SyslogNGClusterOutput`/`SyslogNGOutput` will allow sending events to different tenants in a multi-tenant Loki environment.

Without specifying this option, it is not possible to use AxoSyslog Loki output in a multi-tenant Loki environment with authentication enabled.

An error will be displayed in the pod with the AxoSyslog aggregator:
```
Error sending Loki batch; error='no org id', details='', location='/etc/syslog-ng/config/syslog-ng.conf:17:5'
```