### PR TITLE
Fix for LogicMonitor resource_mapping field

### DIFF
--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_clusteroutputs.yaml
@@ -4378,7 +4378,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:
@@ -12050,7 +12049,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_outputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_outputs.yaml
@@ -11107,7 +11107,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -4375,7 +4375,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:
@@ -12047,7 +12046,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
@@ -11104,7 +11104,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:

--- a/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
@@ -4375,7 +4375,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:
@@ -12047,7 +12046,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:

--- a/config/crd/bases/logging.banzaicloud.io_outputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_outputs.yaml
@@ -11104,7 +11104,6 @@ spec:
                     type: string
                 required:
                 - company_name
-                - resource_mapping
                 type: object
               logdna:
                 properties:

--- a/pkg/sdk/logging/model/output/lm_logs.go
+++ b/pkg/sdk/logging/model/output/lm_logs.go
@@ -69,7 +69,7 @@ type LMLogsOutputConfig struct {
 	// LogicMonitor account domain. For eg. for url test.logicmonitor.com, company_domain is logicmonitor.com (default: logicmonitor.com)
 	CompanyDomain string `json:"company_domain,omitempty" plugin:"default:logicmonitor.com"`
 	// The mapping that defines the source of the log event to the LM resource. In this case, the <event_key> in the incoming event is mapped to the value of <lm_property>
-	ResourceMapping string `json:"resource_mapping"`
+	ResourceMapping string `json:"resource_mapping,omitempty"`
 	// LM API Token access ID
 	// +docLink:"Secret,../secret/"
 	AccessID *secret.Secret `json:"access_id,omitempty"`

--- a/pkg/sdk/logging/model/output/lm_logs_test.go
+++ b/pkg/sdk/logging/model/output/lm_logs_test.go
@@ -144,3 +144,36 @@ force_encoding: "UTF-8"
 	test := render.NewOutputPluginTest(t, s)
 	test.DiffResult(expected)
 }
+
+func TestLMLogsOutputConfigWithoutResourceMapping(t *testing.T) {
+	CONFIG := []byte(`
+company_name: mycompany
+access_id:
+  value: "my_access_id"
+access_key:
+  value: "my_access_key"
+`)
+
+	expected := `
+  <match **>
+  @type lm
+  @id test
+  access_id my_access_id
+  access_key my_access_key
+  company_domain logicmonitor.com
+  company_name mycompany
+  flush_interval 60s
+  <buffer tag,time>
+	@type file
+	path /buffers/test.*.buffer
+	retry_forever true
+	timekey 10m
+	timekey_wait 1m
+  </buffer>
+</match>
+`
+	s := &output.LMLogsOutputConfig{}
+	require.NoError(t, yaml.Unmarshal(CONFIG, s))
+	test := render.NewOutputPluginTest(t, s)
+	test.DiffResult(expected)
+}


### PR DESCRIPTION
This is a follow up to PR #2059. I apologize, right before opening the last PR I changed the `resource_mapping` property to be optional. I forgot two critical things:

1. I forgot to properly re-generate the CRDs to remove this as a required field. I thought I did this but I guess I missed a step.
2. I didn't configure the field for `omitempty`, so if unspecified, it currently generates a broken config.

I fixed these issues and added an additional test.