### PR TITLE
fix: enable dual-stack for Fluent Bit metrics services

### DIFF
--- a/pkg/resources/fluentbit/service.go
+++ b/pkg/resources/fluentbit/service.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kube-logging/logging-operator/pkg/resources/model"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
 func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, error) {
@@ -49,7 +50,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 				TargetPort: intstr.IntOrString{IntVal: model.ConfigReloaderMetricsPort},
 			})
 		}
-		return &corev1.Service{
+		desired := &corev1.Service{
 			ObjectMeta: objectMetadata,
 			Spec: corev1.ServiceSpec{
 				Ports:     ports,
@@ -57,7 +58,13 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 				Type:      corev1.ServiceTypeClusterIP,
 				ClusterIP: corev1.ClusterIPNone,
 			},
-		}, reconciler.StatePresent, nil
+		}
+
+		if r.fluentbitSpec.EnabledIPv6 {
+			v1beta1.EnableIPv6Options(&desired.Spec)
+		}
+
+		return desired, reconciler.StatePresent, nil
 	}
 	return &corev1.Service{
 		ObjectMeta: objectMetadata,
@@ -143,7 +150,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 			port = r.fluentbitSpec.BufferVolumeMetrics.Port
 		}
 
-		return &corev1.Service{
+		desired := &corev1.Service{
 			ObjectMeta: objectMetadata,
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{
@@ -158,7 +165,13 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 				Type:      corev1.ServiceTypeClusterIP,
 				ClusterIP: corev1.ClusterIPNone,
 			},
-		}, reconciler.StatePresent, nil
+		}
+
+		if r.fluentbitSpec.EnabledIPv6 {
+			v1beta1.EnableIPv6Options(&desired.Spec)
+		}
+
+		return desired, reconciler.StatePresent, nil
 	}
 	return &corev1.Service{
 		ObjectMeta: objectMetadata,

--- a/pkg/resources/fluentbit/service_test.go
+++ b/pkg/resources/fluentbit/service_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentbit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+func TestMetricsServicesIPFamilies(t *testing.T) {
+	metricsEnabled := true
+	tests := []struct {
+		name        string
+		enabledIPv6 bool
+	}{
+		{name: "single-stack"},
+		{name: "dual-stack", enabledIPv6: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logging := &v1beta1.Logging{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+			r := &Reconciler{
+				Logging: logging,
+				fluentbitSpec: &v1beta1.FluentbitSpec{
+					EnabledIPv6: test.enabledIPv6,
+					Metrics: &v1beta1.Metrics{
+						Enabled: &metricsEnabled,
+						Port:    2020,
+					},
+					BufferVolumeMetrics: &v1beta1.Metrics{
+						Enabled: &metricsEnabled,
+						Port:    9200,
+					},
+				},
+				nameProvider: NewLegacyFluentbitNameProvider(logging),
+			}
+
+			metricsService, _, err := r.serviceMetrics()
+			require.NoError(t, err)
+			bufferMetricsService, _, err := r.serviceBufferMetrics()
+			require.NoError(t, err)
+
+			assertIPFamilies(t, metricsService, test.enabledIPv6)
+			assertIPFamilies(t, bufferMetricsService, test.enabledIPv6)
+		})
+	}
+}
+
+func assertIPFamilies(t *testing.T, object runtime.Object, enabledIPv6 bool) {
+	t.Helper()
+
+	service, ok := object.(*corev1.Service)
+	require.True(t, ok)
+
+	if !enabledIPv6 {
+		require.Nil(t, service.Spec.IPFamilyPolicy)
+		require.Nil(t, service.Spec.IPFamilies)
+		return
+	}
+
+	require.NotNil(t, service.Spec.IPFamilyPolicy)
+	require.Equal(t, corev1.IPFamilyPolicyPreferDualStack, *service.Spec.IPFamilyPolicy)
+	require.Equal(t, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, service.Spec.IPFamilies)
+}


### PR DESCRIPTION
## Summary

- configure Fluent Bit metrics and buffer metrics Services for dual-stack networking when `enabledIPv6` is enabled
- preserve the existing IP family behavior when `enabledIPv6` is disabled
- add focused unit coverage for both modes

## Testing

- `make check`
- `make check-diff`

Fixes #2238
