### PR TITLE
fix(helm): priorityClassName must be of type string

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -64,7 +64,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | monitoring.serviceMonitor.relabelings | list | `[]` |  |
 | podSecurityContext | object | `{}` | Pod SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/) # SecurityContext holds pod-level security attributes and common container settings. # This defaults to non root user with uid 1000 and gid 2000.	*v1.PodSecurityContext	false # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | securityContext | object | `{}` | Container SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/) |
-| priorityClassName | object | `{}` | Operator priorityClassName. |
+| priorityClassName | string | `nil` | Operator priorityClassName. |
 | serviceAccount.annotations | object | `{}` | Define annotations for logging-operator ServiceAccount. |
 | resources | object | `{}` | CPU/Memory resource requests/limits |
 | nodeSelector | object | `{}` |  |

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -105,7 +105,7 @@ securityContext: {}
   #   drop: ["ALL"]
 
 # -- Operator priorityClassName.
-priorityClassName: {}
+priorityClassName: ~
 
 serviceAccount:
   # -- Define annotations for logging-operator ServiceAccount.


### PR DESCRIPTION
The default value of `priorityClassName` is currently a map/object, but is used as a string when setting it on the deployment.

This change sets the default value to null (using `~`), and is now considered a string value.

Fixes #2031 