### PR TITLE
fix(fluentd): propagate dnsPolicy to the configcheck pod

### DIFF
--- a/pkg/resources/fluentd/appconfigmap.go
+++ b/pkg/resources/fluentd/appconfigmap.go
@@ -281,6 +281,7 @@ func (r *Reconciler) newCheckPod(hashKey string, fluentdSpec v1beta1.FluentdSpec
 			ImagePullSecrets:   fluentdSpec.Image.ImagePullSecrets,
 			InitContainers:     initContainer,
 			Containers:         container,
+			DNSPolicy:          fluentdSpec.DNSPolicy,
 			DNSConfig:          fluentdSpec.DNSConfig,
 		},
 	}

--- a/pkg/resources/fluentd/appconfigmap_test.go
+++ b/pkg/resources/fluentd/appconfigmap_test.go
@@ -1,0 +1,124 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentd
+
+import (
+	"testing"
+
+	"github.com/cisco-open/operator-tools/pkg/reconciler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+// newCheckPodReconciler builds a Reconciler that is just complete enough for
+// newCheckPod, which only needs the logging resource and the fluentd spec.
+func newCheckPodReconciler(t *testing.T, fluentdSpec *v1beta1.FluentdSpec) *Reconciler {
+	t.Helper()
+
+	logging := &v1beta1.Logging{}
+	logging.Name = "test"
+	logging.Spec.ControlNamespace = "logging"
+	logging.Spec.FluentdSpec = fluentdSpec
+	require.NoError(t, logging.SetDefaults())
+
+	config := "<system>\n</system>\n"
+
+	return New(nil, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{})
+}
+
+func TestNewCheckPodDNSSettings(t *testing.T) {
+	dnsConfig := &corev1.PodDNSConfig{
+		Nameservers: []string{"10.0.0.53"},
+		Searches:    []string{"logging.svc.cluster.local"},
+	}
+
+	tests := []struct {
+		name              string
+		dnsPolicy         corev1.DNSPolicy
+		dnsConfig         *corev1.PodDNSConfig
+		expectedDNSPolicy corev1.DNSPolicy
+	}{
+		{
+			// Left empty the API server applies ClusterFirst, which is what the
+			// configcheck pod did unconditionally before dnsPolicy was propagated.
+			name:              "Unset",
+			expectedDNSPolicy: "",
+		},
+		{
+			// The interesting case: with None the pod resolves *only* through
+			// dnsConfig, so dropping the policy while keeping dnsConfig gives the
+			// configcheck pod a different resolver than the aggregator it checks for.
+			name:              "NoneWithDNSConfig",
+			dnsPolicy:         corev1.DNSNone,
+			dnsConfig:         dnsConfig,
+			expectedDNSPolicy: corev1.DNSNone,
+		},
+		{
+			name:              "ClusterFirstWithHostNet",
+			dnsPolicy:         corev1.DNSClusterFirstWithHostNet,
+			expectedDNSPolicy: corev1.DNSClusterFirstWithHostNet,
+		},
+		{
+			name:              "Default",
+			dnsPolicy:         corev1.DNSDefault,
+			expectedDNSPolicy: corev1.DNSDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &v1beta1.FluentdSpec{
+				DNSPolicy: tt.dnsPolicy,
+				DNSConfig: tt.dnsConfig,
+			}
+			r := newCheckPodReconciler(t, spec)
+
+			pod := r.newCheckPod("deadbeef", *r.fluentdSpec)
+
+			assert.Equal(t, tt.expectedDNSPolicy, pod.Spec.DNSPolicy)
+			assert.Equal(t, tt.dnsConfig, pod.Spec.DNSConfig)
+		})
+	}
+}
+
+// TestNewCheckPodDNSSettingsMatchStatefulSet pins the configcheck pod and the
+// aggregator to the same DNS settings, since a configcheck that resolves names
+// differently from the aggregator can pass or fail for the wrong reason.
+func TestNewCheckPodDNSSettingsMatchStatefulSet(t *testing.T) {
+	ndots := "2"
+	spec := &v1beta1.FluentdSpec{
+		DNSPolicy: corev1.DNSNone,
+		DNSConfig: &corev1.PodDNSConfig{
+			Nameservers: []string{"10.0.0.53"},
+			Options:     []corev1.PodDNSConfigOption{{Name: "ndots", Value: &ndots}},
+		},
+	}
+	r := newCheckPodReconciler(t, spec)
+
+	checkPod := r.newCheckPod("deadbeef", *r.fluentdSpec)
+
+	obj, _, err := r.statefulset()
+	require.NoError(t, err)
+	sts, ok := obj.(*appsv1.StatefulSet)
+	require.True(t, ok)
+
+	assert.Equal(t, sts.Spec.Template.Spec.DNSPolicy, checkPod.Spec.DNSPolicy)
+	assert.Equal(t, sts.Spec.Template.Spec.DNSConfig, checkPod.Spec.DNSConfig)
+}


### PR DESCRIPTION
### Description

`newCheckPod` copies `dnsConfig` from the Fluentd spec into the configcheck pod, but not `dnsPolicy`:

```go
InitContainers:     initContainer,
Containers:         container,
DNSConfig:          fluentdSpec.DNSConfig,   // dnsPolicy is missing
```

The aggregator StatefulSet, a few files over in `statefulset.go`, sets both:

```go
DNSPolicy: r.fluentdSpec.DNSPolicy,
DNSConfig: r.fluentdSpec.DNSConfig,
```

So the configcheck pod always ran with the API server default of `ClusterFirst`, while the aggregator it is meant to validate ran with whatever policy the user configured.

These two fields are not independent. With `dnsPolicy: None` a pod resolves *only* through `dnsConfig`; with `ClusterFirst` the `dnsConfig` is merged on top of cluster DNS. A configcheck pod that resolves names differently from the aggregator can pass or fail for reasons the aggregator will not reproduce, which is the opposite of what the check is for. The same applies to `Default` and `ClusterFirstWithHostNet`.

The fix is one line: copy `dnsPolicy` alongside `dnsConfig`.

Deliberately left alone, to keep this narrow — happy to fold either in if you would rather:

- **`topologySpreadConstraints`** is also not propagated, but that looks intentional. The function already strips `podAntiAffinity` with the comment *"pod anti-affinity has been disabled to avoid blocking configcheck pods accidentally"*, and a `DoNotSchedule` spread constraint would block a configcheck pod in exactly the same way.
- **`terminationGracePeriodSeconds`** is not propagated either, but configcheck pods are `restartPolicy: Never` and short-lived, so it has no practical effect.

### Link to the issue in case of a bug fix.

Refs #2228

That issue reports the configcheck pod missing parts of the configured pod spec. It names `podSecurityContext` specifically, and I should be upfront that **`podSecurityContext` is not the problem on current master** — `newCheckPod` does set `SecurityContext: fluentdSpec.Security.PodSecurityContext`, and I verified it lands on the pod. The report was filed against 6.2.2. `dnsPolicy` is a real instance of the same class of gap, so this PR fixes that one rather than closing the issue. I have left a note there with the details.

### Testing details

1. Manual - verified on a kind cluster (v1.33.1), A/B against the released operator. `Logging` with `spec.fluentd.dnsPolicy: None` plus a custom `dnsConfig`:

   | | aggregator StatefulSet | configcheck pod |
   |---|---|---|
   | released 6.7.0 | `dnsPolicy: None` | `dnsPolicy: ClusterFirst` |
   | this PR | `dnsPolicy: None` | `dnsPolicy: None` |

   `dnsConfig` was identical in all four cases, which is what makes the mismatch matter. The `Logging` resource was deleted and recreated between the two runs so the configcheck result was not served from `status.configCheckResults` — I confirmed the "after" pod had a new UID and a `creationTimestamp` later than the operator rollout. The configcheck still completed (`status.configCheckResults: {"893225a7": true}`) and the aggregator came up, so propagating the policy does not break the check.

2. Unit tests - added `pkg/resources/fluentd/appconfigmap_test.go`. `TestNewCheckPodDNSSettings` covers unset, `None` with a `dnsConfig`, `ClusterFirstWithHostNet` and `Default`; `TestNewCheckPodDNSSettingsMatchStatefulSet` asserts the configcheck pod and the aggregator pod template agree, so the two cannot drift apart again.

   As a negative control I reverted the one-line fix and confirmed the new tests fail with `expected: "None", actual: ""`. The `Unset` case passes either way by design — it is the boundary case that pins the no-change-for-existing-users behaviour.

3. `go test ./pkg/resources/...`, `make lint` (0 issues in both modules) and `make generate` all clean; `make generate` produces no diff beyond the two files in this PR.

### Any backward incompatible change? If so, please explain.

No. `dnsPolicy` is not defaulted anywhere in the API, so an installation that does not set `spec.fluentd.dnsPolicy` leaves the field empty and the API server continues to apply `ClusterFirst` to the configcheck pod exactly as before. Only installations that explicitly set a policy see a change, and for them the new behaviour is the one they asked for.
