### PR TITLE
fix: support custom CA certificates for S3 outputs

### DIFF
--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_clusteroutputs.yaml
@@ -6742,6 +6742,10 @@ spec:
                     type: string
                   ssekms_key_id:
                     type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
+                    type: string
                   ssl_verify_peer:
                     type: string
                   storage_class:
@@ -14646,6 +14650,10 @@ spec:
                   sse_customer_key_md5:
                     type: string
                   ssekms_key_id:
+                    type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
                     type: string
                   ssl_verify_peer:
                     type: string

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_outputs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_outputs.yaml
@@ -5956,6 +5956,10 @@ spec:
                     type: string
                   ssekms_key_id:
                     type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
+                    type: string
                   ssl_verify_peer:
                     type: string
                   storage_class:
@@ -13470,6 +13474,10 @@ spec:
                   sse_customer_key_md5:
                     type: string
                   ssekms_key_id:
+                    type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
                     type: string
                   ssl_verify_peer:
                     type: string

--- a/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_clusteroutputs.yaml
@@ -6739,6 +6739,10 @@ spec:
                     type: string
                   ssekms_key_id:
                     type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
+                    type: string
                   ssl_verify_peer:
                     type: string
                   storage_class:
@@ -14643,6 +14647,10 @@ spec:
                   sse_customer_key_md5:
                     type: string
                   ssekms_key_id:
+                    type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
                     type: string
                   ssl_verify_peer:
                     type: string

--- a/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_outputs.yaml
@@ -5953,6 +5953,10 @@ spec:
                     type: string
                   ssekms_key_id:
                     type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
+                    type: string
                   ssl_verify_peer:
                     type: string
                   storage_class:
@@ -13467,6 +13471,10 @@ spec:
                   sse_customer_key_md5:
                     type: string
                   ssekms_key_id:
+                    type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
                     type: string
                   ssl_verify_peer:
                     type: string

--- a/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_clusteroutputs.yaml
@@ -6739,6 +6739,10 @@ spec:
                     type: string
                   ssekms_key_id:
                     type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
+                    type: string
                   ssl_verify_peer:
                     type: string
                   storage_class:
@@ -14643,6 +14647,10 @@ spec:
                   sse_customer_key_md5:
                     type: string
                   ssekms_key_id:
+                    type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
                     type: string
                   ssl_verify_peer:
                     type: string

--- a/config/crd/bases/logging.banzaicloud.io_outputs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_outputs.yaml
@@ -5953,6 +5953,10 @@ spec:
                     type: string
                   ssekms_key_id:
                     type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
+                    type: string
                   ssl_verify_peer:
                     type: string
                   storage_class:
@@ -13467,6 +13471,10 @@ spec:
                   sse_customer_key_md5:
                     type: string
                   ssekms_key_id:
+                    type: string
+                  ssl_ca_bundle:
+                    type: string
+                  ssl_ca_directory:
                     type: string
                   ssl_verify_peer:
                     type: string

--- a/docs/configuration/plugins/outputs/s3.md
+++ b/docs/configuration/plugins/outputs/s3.md
@@ -237,6 +237,16 @@ Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321
 Specifies the AWS KMS key ID to use for object encryption 
 
 
+### ssl_ca_bundle (string, optional) {#output config-ssl_ca_bundle}
+
+Full path to the SSL certificate authority bundle file used to verify peer certificates 
+
+
+### ssl_ca_directory (string, optional) {#output config-ssl_ca_directory}
+
+Full path to the directory containing unbundled SSL certificate authority files 
+
+
 ### ssl_verify_peer (string, optional) {#output config-ssl_verify_peer}
 
 If false, the certificate of endpoint will not be verified 

--- a/pkg/sdk/logging/model/output/s3.go
+++ b/pkg/sdk/logging/model/output/s3.go
@@ -121,6 +121,10 @@ type S3OutputConfig struct {
 	EnableTransferAcceleration string `json:"enable_transfer_acceleration,omitempty"`
 	// If false, the certificate of endpoint will not be verified
 	SslVerifyPeer string `json:"ssl_verify_peer,omitempty"`
+	// Full path to the SSL certificate authority bundle file used to verify peer certificates
+	SslCaBundle string `json:"ssl_ca_bundle,omitempty"`
+	// Full path to the directory containing unbundled SSL certificate authority files
+	SslCaDirectory string `json:"ssl_ca_directory,omitempty"`
 	// URI of proxy environment
 	ProxyUri string `json:"proxy_uri,omitempty"`
 	// Allows grantee to read the object ACL

--- a/pkg/sdk/logging/model/output/s3_test.go
+++ b/pkg/sdk/logging/model/output/s3_test.go
@@ -30,6 +30,8 @@ assume_role_credentials:
   role_arn: arn:aws:iam::123456789012:role/logs
 s3_bucket: logging-amazon-s3
 s3_region: eu-central-1
+ssl_ca_bundle: /etc/ssl/certs/private-ca-bundle.pem
+ssl_ca_directory: /etc/ssl/certs/private-ca
 path: logs/${tag}/%Y/%m/%d/
 compress:
   parquet_compression_codec: snappy
@@ -46,6 +48,8 @@ buffer:
     s3_bucket logging-amazon-s3
     s3_object_key_format %{path}%{time_slice}_%{uuid_hash}_%{index}.%{file_extension}
     s3_region eu-central-1
+    ssl_ca_bundle /etc/ssl/certs/private-ca-bundle.pem
+    ssl_ca_directory /etc/ssl/certs/private-ca
     <buffer tag,time>
       @type file
       path /buffers/test.*.buffer


### PR DESCRIPTION
## Summary

- add `ssl_ca_bundle` and `ssl_ca_directory` to `S3OutputConfig`
- regenerate the Output and ClusterOutput CRDs, Helm CRDs, and S3 plugin documentation
- extend the S3 output test to verify both Fluentd directives are rendered

This enables S3-compatible endpoints that use private certificate authorities while preserving existing behavior when the options are unset.

Closes #2066

## Testing

- `make fmt`
- `cd pkg/sdk && go test ./logging/model/output -run '^TestS3$' -count=1 -v`
- `make generate`
- `make check`
- `make check-diff`

## AI assistance

Codex assisted with researching the upstream plugin options, implementing the scoped change, and running validation. I reviewed and understand the submitted diff.