### PR TITLE
fix version 5.3.0 instead of 0.0.0

### DIFF
--- a/charts/logging-operator/Chart.yaml
+++ b/charts/logging-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: logging-operator
-version: 0.0.0
-appVersion: latest
+version: 5.3.0
+appVersion: 5.3.0
 kubeVersion: ">=1.22.0-0"
 description: Logging operator for Kubernetes based on Fluentd and Fluentbit.
 keywords:


### PR DESCRIPTION
The version `0.0.0` is a bit weird and somehow it stopped the fluentd to use the right ES fluentd plugin https://github.com/uken/fluent-plugin-elasticsearch version `6.0.0` https://github.com/uken/fluent-plugin-elasticsearch/pull/1067

Specifying the fixed version seems solved the issue in our end