### PR TITLE
fix(ipv6): set IPv6 as primary address family when enabledIPv6 is set

### DIFF
--- a/pkg/resources/fluentbit/service_test.go
+++ b/pkg/resources/fluentbit/service_test.go
@@ -79,5 +79,5 @@ func assertIPFamilies(t *testing.T, object runtime.Object, enabledIPv6 bool) {
 
 	require.NotNil(t, service.Spec.IPFamilyPolicy)
 	require.Equal(t, corev1.IPFamilyPolicyPreferDualStack, *service.Spec.IPFamilyPolicy)
-	require.Equal(t, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, service.Spec.IPFamilies)
+	require.Equal(t, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, service.Spec.IPFamilies)
 }

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -201,5 +201,5 @@ type ReadinessDefaultCheck struct {
 func EnableIPv6Options(serviceSpec *corev1.ServiceSpec) {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	serviceSpec.IPFamilyPolicy = &ipFamilyPolicy
-	serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+	serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
 }


### PR DESCRIPTION
 **Problem**

When `enabledIPv6: true` is set, `EnableIPv6Options` configures services with `ipFamilies: [IPv4, IPv6]` (IPv4 primary). Prometheus therefore scrapes the IPv4 ClusterIP. Since Fluentd 1.18 (Ruby 3.4), `bind "[::]"` no longer creates a dual-stack socket but binds to IPv6 only, causing all IPv4 scrape attempts to fail with connection refused and `FluentdNodeDown` alerts to fire.

**Fix**

Swap the `IPFamilies` order to `[IPv6, IPv4]` so the service receives an IPv6 primary ClusterIP. `PreferDualStack` policy is retained for backward compatibility — on IPv4-only clusters the service falls back to single-stack IPv4 automatically.

**Tested on**

Dual-stack Kubernetes cluster running Fluentd 6.7.0-full (Fluentd 1.18 / Ruby 3.4).

Fixes: #2100