### PR TITLE
feat(chart): allow pinning the operator image by digest

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -37,6 +37,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | replicaCount | int | `1` |  |
 | image.repository | string | `"ghcr.io/kube-logging/logging-operator"` | Name of the image repository to pull the container image from. |
 | image.tag | string | `""` | Image tag override for the default value (chart appVersion). |
+| image.digest | string | `""` | Image digest override (format: `sha256:...`). Takes precedence over `image.tag` and the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | env | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -37,7 +37,11 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           args:
           {{- range .Values.extraArgs }}
             - {{ . }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -11,6 +11,9 @@ image:
   # -- Image tag override for the default value (chart appVersion).
   tag: ""
 
+  # -- Image digest override (format: `sha256:...`). Takes precedence over `image.tag` and the chart appVersion.
+  digest: ""
+
   # -- [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Description

In Operator Helm Chart the image tag of the deployment is set to the app version  or can be set to a tag, but never to a sha256 checksum, because the different syntax between `<repo>:<tag>` and `<repo>@<sha256:tag>`.

Let's define an optional new Chart value where the user can a sha tag as image version. Sometimes we want to test pre-versions or user use also sha tag as security feature to get a valid image.