### PR TITLE
fix: add Parsers_File to fluent-bit.conf if enableDockerParserCompatibilityForCRI is enabled

### DIFF
--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -35,6 +35,9 @@ var fluentBitConfigTemplate = `
     {{- if .CustomParsers }}
     Parsers_File {{ .CustomParsers }}
     {{- end }}
+    {{- if .CRIParser }}
+    Parsers_File {{ .CRIParser }}
+    {{- end }}
     Coro_Stack_Size    {{ .CoroStackSize }}
     {{- if .Monitor.Enabled }}
     HTTP_Server  On

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -82,6 +82,7 @@ type fluentBitConfig struct {
 	SyslogNGOutput           *syslogNGOutputConfig
 	DefaultParsers           string
 	CustomParsers            string
+	CRIParser                string
 	HealthCheck              *v1beta1.HealthCheck
 }
 
@@ -246,6 +247,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		default:
 			if r.Logging.Spec.EnableDockerParserCompatibilityForCRI {
 				r.fluentbitSpec.InputTail.Parser = "cri-log-compatibility"
+				input.CRIParser = fmt.Sprintf("%s/%s", OperatorConfigPath, CRIParserConfigName)
 			} else {
 				r.fluentbitSpec.InputTail.Parser = "cri"
 			}


### PR DESCRIPTION
`Parsers_File` with the path to the `cri-log-compatibility` parser configuration should be added if the `enableDockerParserCompatibilityForCRI` option is used in the `Logging` resource.

This PR fixes: #2025 