### PR TITLE
bugfix: mount /var/log only if config parameter is set to false

### DIFF
--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -218,15 +218,16 @@ func (r *Reconciler) generateVolumeMounts() (v []corev1.VolumeMount) {
 }
 
 func (r *Reconciler) generateVolume() (v []corev1.Volume) {
-	v = []corev1.Volume{
-		{
+	if !*r.fluentbitSpec.DisableVarLog {
+		v = append(v, corev1.Volume{
+
 			Name: "varlogs",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/var/log",
 				},
 			},
-		},
+		})
 	}
 
 	if !*r.fluentbitSpec.DisableVarLibDockerContainers {


### PR DESCRIPTION
We missed a thing in https://github.com/kube-logging/logging-operator/pull/2043

This PR ensures that volume and volumeMount is set only if switch "disableVarLog" is set to true