### PR TITLE
fix: healthy.sh using touch invalidly

### DIFF
--- a/images/fluentd/healthy.sh
+++ b/images/fluentd/healthy.sh
@@ -9,15 +9,13 @@
 # liveness probe off completely.
 # soiurce https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml#L58
 
-BUFFER_PATH=${BUFFER_PATH};
+BUFFER_PATH=${BUFFER_PATH:-/buffers};
 LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
 
-if [ ! -e ${BUFFER_PATH} ];
-then
+if [ ! -e "${BUFFER_PATH}" ]; then
   exit 1;
 fi;
-touch -d "@$(($(date +%s) - $LIVENESS_THRESHOLD_SECONDS))" /tmp/marker-liveness;
-if [ -z "$(find ${BUFFER_PATH} -type d -newer /tmp/marker-liveness -print -quit)" ];
-then
+MINUTES=$(( (LIVENESS_THRESHOLD_SECONDS + 59) / 60 ));
+if [ -z "$(find "${BUFFER_PATH}" -type d -mmin -"${MINUTES}" -print -quit)" ]; then
   exit 1;
 fi;


### PR DESCRIPTION
Fixes: https://github.com/kube-logging/logging-operator/issues/2161

Alpine Linux's BusyBox date command doesn't support relative date formats like "X seconds ago" [GitLab](https://gitlab.alpinelinux.org/alpine/aports/-/issues/551), switched to using find instead.
docs PR: https://github.com/kube-logging/kube-logging.github.io/pull/306