### PR TITLE
fix(syslog-ng): keep default image tags when only the repository is set

### DIFF
--- a/pkg/sdk/logging/api/v1beta1/syslogng_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_types.go
@@ -150,10 +150,13 @@ func (s *SyslogNGSpec) SetDefaults() {
 			}
 		}
 		if s.SyslogNGImage == nil {
-			s.SyslogNGImage = &BasicImageSpec{
-				Repository: defaultSyslogngImageRepository,
-				Tag:        defaultSyslogngImageTag,
-			}
+			s.SyslogNGImage = &BasicImageSpec{}
+		}
+		if s.SyslogNGImage.Repository == "" {
+			s.SyslogNGImage.Repository = defaultSyslogngImageRepository
+		}
+		if s.SyslogNGImage.Tag == "" {
+			s.SyslogNGImage.Tag = defaultSyslogngImageTag
 		}
 		if s.ConfigReloadImage == nil {
 			s.ConfigReloadImage = &BasicImageSpec{}
@@ -169,10 +172,13 @@ func (s *SyslogNGSpec) SetDefaults() {
 			}
 		}
 		if s.MetricsExporterImage == nil {
-			s.MetricsExporterImage = &BasicImageSpec{
-				Repository: defaultPrometheusExporterImageRepository,
-				Tag:        defaultPrometheusExporterImageTag,
-			}
+			s.MetricsExporterImage = &BasicImageSpec{}
+		}
+		if s.MetricsExporterImage.Repository == "" {
+			s.MetricsExporterImage.Repository = defaultPrometheusExporterImageRepository
+		}
+		if s.MetricsExporterImage.Tag == "" {
+			s.MetricsExporterImage.Tag = defaultPrometheusExporterImageTag
 		}
 		if s.BufferVolumeMetricsImage == nil {
 			s.BufferVolumeMetricsImage = &BasicImageSpec{}

--- a/pkg/sdk/logging/api/v1beta1/syslogng_types_test.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_types_test.go
@@ -1,0 +1,144 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every image in SyslogNGSpec has to default its repository and its tag
+// independently, so that overriding only the repository - to point at a
+// registry mirror, for example - keeps the operator's own default tag.
+func TestSyslogNGSpecSetDefaultsImages(t *testing.T) {
+	images := []struct {
+		name        string
+		get         func(*SyslogNGSpec) *BasicImageSpec
+		set         func(*SyslogNGSpec, *BasicImageSpec)
+		defaultRepo string
+		defaultTag  string
+	}{
+		{
+			name:        "syslogNGImage",
+			get:         func(s *SyslogNGSpec) *BasicImageSpec { return s.SyslogNGImage },
+			set:         func(s *SyslogNGSpec, i *BasicImageSpec) { s.SyslogNGImage = i },
+			defaultRepo: defaultSyslogngImageRepository,
+			defaultTag:  defaultSyslogngImageTag,
+		},
+		{
+			name:        "configReloadImage",
+			get:         func(s *SyslogNGSpec) *BasicImageSpec { return s.ConfigReloadImage },
+			set:         func(s *SyslogNGSpec, i *BasicImageSpec) { s.ConfigReloadImage = i },
+			defaultRepo: defaultConfigReloaderImageRepository,
+			defaultTag:  defaultConfigReloaderImageTag,
+		},
+		{
+			name:        "metricsExporterImage",
+			get:         func(s *SyslogNGSpec) *BasicImageSpec { return s.MetricsExporterImage },
+			set:         func(s *SyslogNGSpec, i *BasicImageSpec) { s.MetricsExporterImage = i },
+			defaultRepo: defaultPrometheusExporterImageRepository,
+			defaultTag:  defaultPrometheusExporterImageTag,
+		},
+		{
+			name:        "bufferVolumeMetricsImage",
+			get:         func(s *SyslogNGSpec) *BasicImageSpec { return s.BufferVolumeMetricsImage },
+			set:         func(s *SyslogNGSpec, i *BasicImageSpec) { s.BufferVolumeMetricsImage = i },
+			defaultRepo: defaultBufferVolumeImageRepository,
+			defaultTag:  defaultBufferVolumeImageTag,
+		},
+	}
+
+	// Version is baked in at build time and overrides the fallback tag of the
+	// operator's own images. Pin it so the expectations below stay stable.
+	originalVersion := Version
+	Version = ""
+	t.Cleanup(func() { Version = originalVersion })
+
+	const (
+		customRepo = "registry.internal/mirror/some-image"
+		customTag  = "1.2.3-custom"
+	)
+
+	for _, image := range images {
+		t.Run(image.name, func(t *testing.T) {
+			t.Run("unset defaults both fields", func(t *testing.T) {
+				spec := &SyslogNGSpec{}
+				spec.SetDefaults()
+
+				result := image.get(spec)
+				require.NotNil(t, result)
+				assert.Equal(t, image.defaultRepo, result.Repository)
+				assert.Equal(t, image.defaultTag, result.Tag)
+			})
+
+			t.Run("repository override keeps the default tag", func(t *testing.T) {
+				spec := &SyslogNGSpec{}
+				image.set(spec, &BasicImageSpec{Repository: customRepo})
+				spec.SetDefaults()
+
+				result := image.get(spec)
+				require.NotNil(t, result)
+				assert.Equal(t, customRepo, result.Repository)
+				assert.Equal(t, image.defaultTag, result.Tag)
+				assert.Equal(t, customRepo+":"+image.defaultTag, result.RepositoryWithTag())
+			})
+
+			t.Run("tag override keeps the default repository", func(t *testing.T) {
+				spec := &SyslogNGSpec{}
+				image.set(spec, &BasicImageSpec{Tag: customTag})
+				spec.SetDefaults()
+
+				result := image.get(spec)
+				require.NotNil(t, result)
+				assert.Equal(t, image.defaultRepo, result.Repository)
+				assert.Equal(t, customTag, result.Tag)
+			})
+
+			t.Run("both overrides are preserved", func(t *testing.T) {
+				spec := &SyslogNGSpec{}
+				image.set(spec, &BasicImageSpec{Repository: customRepo, Tag: customTag})
+				spec.SetDefaults()
+
+				result := image.get(spec)
+				require.NotNil(t, result)
+				assert.Equal(t, customRepo, result.Repository)
+				assert.Equal(t, customTag, result.Tag)
+			})
+		})
+	}
+}
+
+// The operator's own images follow the build-time Version when the user does
+// not pin a tag, while the third-party images keep their vendored defaults.
+func TestSyslogNGSpecSetDefaultsImagesFollowVersion(t *testing.T) {
+	originalVersion := Version
+	Version = "9.9.9"
+	t.Cleanup(func() { Version = originalVersion })
+
+	spec := &SyslogNGSpec{
+		ConfigReloadImage:        &BasicImageSpec{Repository: "registry.internal/mirror/reloader"},
+		BufferVolumeMetricsImage: &BasicImageSpec{Repository: "registry.internal/mirror/node-exporter"},
+		SyslogNGImage:            &BasicImageSpec{Repository: "registry.internal/mirror/axosyslog"},
+		MetricsExporterImage:     &BasicImageSpec{Repository: "registry.internal/mirror/metrics-exporter"},
+	}
+	spec.SetDefaults()
+
+	assert.Equal(t, "registry.internal/mirror/reloader:9.9.9", spec.ConfigReloadImage.RepositoryWithTag())
+	assert.Equal(t, "registry.internal/mirror/node-exporter:9.9.9", spec.BufferVolumeMetricsImage.RepositoryWithTag())
+	assert.Equal(t, "registry.internal/mirror/axosyslog:"+defaultSyslogngImageTag, spec.SyslogNGImage.RepositoryWithTag())
+	assert.Equal(t, "registry.internal/mirror/metrics-exporter:"+defaultPrometheusExporterImageTag, spec.MetricsExporterImage.RepositoryWithTag())
+}


### PR DESCRIPTION
## Summary

`SyslogNGSpec.SetDefaults` defaults `syslogNGImage` and `metricsExporterImage` as a whole struct: the defaults are only applied when the field is absent entirely. Setting just `repository`, which is what you do to point at a registry mirror, therefore leaves `tag` empty and the image resolves to `:latest`.

The two images next to them, `configReloadImage` and `bufferVolumeMetricsImage`, already default each field on its own, which is why the reporter saw the two behave differently in the same resource.

Closes #2202

## Changes

`pkg/sdk/logging/api/v1beta1/syslogng_types.go`: default `Repository` and `Tag` independently for `syslogNGImage` and `metricsExporterImage`.

```go
if s.SyslogNGImage == nil {
    s.SyslogNGImage = &BasicImageSpec{}
}
if s.SyslogNGImage.Repository == "" {
    s.SyslogNGImage.Repository = defaultSyslogngImageRepository
}
if s.SyslogNGImage.Tag == "" {
    s.SyslogNGImage.Tag = defaultSyslogngImageTag
}
```

This is the pattern `configReloadImage` and `bufferVolumeMetricsImage` use in the same function, and the one every image spec in `fluentd_types.go` and `logging_types.go` uses. After the change all four images in `SyslogNGSpec` are defaulted the same way, and there are no whole-struct image literals left in the API types.

`pkg/sdk/logging/api/v1beta1/syslogng_types_test.go` (new): table test over all four images, each with four cases - unset, repository only, tag only, both. It is written against the whole set rather than the two broken fields so that a future image added to this spec has to behave consistently too. A second test pins the split between the operator's own images, whose tag follows the build-time `Version`, and the third-party images, which keep their vendored default tags.

## Compatibility

This does change observed behaviour for anyone who sets only `repository` on these two images today and is happy to run whatever `:latest` resolves to in their mirror. After the change they get the operator's default tag instead. That seems like the right trade, since it is what the issue asks for and what the other images already do, and an explicit `tag: latest` still gets the old result. Worth a line in the release notes though.

## Verification

Unit, before the fix - the test reproduces the report exactly, including which fields are unaffected:

```
--- FAIL: TestSyslogNGSpecSetDefaultsImages/syslogNGImage
        expected: "4.25.0"
        actual  : ""
--- PASS: TestSyslogNGSpecSetDefaultsImages/configReloadImage
--- FAIL: TestSyslogNGSpecSetDefaultsImages/metricsExporterImage
        expected: "0.0.15"
        actual  : ""
--- PASS: TestSyslogNGSpecSetDefaultsImages/bufferVolumeMetricsImage
```

Suites, after the fix: `go test ./pkg/...`, `go test ./controllers/...` and the `pkg/sdk` module with envtest assets all pass. `make lint` reports 0 issues in both modules. `make generate` leaves the tree clean, so `check-diff` stays green - the API shape is unchanged, so no CRD or docs regeneration is involved.

End to end on a kind cluster, since the reported path goes through a `SyslogNGConfig` and the controller rather than through `SetDefaults` directly. Same cluster, same manifest, only the operator swapped. The manifest overrides only `repository` on all four images, pointing at the real upstream repositories so the config check passes and the StatefulSet renders:

Released 6.7.0:

```
syslog-ng         ghcr.io/axoflow/axosyslog
config-reloader   ghcr.io/kube-logging/logging-operator/syslog-ng-reloader:6.7.0
exporter          ghcr.io/axoflow/axosyslog-metrics-exporter
```

Built from this branch:

```
syslog-ng         ghcr.io/axoflow/axosyslog:4.25.0
config-reloader   ghcr.io/kube-logging/logging-operator/syslog-ng-reloader:latest
exporter          ghcr.io/axoflow/axosyslog-metrics-exporter:0.0.15
```

One thing to read past in that comparison: `config-reloader` shows `:6.7.0` on the release and `:latest` on my build only because its tag follows the build-time `Version` stamp, which is empty in a plain `docker build`. That image was never part of the bug. The two that change behaviour are `syslog-ng` and `exporter`, which go from untagged to correctly tagged.

With the fictional `registry.internal` repositories from the issue the config check never completes, but the config check pod alone is enough to show the effect, and containerd names the consequence directly:

```
Back-off pulling image "registry.internal/ghcr/axoflow/axosyslog":
failed to pull and unpack image "registry.internal/ghcr/axoflow/axosyslog:latest"
```

`bufferVolumeMetricsImage` does not appear in the rendered StatefulSet in this setup because no buffer volume is configured; it is covered by the unit test, and it was already correct.
