### PR TITLE
fix(chart): support HostTailer namespaces

### DIFF
--- a/charts/logging-operator/templates/logging/hosttailers.yaml
+++ b/charts/logging-operator/templates/logging/hosttailers.yaml
@@ -7,7 +7,7 @@ kind: HostTailer
 metadata:
   name: {{ .name }}
   {{- with .namespace }}
-  namespace: {{ . }}
+  namespace: {{ . | quote }}
   {{- end }}
 spec:
   {{- with .fileTailers }}

--- a/charts/logging-operator/templates/logging/hosttailers.yaml
+++ b/charts/logging-operator/templates/logging/hosttailers.yaml
@@ -6,6 +6,9 @@ apiVersion: logging-extensions.banzaicloud.io/v1alpha1
 kind: HostTailer
 metadata:
   name: {{ .name }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
 spec:
   {{- with .fileTailers }}
   fileTailers:

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -285,6 +285,8 @@ logging:
     # -- List of hostTailers configurations
     instances: []
     # - name: hosttailer
+      # -- Namespace of the HostTailer resource
+      # namespace: custom-namespace
       # -- Enable hostTailer
       # enabled: true
       # -- workloadMetaOverrides of HostTailer

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -285,7 +285,7 @@ logging:
     # -- List of hostTailers configurations
     instances: []
     # - name: hosttailer
-      # -- Namespace of the HostTailer resource
+      # -- Namespace of the HostTailer resource. Defaults to the Helm release namespace when omitted.
       # namespace: custom-namespace
       # -- Enable hostTailer
       # enabled: true


### PR DESCRIPTION
## Summary

- allow each `logging.hostTailers.instances` entry to set `metadata.namespace`
- preserve the existing release-namespace behavior when `namespace` is omitted
- document the per-instance value in `values.yaml`

Closes #2215

## Testing

- `helm lint --strict charts/logging-operator`
- rendered the HostTailer template with and without an explicit namespace
- `make check`