### PR TITLE
fix: drain-watch should wait for fluentd to terminate

### DIFF
--- a/images/fluentd-drain-watch/README.md
+++ b/images/fluentd-drain-watch/README.md
@@ -20,8 +20,15 @@ export CHECK_INTERVAL=60  # Optional, default is 60 seconds
 export RPC_ADDRESS=127.0.0.1:24444  # Optional, default is 127.0.0.1:24444
 export CUSTOM_RUNNER_ADDRESS=127.0.0.1:7357  # Optional, default is 127.0.0.1:7357
 export CUSTOM_RUNNER_TIMEOUT=30  # Optional, default is 30 seconds
+export KILL_TIMEOUT=300  # Optional, default is 300 seconds
 ```
 
-## Custom Runner Timeout
+## Timeouts
+
+### Custom Runner Timeout
 
 The script waits for the custom-runner HTTP endpoint to become available, with a configurable timeout (default: 30 seconds). If the custom-runner is not available after the timeout, the script assumes it is not deployed (e.g., when buffer volume metrics sidecar is disabled) and continues without it. This prevents the drainer pod from hanging indefinitely when the custom-runner sidecar is not present.
+
+### Kill Timeout
+
+After sending the `killWorkers` signal to Fluentd, the script waits for the RPC endpoint to stop listening, confirming that Fluentd has shut down gracefully. The `KILL_TIMEOUT` (default: 300 seconds) sets the maximum time to wait for this shutdown. If Fluentd doesn't stop within this timeout, the script exits with an error code 1, preventing indefinite waiting in cases where Fluentd fails to terminate properly.


### PR DESCRIPTION
Fixes: https://github.com/kube-logging/logging-operator/issues/2181#issuecomment-3925464373

Manually tested:

```yaml
apiVersion: logging.banzaicloud.io/v1beta1
kind: Logging
metadata:
  name: test-drain
spec:
  controlNamespace: logging
  fluentd:
    bufferVolumeMetrics:
      enabled: true
    scaling:
      replicas: 2
      drain:
        enabled: true
        deleteVolume: true
        image:
          repository: ghcr.io/kube-logging/fluentd-drain-watch
          tag: testing
```

```sh
# Scale down to trigger drainer job
kubectl patch logging test-drain --type merge -p '{"spec":{"fluentd":{"scaling":{"replicas":1}}}}'
```


```sh
[Thu Feb 19 09:10:07 UTC 2026] waiting for fluentd RPC endpoint to become available
[Thu Feb 19 09:10:07 UTC 2026] fluentd RPC endpoint not available, waiting
[Thu Feb 19 09:10:08 UTC 2026] waiting for custom-runner HTTP endpoint to become available (timeout: 30s)
[Thu Feb 19 09:10:08 UTC 2026] custom-runner HTTP endpoint is available
[Thu Feb 19 09:10:08 UTC 2026] waiting for fluentd to exit
[Thu Feb 19 09:10:08 UTC 2026] RPC endpoint still listening
[Thu Feb 19 09:10:08 UTC 2026] exiting node exporter custom runner: {"success":true}
[Thu Feb 19 09:10:08 UTC 2026] no buffers left, terminating workers: {"ok":true}
[Thu Feb 19 09:10:08 UTC 2026] waiting for fluentd to shut down gracefully
[Thu Feb 19 09:10:18 UTC 2026] fluentd has stopped listening on RPC endpoint
[Thu Feb 19 09:10:18 UTC 2026] checking for remaining buffers
stream closed: EOF for logging/test-drain-fluentd-1-drainer-r82px (drain-watch)
```