### PR TITLE
Fix incorrect doc for default LineFormat for loki

### DIFF
--- a/docs/configuration/plugins/outputs/loki.md
+++ b/docs/configuration/plugins/outputs/loki.md
@@ -89,7 +89,7 @@ Set of labels to include with every Loki stream.
 
 ### line_format (string, optional) {#output config-line_format}
 
-Format to use when flattening the record to a log line: json, key_value (default: key_value) 
+Format to use when flattening the record to a log line: json, key_value (default: json) 
 
 Default: json
 

--- a/pkg/sdk/logging/model/output/loki.go
+++ b/pkg/sdk/logging/model/output/loki.go
@@ -79,7 +79,7 @@ type LokiOutput struct {
 	Labels Label `json:"labels,omitempty"`
 	// Set of extra labels to include with every Loki stream.
 	ExtraLabels map[string]string `json:"extra_labels,omitempty"`
-	// Format to use when flattening the record to a log line: json, key_value (default: key_value)
+	// Format to use when flattening the record to a log line: json, key_value (default: json)
 	LineFormat string `json:"line_format,omitempty" plugin:"default:json"`
 	// Extract kubernetes labels as loki labels (default: false)
 	ExtractKubernetesLabels *bool `json:"extract_kubernetes_labels,omitempty"`


### PR DESCRIPTION
Fix incorrect doc for default LineFormat for loki logs.

https://kube-logging.dev/docs/configuration/plugins/outputs/loki/

<img width="754" alt="Screenshot 2025-05-13 at 10 51 01" src="https://github.com/user-attachments/assets/e5f21daa-fa73-4293-ae86-b3ae3efb47d5" />
