### PR TITLE
feat: support eventrouter 1.0.0 for EventTailer

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -101,7 +101,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | logging.eventTailer.enabled | bool | `false` | Enable EventTailer |
 | logging.eventTailer.name | string | `"event-tailer"` | Name of the EventTailer resource |
 | logging.eventTailer.image.repository | string | `"ghcr.io/kube-logging/eventrouter"` | Repository of the EventTailer image |
-| logging.eventTailer.image.tag | string | `"0.5.0"` | Tag of the EventTailer image |
+| logging.eventTailer.image.tag | string | `"1.0.0"` | Tag of the EventTailer image |
 | logging.eventTailer.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the EventTailer image |
 | logging.eventTailer.image.imagePullSecrets | list | `[]` | Image pull secrets for the EventTailer image |
 | logging.eventTailer.pvc.enabled | bool | `true` | Enable PVC for position storage |

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -255,7 +255,7 @@ logging:
       # -- Repository of the EventTailer image
       repository: ghcr.io/kube-logging/eventrouter
       # -- Tag of the EventTailer image
-      tag: "0.5.0"
+      tag: "1.0.0"
       # -- Image pull policy for the EventTailer image
       pullPolicy: IfNotPresent
       # -- Image pull secrets for the EventTailer image

--- a/pkg/resources/eventtailer/configmap.go
+++ b/pkg/resources/eventtailer/configmap.go
@@ -25,6 +25,8 @@ import (
 	config "github.com/kube-logging/logging-operator/pkg/sdk/extensions/extensionsconfig"
 )
 
+const eventTailerSink = "stdout"
+
 // Config for configmap json serialization
 type Config struct {
 	Sink                            string `json:"sink"`
@@ -37,23 +39,30 @@ func (e *EventTailer) positionFile() string {
 
 func (e *EventTailer) makeJSONString() (string, error) {
 	c := Config{
-		Sink:                            "stdout",
+		Sink:                            eventTailerSink,
 		LastResourceVersionPositionPath: e.positionFile(),
 	}
 
 	config, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("marshal eventrouter config: %w", err)
+	}
 
-	return string(config), err
+	return string(config), nil
 }
 
-// ConfigMap resource for reconciler
+// ConfigMap resource for reconciler. Eventrouter >= 1.0.0 is configured via environment variables, so the legacy JSON ConfigMap is reconciled away.
 func (e *EventTailer) ConfigMap() (runtime.Object, reconciler.DesiredState, error) {
-	conf, err := e.makeJSONString()
 	configMap := corev1.ConfigMap{
 		ObjectMeta: e.objectMeta(),
-		Data: map[string]string{
-			config.EventTailer.ConfigurationFileName: conf,
-		},
+	}
+	if e.usesEnvConfig() {
+		return &configMap, reconciler.StateAbsent, nil
+	}
+
+	conf, err := e.makeJSONString()
+	configMap.Data = map[string]string{
+		config.EventTailer.ConfigurationFileName: conf,
 	}
 	return &configMap, reconciler.StatePresent, err
 }

--- a/pkg/resources/eventtailer/helpers.go
+++ b/pkg/resources/eventtailer/helpers.go
@@ -29,6 +29,22 @@ func (e *EventTailer) Name() string {
 	return fmt.Sprintf("%v-%v", e.customResource.Name, config.EventTailer.TailerAffix)
 }
 
+func (e *EventTailer) image() string {
+	if e.customResource.Spec.Image != nil {
+		if repositoryWithTag := e.customResource.Spec.Image.RepositoryWithTag(); repositoryWithTag != "" {
+			return repositoryWithTag
+		}
+	}
+	if e.customResource.Spec.ContainerBase != nil && e.customResource.Spec.ContainerBase.Image != "" {
+		return e.customResource.Spec.ContainerBase.Image
+	}
+	return config.EventTailer.ImageWithTag
+}
+
+func (e *EventTailer) usesEnvConfig() bool {
+	return config.EventTailer.UsesEnvConfig(e.image())
+}
+
 func (e *EventTailer) objectMeta() metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{
 		Name:            e.Name(),

--- a/pkg/resources/eventtailer/statefulset.go
+++ b/pkg/resources/eventtailer/statefulset.go
@@ -66,6 +66,46 @@ func (e *EventTailer) statefulSetSpec() *appsv1.StatefulSetSpec {
 		imagePullSecrets = e.customResource.Spec.Image.ImagePullSecrets
 	}
 
+	container := corev1.Container{
+		Name:            config.EventTailer.TailerAffix,
+		Image:           config.EventTailer.ImageWithTag,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "monitor",
+				ContainerPort: 8080,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+	}
+
+	var volumes []corev1.Volume
+	if e.usesEnvConfig() {
+		container.Env = []corev1.EnvVar{
+			{Name: "EVENTROUTER_SINK", Value: eventTailerSink},
+			{Name: "EVENTROUTER_BOOKMARK_PATH", Value: e.positionFile()},
+			{Name: "EVENTROUTER_LOG_FORMAT", Value: "json"},
+		}
+	} else {
+		container.VolumeMounts = []corev1.VolumeMount{
+			{
+				Name:      "config-volume",
+				ReadOnly:  true,
+				MountPath: "/etc/eventrouter",
+			},
+		}
+		volumes = append(volumes, corev1.Volume{
+			Name: "config-volume",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: e.Name(),
+					},
+				},
+			},
+		})
+	}
+
 	spec := appsv1.StatefulSetSpec{
 		Replicas: new(int32(1)),
 		Selector: &metav1.LabelSelector{
@@ -78,25 +118,7 @@ func (e *EventTailer) statefulSetSpec() *appsv1.StatefulSetSpec {
 			Spec: e.customResource.Spec.WorkloadBase.Override(
 				corev1.PodSpec{
 					Containers: []corev1.Container{
-						e.customResource.Spec.ContainerBase.Override(corev1.Container{
-							Name:            config.EventTailer.TailerAffix,
-							Image:           config.EventTailer.ImageWithTag,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          "monitor",
-									ContainerPort: 8080,
-									Protocol:      corev1.ProtocolTCP,
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "config-volume",
-									ReadOnly:  true,
-									MountPath: "/etc/eventrouter",
-								},
-							},
-						}),
+						e.customResource.Spec.ContainerBase.Override(container),
 					},
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup:      new(int64(2000)),
@@ -104,19 +126,8 @@ func (e *EventTailer) statefulSetSpec() *appsv1.StatefulSetSpec {
 						RunAsUser:    new(int64(1000)),
 					},
 					ServiceAccountName: e.Name(),
-					Volumes: []corev1.Volume{
-						{
-							Name: "config-volume",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: e.Name(),
-									},
-								},
-							},
-						},
-					},
-					ImagePullSecrets: imagePullSecrets,
+					Volumes:            volumes,
+					ImagePullSecrets:   imagePullSecrets,
 				}),
 		},
 	}

--- a/pkg/sdk/extensions/extensionsconfig/config.go
+++ b/pkg/sdk/extensions/extensionsconfig/config.go
@@ -77,10 +77,27 @@ var HostTailer = HostTailerConfig{
 
 // EventTailer configuration
 var EventTailer = EventTailerConfig{
-	ImageWithTag:          "ghcr.io/kube-logging/eventrouter:0.5.0",
+	ImageWithTag:          "ghcr.io/kube-logging/eventrouter:1.0.0",
 	TailerAffix:           "event-tailer",
 	ConfigurationFileName: "config.json",
 	PositionVolumeName:    "event-tailer-position",
+}
+
+// EventTailerEnvConfigVersion is the eventrouter release that replaced the JSON config file with environment-variable configuration.
+const EventTailerEnvConfigVersion = "1.0.0"
+
+// UsesEnvConfig reports whether the image is configured via env vars (>= 1.0.0); non-semver tags (e.g. "latest", a bare digest) are treated as modern.
+func (t EventTailerConfig) UsesEnvConfig(image string) bool {
+	ref := image
+	if i := strings.Index(ref, "@"); i != -1 {
+		ref = ref[:i]
+	}
+	tag := ref[strings.LastIndex(ref, ":")+1:]
+	v, err := semver.NewVersion(tag)
+	if err != nil {
+		return true
+	}
+	return !v.LessThan(semver.MustParse(EventTailerEnvConfigVersion))
 }
 
 // TailerWebhook configuration

--- a/pkg/sdk/extensions/extensionsconfig/config_test.go
+++ b/pkg/sdk/extensions/extensionsconfig/config_test.go
@@ -104,3 +104,30 @@ func TestFluentBitConfigFilePath(t *testing.T) {
 		})
 	}
 }
+
+func TestEventTailerUsesEnvConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		want  bool
+	}{
+		{name: "default", image: EventTailer.ImageWithTag, want: true},
+		{name: "breakingVersion", image: "ghcr.io/kube-logging/eventrouter:1.0.0", want: true},
+		{name: "newerVersion", image: "ghcr.io/kube-logging/eventrouter:1.2.0", want: true},
+		{name: "olderVersion", image: "ghcr.io/kube-logging/eventrouter:0.5.0", want: false},
+		{name: "olderPatch", image: "ghcr.io/kube-logging/eventrouter:0.4.0", want: false},
+		{name: "registryWithPort", image: "localhost:5000/eventrouter:0.5.0", want: false},
+		{name: "latestTag", image: "ghcr.io/kube-logging/eventrouter:latest", want: true},
+		{name: "noTag", image: "ghcr.io/kube-logging/eventrouter", want: true},
+		{name: "digestPin", image: "ghcr.io/kube-logging/eventrouter@sha256:abc123", want: true},
+		{name: "legacyTagWithDigest", image: "ghcr.io/kube-logging/eventrouter:0.5.0@sha256:abc123", want: false},
+		{name: "modernTagWithDigest", image: "ghcr.io/kube-logging/eventrouter:1.0.0@sha256:abc123", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EventTailer.UsesEnvConfig(tt.image); got != tt.want {
+				t.Errorf("UsesEnvConfig(%q) = %v, want %v", tt.image, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

eventrouter [1.0.0](https://github.com/kube-logging/eventrouter/releases/tag/1.0.0) removed the JSON config file / ConfigMap entirely in favor of environment-variable configuration. The operator previously configured the EventTailer via a `config.json` ConfigMap mounted at `/etc/eventrouter`, so a plain image bump would have left the pod with no sink and no bookmark path (silently losing event position tracking across restarts).

This makes the operator version-aware:
- Images `>= 1.0.0` (and non-semver tags like `latest` / digests) are configured via `EVENTROUTER_SINK`, `EVENTROUTER_BOOKMARK_PATH`, `EVENTROUTER_LOG_FORMAT`; the legacy ConfigMap is reconciled to absent (cleans up the stale ConfigMap on upgrade).
- Older pinned images keep the legacy `config.json` ConfigMap mounted at `/etc/eventrouter`, so existing `spec.image` overrides keep working.

Default EventTailer image and the Helm chart value are bumped `0.5.0 -> 1.0.0`.

## Upgrade note

eventrouter 1.0.0 renames the Prometheus metric prefix `heptio_eventrouter_* -> eventrouter_*` and drops the `involved_object_name` label. Users scraping these metrics should update their dashboards/alerts. The entrypoint also changed (`/app/eventrouter -> /eventrouter`) and CLI flags were removed, but the operator never set `command` or passed flags, so no change is needed there.

## Changes

- `pkg/sdk/extensions/extensionsconfig`: new `UsesEnvConfig(image)` + `EventTailerEnvConfigVersion`; default image `0.5.0 -> 1.0.0`
- `pkg/resources/eventtailer`: version-aware StatefulSet (env vars vs ConfigMap volume) and conditional ConfigMap (`StateAbsent` when env-configured)
- `charts/logging-operator`: EventTailer image tag `0.5.0 -> 1.0.0`

## Automated tests

- `TestEventTailerUsesEnvConfig` covers version comparison + tag edge cases (registry port, `latest`, no tag, bare digest, tag+digest)
- root + SDK builds, `gofmt` clean
- envtest `controllers/extensions` suite green

## Manually tested

Operator built from this branch, deployed on KIND with `eventTailer.enabled=true`.

eventrouter 1.0.0:
- StatefulSet has `EVENTROUTER_SINK`, `EVENTROUTER_BOOKMARK_PATH=/var/pos/event-tailer`, `EVENTROUTER_LOG_FORMAT=json`, no `/etc/eventrouter` mount
- legacy ConfigMap reconciled away (NotFound)
- pod Running, events emitted as JSON to stdout, test event captured
- bookmark file written to `/var/pos/event-tailer` on the PVC (resourceVersion persisted), confirming position tracking

Downgrade to eventrouter 0.5.0 (patched `spec.image.tag`):
- operator removed env vars, recreated `config.json` ConfigMap mounted read-only at `/etc/eventrouter`
- ConfigMap content `{"sink":"stdout","lastResourceVersionPositionPath":"/var/pos/event-tailer"}`
- pod Running on 0.5.0

Switching the tag flips configuration mode with no manual intervention in both directions.