### PR TITLE
add snappy gem for fluentd

### DIFF
--- a/images/fluentd/Dockerfile
+++ b/images/fluentd/Dockerfile
@@ -26,6 +26,7 @@ RUN addgroup -S -g 101 fluent && adduser -S -G fluent -u 100 fluent \
  && gem install fluentd -v 1.18.0 \
  && fluent-gem install specific_install -v 0.3.8 \
  && fluent-gem install fluent-plugin-label-router -v 0.5.0 \
+ && fluent-gem install snappy -v 0.0.15 \
  && find /usr/local/bundle/gems/ -newer /etc/gemrc -exec chown fluent:fluent {} \; \
  && apk del $BUILD_DEPS \
  && rm -rf /usr/local/bundle/cache/* && find /usr/local/bundle -name '*.o' -delete


### PR DESCRIPTION
Snappy is a common `compression_codec` for Kafka Logging Output. Unfortunatelly the plugin is missing in the fluentd 1´.18 Dockerfile, it was previously installed in [1.16](https://github.com/kube-logging/fluentd-images/blob/main/v1.16-4.10/Dockerfile#L42), maybe the use case is not broad that the gem module was missing so far.