### PR TITLE
fix: drain-watch left hanging waiting for custom-runner

### DIFF
--- a/images/fluentd-drain-watch/README.md
+++ b/images/fluentd-drain-watch/README.md
@@ -5,7 +5,8 @@ Fluentd Drain Watch is a monitoring script that ensures proper shutdown of Fluen
 ## Features
 
 - Waits for Fluentd's RPC endpoint to be available before proceeding.
-- Monitors a custom-runner HTTP endpoint.
+- Monitors a custom-runner HTTP endpoint (if available).
+- Handles cases where custom-runner is not deployed (e.g., when buffer metrics sidecar is disabled).
 - Ensures all buffer files are processed before exiting.
 - Triggers termination of custom workers upon completion.
 
@@ -18,4 +19,9 @@ export BUFFER_PATH=/path/to/buffers
 export CHECK_INTERVAL=60  # Optional, default is 60 seconds
 export RPC_ADDRESS=127.0.0.1:24444  # Optional, default is 127.0.0.1:24444
 export CUSTOM_RUNNER_ADDRESS=127.0.0.1:7357  # Optional, default is 127.0.0.1:7357
+export CUSTOM_RUNNER_TIMEOUT=30  # Optional, default is 30 seconds
 ```
+
+## Custom Runner Timeout
+
+The script waits for the custom-runner HTTP endpoint to become available, with a configurable timeout (default: 30 seconds). If the custom-runner is not available after the timeout, the script assumes it is not deployed (e.g., when buffer volume metrics sidecar is disabled) and continues without it. This prevents the drainer pod from hanging indefinitely when the custom-runner sidecar is not present.

--- a/images/fluentd-drain-watch/drain-watch.sh
+++ b/images/fluentd-drain-watch/drain-watch.sh
@@ -3,6 +3,7 @@
 CHECK_INTERVAL="${CHECK_INTERVAL:-60}"
 RPC_ADDRESS="${RPC_ADDRESS:-127.0.0.1:24444}"
 CUSTOM_RUNNER_ADDRESS="${CUSTOM_RUNNER_ADDRESS:-127.0.0.1:7357}"
+CUSTOM_RUNNER_TIMEOUT="${CUSTOM_RUNNER_TIMEOUT:-30}"
 
 [ -z "$BUFFER_PATH" ] && exit 2
 
@@ -15,14 +16,28 @@ do
   sleep 1
 done
 
-# this loop will not go on indefinitely because the custom-runner's HTTP endpoint should
-# come up eventually and won't terminate without a signal from outside (barring errors)
-echo '['$(date)']' 'waiting for custom-runner HTTP endpoint to become available'
-until curl -so /dev/null ${CUSTOM_RUNNER_ADDRESS}
-do 
-  [ -z "$DEBUG" ] && echo '['$(date)']' 'custom-runner HTTP endpoint not available, waiting'
+# Wait for custom-runner with a timeout since it may not be deployed
+# (it's only present when buffer volume metrics are enabled)
+echo '['$(date)']' 'waiting for custom-runner HTTP endpoint to become available (timeout: '${CUSTOM_RUNNER_TIMEOUT}'s)'
+CUSTOM_RUNNER_AVAILABLE=false
+elapsed=0
+while [ $elapsed -lt $CUSTOM_RUNNER_TIMEOUT ]
+do
+  if curl -so /dev/null ${CUSTOM_RUNNER_ADDRESS}
+  then
+    CUSTOM_RUNNER_AVAILABLE=true
+    echo '['$(date)']' 'custom-runner HTTP endpoint is available'
+    break
+  fi
+  [ -z "$DEBUG" ] && echo '['$(date)']' 'custom-runner HTTP endpoint not available, waiting ('$elapsed's/'${CUSTOM_RUNNER_TIMEOUT}'s)'
   sleep 1
+  elapsed=$((elapsed + 1))
 done
+
+if [ "$CUSTOM_RUNNER_AVAILABLE" = "false" ]
+then
+  echo '['$(date)']' 'custom-runner HTTP endpoint not available after '${CUSTOM_RUNNER_TIMEOUT}' seconds, assuming it is not deployed (buffer metrics sidecar disabled)'
+fi
 
 echo '['$(date)']' 'waiting for fluentd to exit' # i.e. stop listening on the RPC address
 while netstat -tln | grep "$RPC_ADDRESS" >/dev/null
@@ -31,7 +46,10 @@ do
 
   if [ "$(find $BUFFER_PATH -iname '*.buffer' -or -iname '*.buffer.meta' | wc -l)" = 0 ]
   then
-    echo '['$(date)']' 'exiting node exporter custom runner:' "$(curl --silent --show-error http://$CUSTOM_RUNNER_ADDRESS/exit)"
+    if [ "$CUSTOM_RUNNER_AVAILABLE" = "true" ]
+    then
+      echo '['$(date)']' 'exiting node exporter custom runner:' "$(curl --silent --show-error http://$CUSTOM_RUNNER_ADDRESS/exit)"
+    fi
     echo '['$(date)']' 'no buffers left, terminating workers:' "$(curl --silent --show-error http://$RPC_ADDRESS/api/processes.killWorkers)"
     exit 0
   fi


### PR DESCRIPTION
Fixes: https://github.com/kube-logging/logging-operator/issues/2181

Manually tested:

```yaml
# NO bufferVolumeMetrics
apiVersion: logging.banzaicloud.io/v1beta1
kind: Logging
metadata:
  name: test-drain
spec:
  controlNamespace: default
  fluentd:
    scaling:
      replicas: 2
      drain:
        enabled: true
        image:
          repository: ghcr.io/kube-logging/fluentd-drain-watch
          tag: testing
```

```sh
# Scale down to trigger drainer job
kubectl patch logging test-drain --type merge -p '{"spec":{"fluentd":{"scaling":{"replicas":1}}}}'
```


```sh
[Wed Feb 18 10:43:38 UTC 2026] waiting for fluentd RPC endpoint to become available
[Wed Feb 18 10:43:38 UTC 2026] fluentd RPC endpoint not available, waiting
[Wed Feb 18 10:43:39 UTC 2026] waiting for custom-runner HTTP endpoint to become available (timeout: 30s)
[Wed Feb 18 10:43:39 UTC 2026] custom-runner HTTP endpoint not available, waiting (0s/30s)
[Wed Feb 18 10:43:40 UTC 2026] custom-runner HTTP endpoint not available, waiting (1s/30s)
[Wed Feb 18 10:43:41 UTC 2026] custom-runner HTTP endpoint not available, waiting (2s/30s)
[Wed Feb 18 10:43:42 UTC 2026] custom-runner HTTP endpoint not available, waiting (3s/30s)
[Wed Feb 18 10:43:43 UTC 2026] custom-runner HTTP endpoint not available, waiting (4s/30s)
[Wed Feb 18 10:43:44 UTC 2026] custom-runner HTTP endpoint not available, waiting (5s/30s)
[Wed Feb 18 10:43:45 UTC 2026] custom-runner HTTP endpoint not available, waiting (6s/30s)
[Wed Feb 18 10:43:46 UTC 2026] custom-runner HTTP endpoint not available, waiting (7s/30s)
[Wed Feb 18 10:43:47 UTC 2026] custom-runner HTTP endpoint not available, waiting (8s/30s)
[Wed Feb 18 10:43:48 UTC 2026] custom-runner HTTP endpoint not available, waiting (9s/30s)
[Wed Feb 18 10:43:49 UTC 2026] custom-runner HTTP endpoint not available, waiting (10s/30s)
[Wed Feb 18 10:43:50 UTC 2026] custom-runner HTTP endpoint not available, waiting (11s/30s)
[Wed Feb 18 10:43:51 UTC 2026] custom-runner HTTP endpoint not available, waiting (12s/30s)
[Wed Feb 18 10:43:52 UTC 2026] custom-runner HTTP endpoint not available, waiting (13s/30s)
[Wed Feb 18 10:43:53 UTC 2026] custom-runner HTTP endpoint not available, waiting (14s/30s)
[Wed Feb 18 10:43:54 UTC 2026] custom-runner HTTP endpoint not available, waiting (15s/30s)
[Wed Feb 18 10:43:55 UTC 2026] custom-runner HTTP endpoint not available, waiting (16s/30s)
[Wed Feb 18 10:43:56 UTC 2026] custom-runner HTTP endpoint not available, waiting (17s/30s)
[Wed Feb 18 10:43:57 UTC 2026] custom-runner HTTP endpoint not available, waiting (18s/30s)
[Wed Feb 18 10:43:58 UTC 2026] custom-runner HTTP endpoint not available, waiting (19s/30s)
[Wed Feb 18 10:43:59 UTC 2026] custom-runner HTTP endpoint not available, waiting (20s/30s)
[Wed Feb 18 10:44:00 UTC 2026] custom-runner HTTP endpoint not available, waiting (21s/30s)
[Wed Feb 18 10:44:01 UTC 2026] custom-runner HTTP endpoint not available, waiting (22s/30s)
[Wed Feb 18 10:44:02 UTC 2026] custom-runner HTTP endpoint not available, waiting (23s/30s)
[Wed Feb 18 10:44:03 UTC 2026] custom-runner HTTP endpoint not available, waiting (24s/30s)
[Wed Feb 18 10:44:04 UTC 2026] custom-runner HTTP endpoint not available, waiting (25s/30s)
[Wed Feb 18 10:44:05 UTC 2026] custom-runner HTTP endpoint not available, waiting (26s/30s)
[Wed Feb 18 10:44:06 UTC 2026] custom-runner HTTP endpoint not available, waiting (27s/30s)
[Wed Feb 18 10:44:07 UTC 2026] custom-runner HTTP endpoint not available, waiting (28s/30s)
[Wed Feb 18 10:44:08 UTC 2026] custom-runner HTTP endpoint not available, waiting (29s/30s)
[Wed Feb 18 10:44:09 UTC 2026] custom-runner HTTP endpoint not available after 30 seconds, assuming it is not deployed (buffer metrics sidecar disabled)
[Wed Feb 18 10:44:09 UTC 2026] waiting for fluentd to exit
[Wed Feb 18 10:44:09 UTC 2026] RPC endpoint still listening
[Wed Feb 18 10:44:09 UTC 2026] no buffers left, terminating workers: {"ok":true}
stream closed: EOF for default/test-drain-fluentd-1-drainer-2rn7j (drain-watch)
```