### PR TITLE
Add spec.fluentBitAgentNamespace to run Fluent Bit in a dedicated namespace

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -90,7 +90,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | logging.watchNamespaceSelector | object | `{}` | Limit namespaces to watch Flow and Output custom resources. |
 | logging.clusterDomain | string | `"cluster.local."` | Cluster domain name to be used when templating URLs to services |
 | logging.controlNamespace | string | `""` | Namespace for cluster wide configuration resources like ClusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well. |
-| logging.nodeAgentNamespace | string | `""` | Namespace to deploy Fluent Bit resources into. If empty, defaults to controlNamespace for backward compatibility. |
+| logging.fluentBitAgentNamespace | string | `""` | Namespace to deploy FluentBit resources into. If empty, defaults to controlNamespace for backward compatibility. |
 | logging.allowClusterResourcesFromAllNamespaces | bool | `false` | Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources |
 | logging.configCheck | object | `{}` | configCheck provides possibility for timeout-based configuration checks https://kube-logging.dev/docs/whats-new/#timeout-based-configuration-checks |
 | logging.enableRecreateWorkloadOnImmutableFieldChange | bool | `false` | EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future) in case there is a change in an immutable field that otherwise couldn’t be managed with a simple update. |

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -90,6 +90,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | logging.watchNamespaceSelector | object | `{}` | Limit namespaces to watch Flow and Output custom resources. |
 | logging.clusterDomain | string | `"cluster.local."` | Cluster domain name to be used when templating URLs to services |
 | logging.controlNamespace | string | `""` | Namespace for cluster wide configuration resources like ClusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well. |
+| logging.nodeAgentNamespace | string | `""` | Namespace to deploy Fluent Bit resources into. If empty, defaults to controlNamespace for backward compatibility. |
 | logging.allowClusterResourcesFromAllNamespaces | bool | `false` | Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources |
 | logging.configCheck | object | `{}` | configCheck provides possibility for timeout-based configuration checks https://kube-logging.dev/docs/whats-new/#timeout-based-configuration-checks |
 | logging.enableRecreateWorkloadOnImmutableFieldChange | bool | `false` | EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future) in case there is a change in an immutable field that otherwise couldn’t be managed with a simple update. |

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
@@ -887,6 +887,9 @@ spec:
                 type: string
               fluentBitAgentNamespace:
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable, please recreate the resource
+                  rule: self == oldSelf
               fluentbit:
                 properties:
                   HostNetwork:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
@@ -7799,6 +7799,8 @@ spec:
                 type: array
               loggingRef:
                 type: string
+              nodeAgentNamespace:
+                type: string
               routeConfig:
                 properties:
                   disableLoggingRoute:
@@ -16210,6 +16212,7 @@ spec:
                 type: array
             required:
             - controlNamespace
+            - nodeAgentNamespace
             type: object
           status:
             properties:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
@@ -885,6 +885,8 @@ spec:
                 type: boolean
               flowConfigOverride:
                 type: string
+              fluentBitAgentNamespace:
+                type: string
               fluentbit:
                 properties:
                   HostNetwork:
@@ -7798,8 +7800,6 @@ spec:
                   type: object
                 type: array
               loggingRef:
-                type: string
-              nodeAgentNamespace:
                 type: string
               routeConfig:
                 properties:
@@ -16212,7 +16212,6 @@ spec:
                 type: array
             required:
             - controlNamespace
-            - nodeAgentNamespace
             type: object
           status:
             properties:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -882,6 +882,8 @@ spec:
                 type: boolean
               flowConfigOverride:
                 type: string
+              fluentBitAgentNamespace:
+                type: string
               fluentbit:
                 properties:
                   HostNetwork:
@@ -7795,8 +7797,6 @@ spec:
                   type: object
                 type: array
               loggingRef:
-                type: string
-              nodeAgentNamespace:
                 type: string
               routeConfig:
                 properties:
@@ -16209,7 +16209,6 @@ spec:
                 type: array
             required:
             - controlNamespace
-            - nodeAgentNamespace
             type: object
           status:
             properties:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -884,6 +884,9 @@ spec:
                 type: string
               fluentBitAgentNamespace:
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable, please recreate the resource
+                  rule: self == oldSelf
               fluentbit:
                 properties:
                   HostNetwork:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -7796,6 +7796,8 @@ spec:
                 type: array
               loggingRef:
                 type: string
+              nodeAgentNamespace:
+                type: string
               routeConfig:
                 properties:
                   disableLoggingRoute:
@@ -16207,6 +16209,7 @@ spec:
                 type: array
             required:
             - controlNamespace
+            - nodeAgentNamespace
             type: object
           status:
             properties:

--- a/charts/logging-operator/templates/logging/logging.yaml
+++ b/charts/logging-operator/templates/logging/logging.yaml
@@ -45,8 +45,8 @@ spec:
   {{- end }}
   clusterDomain: {{ .Values.logging.clusterDomain }}
   controlNamespace: {{ .Values.logging.controlNamespace | default .Release.Namespace }}
-  {{- if .Values.logging.nodeAgentNamespace }}
-  nodeAgentNamespace: {{ .Values.logging.nodeAgentNamespace }}
+  {{- if .Values.logging.fluentBitAgentNamespace }}
+  fluentBitAgentNamespace: {{ .Values.logging.fluentBitAgentNamespace }}
   {{- end }}
   {{- with .Values.logging.allowClusterResourcesFromAllNamespaces }}
   allowClusterResourcesFromAllNamespaces: {{ . }}

--- a/charts/logging-operator/templates/logging/logging.yaml
+++ b/charts/logging-operator/templates/logging/logging.yaml
@@ -45,6 +45,9 @@ spec:
   {{- end }}
   clusterDomain: {{ .Values.logging.clusterDomain }}
   controlNamespace: {{ .Values.logging.controlNamespace | default .Release.Namespace }}
+  {{- if .Values.logging.nodeAgentNamespace }}
+  nodeAgentNamespace: {{ .Values.logging.nodeAgentNamespace }}
+  {{- end }}
   {{- with .Values.logging.allowClusterResourcesFromAllNamespaces }}
   allowClusterResourcesFromAllNamespaces: {{ . }}
   {{- end }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -203,8 +203,8 @@ logging:
   # -- Namespace for cluster wide configuration resources like ClusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well.
   controlNamespace: ""
 
-  # -- Namespace to deploy Fluent Bit resources into. If empty, defaults to controlNamespace for backward compatibility.
-  nodeAgentNamespace: ""
+  # -- Namespace to deploy FluentBit resources into. If empty, defaults to controlNamespace for backward compatibility.
+  fluentBitAgentNamespace: ""
 
   # -- Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources
   allowClusterResourcesFromAllNamespaces: false

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -203,6 +203,9 @@ logging:
   # -- Namespace for cluster wide configuration resources like ClusterFlow and ClusterOutput. This should be a protected namespace from regular users. Resources like fluentbit and fluentd will run in this namespace as well.
   controlNamespace: ""
 
+  # -- Namespace to deploy Fluent Bit resources into. If empty, defaults to controlNamespace for backward compatibility.
+  nodeAgentNamespace: ""
+
   # -- Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources
   allowClusterResourcesFromAllNamespaces: false
 

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -882,6 +882,8 @@ spec:
                 type: boolean
               flowConfigOverride:
                 type: string
+              fluentBitAgentNamespace:
+                type: string
               fluentbit:
                 properties:
                   HostNetwork:
@@ -7795,8 +7797,6 @@ spec:
                   type: object
                 type: array
               loggingRef:
-                type: string
-              nodeAgentNamespace:
                 type: string
               routeConfig:
                 properties:
@@ -16209,7 +16209,6 @@ spec:
                 type: array
             required:
             - controlNamespace
-            - nodeAgentNamespace
             type: object
           status:
             properties:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -884,6 +884,9 @@ spec:
                 type: string
               fluentBitAgentNamespace:
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable, please recreate the resource
+                  rule: self == oldSelf
               fluentbit:
                 properties:
                   HostNetwork:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -7796,6 +7796,8 @@ spec:
                 type: array
               loggingRef:
                 type: string
+              nodeAgentNamespace:
+                type: string
               routeConfig:
                 properties:
                   disableLoggingRoute:
@@ -16207,6 +16209,7 @@ spec:
                 type: array
             required:
             - controlNamespace
+            - nodeAgentNamespace
             type: object
           status:
             properties:

--- a/docs/configuration/crds/v1beta1/logging_types.md
+++ b/docs/configuration/crds/v1beta1/logging_types.md
@@ -79,6 +79,11 @@ Global filters to apply on logs before any match or filter mechanism.
 Reference to the logging system. Each of the `loggingRef`s can manage a fluentbit daemonset and a fluentd statefulset. 
 
 
+### nodeAgentNamespace (string, required) {#loggingspec-nodeagentnamespace}
+
+Namespace to deploy Fluent Bit resources (DaemonSet, Service, ServiceAccount, config Secret, ServiceMonitors). If unset, it defaults to `controlNamespace` to preserve backward compatibility. 
+
+
 ### routeConfig (*RouteConfig, optional) {#loggingspec-routeconfig}
 
 RouteConfig determines whether to use loggingRoutes or to create resources based on the logging resource that can be managed by the Telemetry Controller. 

--- a/docs/configuration/crds/v1beta1/logging_types.md
+++ b/docs/configuration/crds/v1beta1/logging_types.md
@@ -59,6 +59,11 @@ Disable configuration check before applying new fluentd or syslogng configuratio
 Override generated config. This is a *raw* configuration string for troubleshooting purposes. 
 
 
+### fluentBitAgentNamespace (string, optional) {#loggingspec-fluentbitagentnamespace}
+
+Namespace to deploy Fluent Bit resources (DaemonSet, Service, ServiceAccount, config Secret, ServiceMonitors). If unset, it defaults to `controlNamespace` to preserve backward compatibility. 
+
+
 ### fluentbit (*FluentbitSpec, optional) {#loggingspec-fluentbit}
 
 FluentbitAgent daemonset configuration. DEPRECATED: Migrate to the standalone FluentBitAgent resource 
@@ -77,11 +82,6 @@ Global filters to apply on logs before any match or filter mechanism.
 ### loggingRef (string, optional) {#loggingspec-loggingref}
 
 Reference to the logging system. Each of the `loggingRef`s can manage a fluentbit daemonset and a fluentd statefulset. 
-
-
-### nodeAgentNamespace (string, required) {#loggingspec-nodeagentnamespace}
-
-Namespace to deploy Fluent Bit resources (DaemonSet, Service, ServiceAccount, config Secret, ServiceMonitors). If unset, it defaults to `controlNamespace` to preserve backward compatibility. 
 
 
 ### routeConfig (*RouteConfig, optional) {#loggingspec-routeconfig}

--- a/e2e/fluentbit-nodeagents-namespace/fluentbit_nodeagents_namespace_test.go
+++ b/e2e/fluentbit-nodeagents-namespace/fluentbit_nodeagents_namespace_test.go
@@ -1,0 +1,252 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbit_nodeagents_namespace
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	v1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
+
+	"github.com/kube-logging/logging-operator/e2e/common"
+	"github.com/kube-logging/logging-operator/e2e/common/cond"
+	"github.com/kube-logging/logging-operator/e2e/common/setup"
+)
+
+var TestTempDir string
+
+func init() {
+	var ok bool
+	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
+	if !ok {
+		TestTempDir = "../.."
+	}
+	TestTempDir = filepath.Join(TestTempDir, "build/_test")
+	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	if err != nil {
+		panic(err)
+	}
+}
+
+var tags = "time"
+var realTimeBuffer = &output.Buffer{
+	Tags:        &tags,
+	Timekey:     "1s",
+	TimekeyWait: "0s",
+}
+var producerLabels = map[string]string{
+	"my-unique-label": "log-producer",
+}
+
+// Verifies that Fluent Bit node agents are deployed to a dedicated namespace when
+// logging.spec.nodeAgentNamespace is set, while the aggregator stays in the control namespace.
+func TestFluentbitNodeAgentsDedicatedNamespace(t *testing.T) {
+	common.Initialize(t)
+
+	nsControl := "logging"
+	nsAgents := "logging-node-agents"
+	release := "fluentbit-nodeagents-namespace"
+	tag := "tag_nodeagents"
+
+	common.WithCluster(release, t, func(t *testing.T, c common.Cluster) {
+		// Install logging-operator Helm chart with test-receiver in control namespace
+		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
+			options.Namespace = nsControl
+			options.NameOverride = release
+		}))
+
+		ctx := context.Background()
+
+		// Ensure node agents namespace exists
+		common.RequireNoError(t, c.GetClient().Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nsAgents,
+			},
+		}))
+
+		// Create ClusterOutput pointing to test-receiver in control namespace
+		httpOut := v1beta1.ClusterOutput{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "http",
+				Namespace: nsControl,
+			},
+			Spec: v1beta1.ClusterOutputSpec{
+				OutputSpec: v1beta1.OutputSpec{
+					LoggingRef: "infra",
+					HTTPOutput: &output.HTTPOutputConfig{
+						Endpoint:    fmt.Sprintf("http://%s-test-receiver:8080/%s", release, tag),
+						ContentType: "application/json",
+						Buffer:      realTimeBuffer,
+					},
+				},
+			},
+		}
+		common.RequireNoError(t, c.GetClient().Create(ctx, &httpOut))
+
+		// Match producer pods cluster-wide
+		clusterFlow := v1beta1.ClusterFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "flow",
+				Namespace: nsControl,
+			},
+			Spec: v1beta1.ClusterFlowSpec{
+				LoggingRef: "infra",
+				Match: []v1beta1.ClusterMatch{
+					{
+						ClusterSelect: &v1beta1.ClusterSelect{
+							Labels: producerLabels,
+						},
+					},
+				},
+				GlobalOutputRefs: []string{httpOut.Name},
+			},
+		}
+		common.RequireNoError(t, c.GetClient().Create(ctx, &clusterFlow))
+
+		// Create Fluent Bit agent (standalone) bound to the same loggingRef
+		agent := v1beta1.FluentbitAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "infra",
+			},
+			Spec: v1beta1.FluentbitSpec{
+				LoggingRef: "infra",
+				ConfigHotReload: &v1beta1.HotReload{
+					Image: v1beta1.ImageSpec{Repository: common.ConfigReloaderRepo, Tag: common.ConfigReloaderTag},
+				},
+				BufferVolumeImage: v1beta1.ImageSpec{Repository: common.NodeExporterRepo, Tag: common.NodeExporterTag},
+			},
+		}
+		common.RequireNoError(t, c.GetClient().Create(ctx, &agent))
+
+		// Create Logging with control namespace and dedicated nodeAgentNamespace
+		logging := v1beta1.Logging{
+			ObjectMeta: metav1.ObjectMeta{Name: "infra"},
+			Spec: v1beta1.LoggingSpec{
+				LoggingRef:         "infra",
+				ControlNamespace:   nsControl,
+				NodeAgentNamespace: nsAgents,
+				FluentdSpec: &v1beta1.FluentdSpec{
+					Image:               v1beta1.ImageSpec{Repository: common.FluentdImageRepo, Tag: common.FluentdImageTag},
+					ConfigReloaderImage: v1beta1.ImageSpec{Repository: common.ConfigReloaderRepo, Tag: common.ConfigReloaderTag},
+					BufferVolumeImage:   v1beta1.ImageSpec{Repository: common.NodeExporterRepo, Tag: common.NodeExporterTag},
+					DisablePvc:          true,
+					Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("50m"),
+						corev1.ResourceMemory: apiresource.MustParse("50M"),
+					}},
+				},
+			},
+		}
+		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
+
+		// Start a log producer in the default namespace
+		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+			options.Namespace = "default"
+			options.Labels = producerLabels
+		}))
+
+		fluentBitLabels := map[string]string{
+			"app.kubernetes.io/name": "fluentbit",
+		}
+		aggregatorLabels := map[string]string{
+			"app.kubernetes.io/name":      "fluentd",
+			"app.kubernetes.io/component": "fluentd",
+		}
+		operatorLabels := map[string]string{
+			"app.kubernetes.io/name": release,
+		}
+
+		require.Eventually(t, func() bool {
+			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+				t.Log("waiting for the operator")
+				return false
+			}
+			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+				t.Log("waiting for the producer")
+				return false
+			}
+			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsControl)); !aggregatorRunning() {
+				t.Log("waiting for the aggregator in control namespace")
+				return false
+			}
+			if fluentbitRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(fluentBitLabels), client.InNamespace(nsAgents)); !fluentbitRunning() {
+				t.Log("waiting for the fluentbit daemonset in node agents namespace")
+				return false
+			}
+
+			cmd := common.CmdEnv(exec.Command("kubectl",
+				"logs",
+				"-n", nsControl,
+				"--tail", "30",
+				"-l", fmt.Sprintf("app.kubernetes.io/name=%s-test-receiver", release)), c)
+			rawOut, err := cmd.Output()
+			if err != nil {
+				t.Logf("failed to get log consumer logs: %v", err)
+				return false
+			}
+			t.Logf("log consumer logs: %s", rawOut)
+			return strings.Contains(string(rawOut), tag)
+		}, 5*time.Minute, 3*time.Second)
+
+	}, func(t *testing.T, c common.Cluster) error {
+		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
+		t.Logf("Printing cluster logs to %s", path)
+		err := c.PrintLogs(common.PrintLogConfig{
+			Namespaces: []string{nsControl, nsAgents, "default"},
+			FilePath:   path,
+			Limit:      100 * 1000,
+		})
+		if err != nil {
+			return err
+		}
+
+		loggingOperatorName := "logging-operator-" + release
+		t.Logf("Collecting coverage files from logging-operator: %s/%s", nsControl, loggingOperatorName)
+		err = c.CollectTestCoverageFiles(nsControl, loggingOperatorName)
+		if err != nil {
+			t.Logf("Failed collecting coverage files: %s", err)
+		}
+		return nil
+	}, func(o *cluster.Options) {
+		if o.Scheme == nil {
+			o.Scheme = runtime.NewScheme()
+		}
+		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
+		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
+	})
+}

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -229,7 +229,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		ForceHotReloadAfterGrace: r.fluentbitSpec.ForceHotReloadAfterGrace,
 		LogLevel:                 r.fluentbitSpec.LogLevel,
 		CoroStackSize:            r.fluentbitSpec.CoroStackSize,
-		Namespace:                r.Logging.Spec.ControlNamespace,
+		Namespace:                r.Logging.Spec.NodeAgentNamespace,
 		DisableKubernetesFilter:  disableKubernetesFilter,
 		FilterModify:             r.fluentbitSpec.FilterModify,
 		HealthCheck:              r.fluentbitSpec.HealthCheck,

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -229,7 +229,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		ForceHotReloadAfterGrace: r.fluentbitSpec.ForceHotReloadAfterGrace,
 		LogLevel:                 r.fluentbitSpec.LogLevel,
 		CoroStackSize:            r.fluentbitSpec.CoroStackSize,
-		Namespace:                r.Logging.Spec.NodeAgentNamespace,
+		Namespace:                r.Logging.Spec.FluentbitAgentNamespace,
 		DisableKubernetesFilter:  disableKubernetesFilter,
 		FilterModify:             r.fluentbitSpec.FilterModify,
 		HealthCheck:              r.fluentbitSpec.HealthCheck,

--- a/pkg/resources/fluentbit/meta.go
+++ b/pkg/resources/fluentbit/meta.go
@@ -22,7 +22,7 @@ import (
 func (r *Reconciler) FluentbitObjectMeta(name string) metav1.ObjectMeta {
 	o := metav1.ObjectMeta{
 		Name:      r.nameProvider.ComponentName(name),
-		Namespace: r.Logging.Spec.NodeAgentNamespace,
+		Namespace: r.Logging.Spec.FluentbitAgentNamespace,
 		Labels:    r.getFluentBitLabels(),
 		OwnerReferences: []metav1.OwnerReference{
 			r.nameProvider.OwnerRef(),

--- a/pkg/resources/fluentbit/meta.go
+++ b/pkg/resources/fluentbit/meta.go
@@ -22,7 +22,7 @@ import (
 func (r *Reconciler) FluentbitObjectMeta(name string) metav1.ObjectMeta {
 	o := metav1.ObjectMeta{
 		Name:      r.nameProvider.ComponentName(name),
-		Namespace: r.Logging.Spec.ControlNamespace,
+		Namespace: r.Logging.Spec.NodeAgentNamespace,
 		Labels:    r.getFluentBitLabels(),
 		OwnerReferences: []metav1.OwnerReference{
 			r.nameProvider.OwnerRef(),

--- a/pkg/resources/fluentbit/rbac.go
+++ b/pkg/resources/fluentbit/rbac.go
@@ -55,7 +55,7 @@ func (r *Reconciler) sccRoleBinding() (runtime.Object, reconciler.DesiredState, 
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      r.getServiceAccount(),
-					Namespace: r.Logging.Spec.NodeAgentNamespace,
+					Namespace: r.Logging.Spec.FluentbitAgentNamespace,
 				},
 			},
 		}, reconciler.StatePresent, nil
@@ -100,7 +100,7 @@ func (r *Reconciler) clusterRoleBinding() (runtime.Object, reconciler.DesiredSta
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      r.getServiceAccount(),
-					Namespace: r.Logging.Spec.NodeAgentNamespace,
+					Namespace: r.Logging.Spec.FluentbitAgentNamespace,
 				},
 			},
 		}, reconciler.StatePresent, nil

--- a/pkg/resources/fluentbit/rbac.go
+++ b/pkg/resources/fluentbit/rbac.go
@@ -55,7 +55,7 @@ func (r *Reconciler) sccRoleBinding() (runtime.Object, reconciler.DesiredState, 
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      r.getServiceAccount(),
-					Namespace: r.Logging.Spec.ControlNamespace,
+					Namespace: r.Logging.Spec.NodeAgentNamespace,
 				},
 			},
 		}, reconciler.StatePresent, nil
@@ -100,7 +100,7 @@ func (r *Reconciler) clusterRoleBinding() (runtime.Object, reconciler.DesiredSta
 				{
 					Kind:      rbacv1.ServiceAccountKind,
 					Name:      r.getServiceAccount(),
-					Namespace: r.Logging.Spec.ControlNamespace,
+					Namespace: r.Logging.Spec.NodeAgentNamespace,
 				},
 			},
 		}, reconciler.StatePresent, nil

--- a/pkg/resources/fluentbit/service.go
+++ b/pkg/resources/fluentbit/service.go
@@ -75,7 +75,7 @@ func (r *Reconciler) monitorServiceMetrics() (runtime.Object, reconciler.Desired
 				Selector: v12.LabelSelector{
 					MatchLabels: util.MergeLabels(r.fluentbitSpec.Labels, r.getFluentBitLabels(), generateLoggingRefLabels(r.Logging.GetName())),
 				},
-				NamespaceSelector: v1.NamespaceSelector{MatchNames: []string{r.Logging.Spec.ControlNamespace}},
+				NamespaceSelector: v1.NamespaceSelector{MatchNames: []string{r.Logging.Spec.FluentbitAgentNamespace}},
 				SampleLimit:       &SampleLimit,
 			},
 		}, reconciler.StatePresent, nil
@@ -140,7 +140,7 @@ func (r *Reconciler) monitorBufferServiceMetrics() (runtime.Object, reconciler.D
 					TLSConfig:            r.fluentbitSpec.Metrics.ServiceMonitorConfig.TLSConfig,
 				}},
 				Selector:          v12.LabelSelector{MatchLabels: r.getFluentBitLabels()},
-				NamespaceSelector: v1.NamespaceSelector{MatchNames: []string{r.Logging.Spec.ControlNamespace}},
+				NamespaceSelector: v1.NamespaceSelector{MatchNames: []string{r.Logging.Spec.FluentbitAgentNamespace}},
 				SampleLimit:       &SampleLimit,
 			},
 		}, reconciler.StatePresent, nil

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -81,7 +81,7 @@ type LoggingSpec struct {
 	ControlNamespace string `json:"controlNamespace"`
 
 	// Namespace to deploy Fluent Bit resources (DaemonSet, Service, ServiceAccount, config Secret, ServiceMonitors). If unset, it defaults to `controlNamespace` to preserve backward compatibility.
-	NodeAgentNamespace string `json:"nodeAgentNamespace"`
+	FluentbitAgentNamespace string `json:"fluentBitAgentNamespace,omitempty"`
 
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable, please recreate the resource"
 
@@ -227,9 +227,9 @@ func (l *Logging) SetDefaults() error {
 	if !l.Spec.FlowConfigCheckDisabled && l.Status.ConfigCheckResults == nil {
 		l.Status.ConfigCheckResults = make(map[string]bool)
 	}
-	// Default/compatibility mapping for node agents namespace
-	if l.Spec.NodeAgentNamespace == "" {
-		l.Spec.NodeAgentNamespace = l.Spec.ControlNamespace
+	// Default/compatibility mapping for fluentbit agents namespace
+	if l.Spec.FluentbitAgentNamespace == "" {
+		l.Spec.FluentbitAgentNamespace = l.Spec.ControlNamespace
 	}
 	if len(l.Status.FluentdConfigName) == 0 {
 		if err := l.Spec.FluentdSpec.SetDefaults(); err != nil {

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -81,6 +81,7 @@ type LoggingSpec struct {
 	ControlNamespace string `json:"controlNamespace"`
 
 	// Namespace to deploy Fluent Bit resources (DaemonSet, Service, ServiceAccount, config Secret, ServiceMonitors). If unset, it defaults to `controlNamespace` to preserve backward compatibility.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable, please recreate the resource"
 	FluentbitAgentNamespace string `json:"fluentBitAgentNamespace,omitempty"`
 
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable, please recreate the resource"

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -80,6 +80,9 @@ type LoggingSpec struct {
 	// Resources like fluentbit and fluentd will run in this namespace as well.
 	ControlNamespace string `json:"controlNamespace"`
 
+	// Namespace to deploy Fluent Bit resources (DaemonSet, Service, ServiceAccount, config Secret, ServiceMonitors). If unset, it defaults to `controlNamespace` to preserve backward compatibility.
+	NodeAgentNamespace string `json:"nodeAgentNamespace"`
+
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable, please recreate the resource"
 
 	// Allow configuration of cluster resources from any namespace. Mutually exclusive with ControlNamespace restriction of Cluster resources
@@ -223,6 +226,10 @@ func (l *Logging) SetDefaults() error {
 	}
 	if !l.Spec.FlowConfigCheckDisabled && l.Status.ConfigCheckResults == nil {
 		l.Status.ConfigCheckResults = make(map[string]bool)
+	}
+	// Default/compatibility mapping for node agents namespace
+	if l.Spec.NodeAgentNamespace == "" {
+		l.Spec.NodeAgentNamespace = l.Spec.ControlNamespace
 	}
 	if len(l.Status.FluentdConfigName) == 0 {
 		if err := l.Spec.FluentdSpec.SetDefaults(); err != nil {


### PR DESCRIPTION
Summary
- Introduces Logging.spec.fluentBitAgentNamespace (immutable) to place Fluent Bit resources in a separate namespace from the control plane. Fixes [2104](https://github.com/kube-logging/logging-operator/issues/2104)
- Defaults to spec.controlNamespace for backwards compatibility.
Motivation
- Separate privileged node agents from restricted control plane to comply with PSA and organizational segregation.
- Clearer ownership and RBAC boundaries for platform vs. infra teams.

What’s changed
- API: LoggingSpec gains fluentBitAgentNamespace; defaulting is applied in SetDefaults()
- FluentBit reconcilers:
  - ObjectMeta.Namespace now uses logging.Spec.fluentBitAgentNamespace
  - RBAC subjects reference ServiceAccount in fluentBitAgentNamespace
- CRDs and Helm chart CRDs/docs regenerated
- E2E: new suite fluentbit-agent-namespace
  - Installs operator in control ns
  - Creates dedicated node agent ns
  - Asserts fluentd in control ns, fluentbit in agents ns
  - Verifies logs reach test receiver

Backwards compatibility
- If spec.fluentBitAgentNamespace is omitted, Fluent Bit continues to deploy into spec.controlNamespace (current behavior).

Testing
- Local:
  - `make generate`
  - `make check`
  - `make docker-build-e2e-test`
  - `make test-e2e E2E_TEST=fluentbit-agent-namespace
- Coverage artifacts are collected from the operator during e2e.

Docs
- CRD reference updated (logging_types.md)
- Helm README refreshed via helm-docs

Risks / Notes
- The field is immutable; changing it requires resource recreation.
- Large CRD diffs due to regeneration are expected.

Release note
- Add Logging.spec.fluentBitAgentNamespace to deploy Fluent Bit into a dedicated namespace (defaults to controlNamespace). Aggregators remain in controlNamespace.

Checklist
- [x] DCO signed
- [x] Unit tests pass
- [x] E2E added for node agents namespace
- [x] CRDs and Helm docs regenerated
- [x] Docs updated