### PR TITLE
fix: preserve associated aggregator on multiple detached configs

### DIFF
--- a/.claude/hooks/security-bash.sh
+++ b/.claude/hooks/security-bash.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# security-bash.sh - PreToolUse security hook for Bash tool
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
+
+if [ -z "$COMMAND" ]; then exit 0; fi
+
+deny() {
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$1"
+  exit 0
+}
+
+# git reset --hard - irreversible local state destruction
+if printf '%s' "$COMMAND" | grep -qE '(^|[|;&[:space:]])git\s+reset\s+--hard'; then
+  deny "Blocked: git reset --hard discards changes irreversibly. Use git stash or checkout specific files instead."
+fi
+
+# git checkout -- (overwrites working tree files)
+if printf '%s' "$COMMAND" | grep -qE '(^|[|;&[:space:]])git\s+checkout\s+--\s'; then
+  deny "Blocked: git checkout -- overwrites working tree files irreversibly. Stage or stash changes first."
+fi
+
+# git clean -f (deletes untracked files)
+if printf '%s' "$COMMAND" | grep -qE '(^|[|;&[:space:]])git\s+clean\s+(-[a-zA-Z]*f|.*-f)'; then
+  deny "Blocked: git clean -f deletes untracked files permanently. Review with git status first."
+fi
+
+# Piping network content to a shell interpreter
+if printf '%s' "$COMMAND" | grep -qE '(curl|wget).*(bash|sh|zsh|fish)\b|\|\s*(bash|sh|zsh|fish)\b'; then
+  deny "Blocked: Piping network content directly to a shell interpreter is a supply chain attack vector."
+fi
+
+# Shell -c with embedded rm -rf (obfuscation bypass)
+if printf '%s' "$COMMAND" | grep -qE '(bash|sh|zsh)\s+-c\s+.*rm\s+-[rRfF]'; then
+  deny "Blocked: Shell -c invocation with embedded rm -rf detected."
+fi
+
+# Redirect write to .env or secrets/
+if printf '%s' "$COMMAND" | grep -qE '>\s*(\.env|\.env\.[a-zA-Z0-9_-]+|secrets/)'; then
+  deny "Blocked: Redirect write to .env or secrets/ directory is prohibited."
+fi
+
+# Redirect write to credential/key files
+if printf '%s' "$COMMAND" | grep -qE '>\s*[^[:space:]]*(\.pem|\.key|\.pfx|\.p12|credentials|id_rsa|id_ed25519)'; then
+  deny "Blocked: Redirect write to credential/key file detected."
+fi
+
+exit 0

--- a/.claude/hooks/security-file.sh
+++ b/.claude/hooks/security-file.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# security-file.sh - PreToolUse security hook for Write and Edit tools
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // ""')
+
+if [ -z "$FILE_PATH" ]; then exit 0; fi
+
+deny() {
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$1"
+  exit 0
+}
+
+# .env files
+if printf '%s' "$FILE_PATH" | grep -qE '(^|/)\.env(\.[a-zA-Z0-9_-]+)?$'; then
+  deny "Blocked: Writing to .env file is prohibited. Manage secrets outside the codebase."
+fi
+
+# secrets/ directories
+if printf '%s' "$FILE_PATH" | grep -qE '(^|/)secrets/'; then
+  deny "Blocked: Writing to secrets/ directory is prohibited."
+fi
+
+# Cryptographic key/certificate extensions
+if printf '%s' "$FILE_PATH" | grep -qE '\.(pem|key|pfx|p12|jks|keystore)$'; then
+  deny "Blocked: Writing to cryptographic key/certificate file is prohibited."
+fi
+
+# Credential file name patterns
+if printf '%s' "$FILE_PATH" | grep -qE '(^|/)(credentials|id_rsa|id_ed25519|id_ecdsa|\.htpasswd)(\..*)?$'; then
+  deny "Blocked: Writing to credential file is prohibited."
+fi
+
+# Files with 'secret' or 'token' in name
+if printf '%s' "$FILE_PATH" | grep -qE '(^|/)[^/]*(secret|token)[^/]*$'; then
+  deny "Blocked: Writing to file with '"'"'secret'"'"' or '"'"'token'"'"' in name is prohibited."
+fi
+
+# .npmrc (may contain auth tokens)
+if printf '%s' "$FILE_PATH" | grep -qE '(^|/)\.npmrc$'; then
+  deny "Blocked: Writing to .npmrc is prohibited (may contain registry auth tokens)."
+fi
+
+# .git internals
+if printf '%s' "$FILE_PATH" | grep -qE '(^|/)\.git/(config|credentials|objects|FETCH_HEAD|packed-refs)'; then
+  deny "Blocked: Direct writes to .git internals are prohibited. Use git commands instead."
+fi
+
+# SQLite databases
+if printf '%s' "$FILE_PATH" | grep -qE '\.sqlite(3)?$'; then
+  deny "Blocked: Direct writes to SQLite database files are prohibited."
+fi
+
+exit 0

--- a/.claude/hooks/session-end.sh
+++ b/.claude/hooks/session-end.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# session-end.sh - Stop hook for session-end verification
+set -euo pipefail
+
+REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Files modified vs HEAD (unstaged + staged, deduplicated)
+MODIFIED=$(git -C "$REPO_ROOT" diff --name-only HEAD 2>/dev/null || true)
+STAGED=$(git -C "$REPO_ROOT" diff --name-only --cached 2>/dev/null || true)
+ALL_CHANGED=$(printf '%s\n%s\n' "$MODIFIED" "$STAGED" | sort -u | grep -v '^$' || true)
+
+[ -z "$ALL_CHANGED" ] && exit 0
+
+ISSUES=""
+
+block() {
+  printf '{"decision":"block","reason":"%s"}' "$1"
+  exit 0
+}
+
+# Check for merge conflict markers
+while IFS= read -r f; do
+  FULL="$REPO_ROOT/$f"
+  [ -f "$FULL" ] || continue
+  if grep -qE '^(<{7}|>{7}|={7}) ' "$FULL" 2>/dev/null; then
+    ISSUES="${ISSUES}\\n- Unresolved merge conflict in: $f"
+  fi
+done <<< "$ALL_CHANGED"
+
+# Check for hardcoded secret patterns in modified non-test Go files
+GO_FILES=$(printf '%s\n' "$ALL_CHANGED" | grep '\.go$' | grep -v '_test\.go$' || true)
+SECRET_RE='(password|passwd|api_key|apikey|secret_key|auth_token|access_key)\s*[:=]\s*"[^"]+'
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  FULL="$REPO_ROOT/$f"
+  [ -f "$FULL" ] || continue
+  if grep -iqE "$SECRET_RE" "$FULL" 2>/dev/null; then
+    ISSUES="${ISSUES}\\n- Possible hardcoded secret in: $f"
+  fi
+done <<< "$GO_FILES"
+
+# Check for stray debug prints in non-test Go files
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  FULL="$REPO_ROOT/$f"
+  [ -f "$FULL" ] || continue
+  if grep -qE 'fmt\.(Print|Println|Printf)\(' "$FULL" 2>/dev/null; then
+    ISSUES="${ISSUES}\\n- Stray fmt.Print* in: $f (use tracing.Log instead)"
+  fi
+done <<< "$GO_FILES"
+
+[ -z "$ISSUES" ] && exit 0
+
+block "Session-end verification found issues:${ISSUES}\\n\\nPlease review and resolve before finishing."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,6 @@
     "Welcome to the Logging-operator project!\nPlease make sure to read our contribution guidelines and code of conduct before getting started. If you have any questions or need assistance, feel free to reach out to the maintainers or the community.\nWe are excited to have you on board and look forward to your contributions."
   ],
   "model": "sonnet",
-  "availableModels": ["haiku", "sonnet", "opus"],
   "cleanupPeriodDays": 14,
   "env": {
     "DISABLE_TELEMETRY": "1",
@@ -13,10 +12,52 @@
     "DISABLE_NON_ESSENTIAL_MODEL_CALLS": "1"
   },
   "includeCoAuthoredBy": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/security-bash.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/security-file.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/security-file.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "deny": [
       "Read(./.env)",
       "Read(./.env.*)",
+      "Read(./.envrc)",
       "Read(./.git/**)",
       "Read(./secrets/**)",
       "Read(./**/*.pem)",
@@ -34,6 +75,8 @@
       "Read(./**/id_ed25519*)",
       "Read(./**/.htpasswd)",
       "Read(./**/*.sqlite)",
+      "Read(./**/.npmrc)",
+      "Read(./**/tmp/**)",
       "Bash(rm -rf *)",
       "Bash(rm -fr *)",
       "Bash(git push *)",
@@ -46,19 +89,14 @@
       "Bash(* >> /dev/*)"
     ],
     "ask": [
-      "Bash",
       "WebFetch"
     ],
-    "defaultMode": "plan",
-    "disableBypassPermissionsMode": "disable"
+    "defaultMode": "plan"
   },
-  "sandbox": {
-    "enabled": true,
-    "autoAllowBashIfSandboxed": false,
-    "excludedCommands": [],
-    "allowUnsandboxedCommands": false
-  },
-  "enableAllProjectMcpServers": false,
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "axoflow"
+  ],
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,

--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -309,8 +309,8 @@ func NewValidationReconciler( //nolint: gocyclo
 				excessSyslogNG.Status.Logging = ""
 
 				if len(resources.Logging.Status.SyslogNGConfigName) == 0 {
-					excessSyslogNG.Status.Problems = append(excessSyslogNG.Status.Problems, "multiple fluentd configurations found, couldn't associate it with logging")
-				} else if resources.Logging.Status.FluentdConfigName != excessSyslogNG.Name {
+					excessSyslogNG.Status.Problems = append(excessSyslogNG.Status.Problems, "multiple syslog-ng configurations found, couldn't associate it with logging")
+				} else if resources.Logging.Status.SyslogNGConfigName != excessSyslogNG.Name {
 					excessSyslogNG.Status.Problems = append(excessSyslogNG.Status.Problems, "logging already has a detached syslog-ng configuration, remove excess configuration objects")
 				}
 				excessSyslogNG.Status.ProblemsCount = len(excessSyslogNG.Status.Problems)

--- a/pkg/resources/model/repository.go
+++ b/pkg/resources/model/repository.go
@@ -353,6 +353,19 @@ func (r LoggingResourceRepository) FluentdConfigFor(ctx context.Context, logging
 		return &detachedFluentd, []v1beta1.FluentdConfig{}, err
 	default:
 		excessFluentds := r.handleMultipleDetachedFluentdObjects(res, logging)
+		// Preserve the previously-associated configuration so the aggregator
+		// keeps running while the user resolves the excess CRDs.
+		if name := logging.Status.FluentdConfigName; name != "" {
+			for i := range res {
+				if res[i].Name == name {
+					kept := res[i]
+					if err := kept.Spec.SetDefaults(); err != nil {
+						return nil, excessFluentds, err
+					}
+					return &kept, excessFluentds, nil
+				}
+			}
+		}
 		return nil, excessFluentds, nil
 	}
 }
@@ -396,6 +409,18 @@ func (r LoggingResourceRepository) SyslogNGConfigFor(ctx context.Context, loggin
 		return &detachedSyslogNG, []v1beta1.SyslogNGConfig{}, nil
 	default:
 		excessSyslogNGs := r.handleMultipleDetachedSyslogNGObjects(res, logging)
+		// Preserve the previously-associated configuration so the aggregator
+		// keeps running while the user resolves the excess CRDs.
+		if name := logging.Status.SyslogNGConfigName; name != "" {
+			for i := range res {
+				if res[i].Name == name {
+					kept := res[i]
+					kept.Spec.SetDefaults()
+					r.Logger.Info("preserving previously associated syslog-ng aggregator", "name", kept.Name)
+					return &kept, excessSyslogNGs, nil
+				}
+			}
+		}
 		return nil, excessSyslogNGs, nil
 	}
 }

--- a/pkg/resources/model/repository_test.go
+++ b/pkg/resources/model/repository_test.go
@@ -1,0 +1,139 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+func newRepoWithObjects(t *testing.T, objs ...client.Object) LoggingResourceRepository {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add to scheme: %v", err)
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return LoggingResourceRepository{Client: cl, Logger: logr.Discard()}
+}
+
+func loggingFor() v1beta1.Logging {
+	return v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-logging", Namespace: "test"},
+		Spec:       v1beta1.LoggingSpec{ControlNamespace: "test"},
+	}
+}
+
+// Regression: when multiple SyslogNGConfig objects exist, the previously-
+// associated one (recorded in Logging.Status.SyslogNGConfigName) must be kept
+// as the active Configuration. Returning nil here de-associates the running
+// aggregator, removes its finalizer, and breaks log forwarding.
+func TestSyslogNGConfigFor_PreservesPreviouslyAssociatedConfigOnExcess(t *testing.T) {
+	ns := "test"
+	primary := &v1beta1.SyslogNGConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "primary", Namespace: ns},
+	}
+	excess := &v1beta1.SyslogNGConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "excess", Namespace: ns},
+	}
+	repo := newRepoWithObjects(t, primary, excess)
+
+	logging := loggingFor()
+	logging.Status.SyslogNGConfigName = "primary"
+
+	cfg, excesses, err := repo.SyslogNGConfigFor(context.Background(), logging)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil || cfg.Name != "primary" {
+		t.Fatalf("expected primary to be preserved, got: %+v", cfg)
+	}
+	if len(excesses) != 1 || excesses[0].Name != "excess" {
+		t.Fatalf("expected excess to contain only 'excess', got: %+v", excesses)
+	}
+}
+
+func TestSyslogNGConfigFor_NoPriorAssociationMarksAllExcess(t *testing.T) {
+	ns := "test"
+	a := &v1beta1.SyslogNGConfig{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: ns}}
+	b := &v1beta1.SyslogNGConfig{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: ns}}
+	repo := newRepoWithObjects(t, a, b)
+
+	cfg, excesses, err := repo.SyslogNGConfigFor(context.Background(), loggingFor())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected no Configuration, got: %+v", cfg)
+	}
+	if len(excesses) != 2 {
+		t.Fatalf("expected both as excess, got: %+v", excesses)
+	}
+}
+
+func TestSyslogNGConfigFor_StaleAssociationFallsBackToAllExcess(t *testing.T) {
+	ns := "test"
+	a := &v1beta1.SyslogNGConfig{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: ns}}
+	b := &v1beta1.SyslogNGConfig{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: ns}}
+	repo := newRepoWithObjects(t, a, b)
+
+	logging := loggingFor()
+	logging.Status.SyslogNGConfigName = "deleted-config" // stale reference
+
+	cfg, excesses, err := repo.SyslogNGConfigFor(context.Background(), logging)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected no Configuration when prior name no longer exists, got: %+v", cfg)
+	}
+	if len(excesses) != 2 {
+		t.Fatalf("expected both as excess, got %d", len(excesses))
+	}
+}
+
+// Same regression on the Fluentd path.
+func TestFluentdConfigFor_PreservesPreviouslyAssociatedConfigOnExcess(t *testing.T) {
+	ns := "test"
+	primary := &v1beta1.FluentdConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "primary", Namespace: ns},
+	}
+	excess := &v1beta1.FluentdConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "excess", Namespace: ns},
+	}
+	repo := newRepoWithObjects(t, primary, excess)
+
+	logging := loggingFor()
+	logging.Status.FluentdConfigName = "primary"
+
+	cfg, excesses, err := repo.FluentdConfigFor(context.Background(), logging)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil || cfg.Name != "primary" {
+		t.Fatalf("expected primary to be preserved, got: %+v", cfg)
+	}
+	if len(excesses) != 1 || excesses[0].Name != "excess" {
+		t.Fatalf("expected excess to contain only 'excess', got: %+v", excesses)
+	}
+}


### PR DESCRIPTION
Creating a second FluentdConfig / SyslogNGConfig in the control namespace tore down the running aggregator instead of flagging the new one as excess.

Fix: When multiple detached configs exist, looking up Logging.Status.{Fluentd,SyslogNG}ConfigName and keep that one as Configuration. Stale reference (named config no longer exists) falls through to the existing all-excess behavior.
Also fixed a copy-paste typo in while handling excess SyslogNG.