### PR TITLE
fix: e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -81,6 +81,22 @@ jobs:
 #        SHARDS: [1]
 
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,6 @@ OPERATOR_IMG_DEBUG ?= controller:debug
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= crd:maxDescLen=0
 
-VERSION := $(shell git describe --abbrev=0 --tags)
-
 E2E_TEST_TIMEOUT ?= 20m
 TEST_COV_DIR := $(shell mkdir -p build/_test_coverage && realpath build/_test_coverage)
 

--- a/e2e/common/kind/commands.go
+++ b/e2e/common/kind/commands.go
@@ -139,8 +139,12 @@ func LoadDockerImage(images []string, options LoadDockerImageOptions) error {
 	args := []string{"load", "docker-image"}
 	args = options.AppendToArgs(args)
 	args = append(args, images...)
-	_, err := exec.Command(KindPath, args...).Output()
-	return err
+	output, err := exec.Command(KindPath, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kind load failed: %w\nOutput: %s", err, string(output))
+	}
+
+	return nil
 }
 
 type LoadDockerImageOptions struct {


### PR DESCRIPTION
The e2e tests in the pipeline were failing due to the following error:

```sh
        Output: Image: "fluentd-full:local" with ID "sha256:be9da3947b19a27052908c44a187be6cadcae109007bc3741e98e491d76a38cb" not yet present on node "fluentbit-hotreload-control-plane", loading...
        ERROR: failed to load image: command "docker exec --privileged -i fluentbit-hotreload-control-plane ctr --namespace=k8s.io images import --all-platforms --digests --snapshotter=overlayfs -" failed with error: exit status 1
        
        Command Output: unpacking docker.io/library/fluentd-full:local (sha256:35c46a45dd6da8e7ed1f7ffeff10670f17c6958ffb64145d581c39414f6ec8a1)...time="2025-10-01T13:48:41Z" level=info msg="apply failure, attempting cleanup" error="failed to extract layer sha256:57892029ff7cdba00a5574383a125683542a563b89ad69ffd082f5cb85a6e57b: mkdir /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/148/fs/usr/local/bundle/gems/aws-partitions-1.1150.0: no space left on device: unknown" key="extract-953956633-GeXl sha256:e2ecf418b4514d050a225be353b89809832c6b118437c8c3b49e2dd57027bf15"
```

So I've added the `jlumbroso/free-disk-space@main` step to get some free disk-space.