### PR TITLE
fix(configcheck): merge aggregator level configCheck field by field

### DIFF
--- a/docs/configuration/crds/v1beta1/fluentd_types.md
+++ b/docs/configuration/crds/v1beta1/fluentd_types.md
@@ -39,7 +39,7 @@ BufferStorageVolume is by default configured as PVC using FluentdPvcSpec [volume
 
 ### configCheck (*ConfigCheck, optional) {#fluentdspec-configcheck}
 
-Overrides the default logging level configCheck setup This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource 
+Overrides the default logging level configCheck setup. This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource. 
 
 
 ### configCheckAnnotations (map[string]string, optional) {#fluentdspec-configcheckannotations}

--- a/docs/configuration/crds/v1beta1/fluentd_types.md
+++ b/docs/configuration/crds/v1beta1/fluentd_types.md
@@ -39,7 +39,7 @@ BufferStorageVolume is by default configured as PVC using FluentdPvcSpec [volume
 
 ### configCheck (*ConfigCheck, optional) {#fluentdspec-configcheck}
 
-Overrides the default logging level configCheck setup This field is not used directly, just copied over the field in the logging resource if defined 
+Overrides the default logging level configCheck setup This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource 
 
 
 ### configCheckAnnotations (map[string]string, optional) {#fluentdspec-configcheckannotations}

--- a/docs/configuration/crds/v1beta1/syslogng_types.md
+++ b/docs/configuration/crds/v1beta1/syslogng_types.md
@@ -25,7 +25,7 @@ SyslogNGSpec defines the desired state of SyslogNG
 
 ### configCheck (*ConfigCheck, optional) {#syslogngspec-configcheck}
 
-Overrides the default logging level configCheck setup. This field is not used directly, just copied over the field in the logging resource if defined. 
+Overrides the default logging level configCheck setup. This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource. 
 
 
 ### configCheckPod (*typeoverride.PodSpec, optional) {#syslogngspec-configcheckpod}

--- a/pkg/sdk/logging/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_types.go
@@ -120,7 +120,7 @@ type FluentdSpec struct {
 	// Configure sidecar container in Fluentd pods, for example: [https://github.com/kube-logging/logging-operator/config/samples/logging_logging_fluentd_sidecars.yaml](https://github.com/kube-logging/logging-operator/config/samples/logging_logging_fluentd_sidecars.yaml).
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
 	// Overrides the default logging level configCheck setup
-	// This field is not used directly, just copied over the field in the logging resource if defined
+	// This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource
 	ConfigCheck *ConfigCheck `json:"configCheck,omitempty"`
 }
 

--- a/pkg/sdk/logging/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_types.go
@@ -119,8 +119,8 @@ type FluentdSpec struct {
 	// Available in Logging operator version 4.5 and later.
 	// Configure sidecar container in Fluentd pods, for example: [https://github.com/kube-logging/logging-operator/config/samples/logging_logging_fluentd_sidecars.yaml](https://github.com/kube-logging/logging-operator/config/samples/logging_logging_fluentd_sidecars.yaml).
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
-	// Overrides the default logging level configCheck setup
-	// This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource
+	// Overrides the default logging level configCheck setup.
+	// This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource.
 	ConfigCheck *ConfigCheck `json:"configCheck,omitempty"`
 }
 

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -256,9 +256,20 @@ func (l *Logging) SetDefaults() error {
 	return nil
 }
 
+// AggregatorLevelConfigCheck lets the aggregator level configCheck override the
+// logging level one. Each field is overridden on its own, so an aggregator that
+// sets a single field does not discard the rest of the logging level settings.
 func (l *Logging) AggregatorLevelConfigCheck(check *ConfigCheck) {
 	if check != nil {
-		l.Spec.ConfigCheck = *check
+		if check.Strategy != "" {
+			l.Spec.ConfigCheck.Strategy = check.Strategy
+		}
+		if check.TimeoutSeconds != 0 {
+			l.Spec.ConfigCheck.TimeoutSeconds = check.TimeoutSeconds
+		}
+		if check.Labels != nil {
+			l.Spec.ConfigCheck.Labels = check.Labels
+		}
 		l.configCheckDefaults()
 	}
 }

--- a/pkg/sdk/logging/api/v1beta1/logging_types_configcheck_test.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types_configcheck_test.go
@@ -1,0 +1,113 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregatorLevelConfigCheck(t *testing.T) {
+	loggingLevel := ConfigCheck{
+		Strategy:       ConfigCheckStrategyTimeout,
+		TimeoutSeconds: 42,
+		Labels:         map[string]string{"from": "logging"},
+	}
+
+	tests := []struct {
+		name       string
+		aggregator *ConfigCheck
+		expected   ConfigCheck
+	}{
+		{
+			// Nothing set on the aggregator, so the logging level settings stand.
+			name:       "NilKeepsLoggingLevel",
+			aggregator: nil,
+			expected:   loggingLevel,
+		},
+		{
+			// An empty struct still means "override nothing".
+			name:       "EmptyKeepsLoggingLevel",
+			aggregator: &ConfigCheck{},
+			expected:   loggingLevel,
+		},
+		{
+			// The regression: overriding only the strategy used to drop the
+			// timeout and the labels set on the logging resource.
+			name:       "StrategyOnlyKeepsTheRest",
+			aggregator: &ConfigCheck{Strategy: ConfigCheckStrategyDryRun},
+			expected: ConfigCheck{
+				Strategy:       ConfigCheckStrategyDryRun,
+				TimeoutSeconds: 42,
+				Labels:         map[string]string{"from": "logging"},
+			},
+		},
+		{
+			name:       "TimeoutOnlyKeepsTheRest",
+			aggregator: &ConfigCheck{TimeoutSeconds: 7},
+			expected: ConfigCheck{
+				Strategy:       ConfigCheckStrategyTimeout,
+				TimeoutSeconds: 7,
+				Labels:         map[string]string{"from": "logging"},
+			},
+		},
+		{
+			name:       "LabelsOnlyKeepsTheRest",
+			aggregator: &ConfigCheck{Labels: map[string]string{"from": "aggregator"}},
+			expected: ConfigCheck{
+				Strategy:       ConfigCheckStrategyTimeout,
+				TimeoutSeconds: 42,
+				Labels:         map[string]string{"from": "aggregator"},
+			},
+		},
+		{
+			name: "AllFieldsOverride",
+			aggregator: &ConfigCheck{
+				Strategy:       ConfigCheckStrategyDryRun,
+				TimeoutSeconds: 7,
+				Labels:         map[string]string{"from": "aggregator"},
+			},
+			expected: ConfigCheck{
+				Strategy:       ConfigCheckStrategyDryRun,
+				TimeoutSeconds: 7,
+				Labels:         map[string]string{"from": "aggregator"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &Logging{}
+			l.Spec.ConfigCheck = *loggingLevel.DeepCopy()
+
+			l.AggregatorLevelConfigCheck(tt.aggregator)
+
+			assert.Equal(t, tt.expected, l.Spec.ConfigCheck)
+		})
+	}
+}
+
+// TestAggregatorLevelConfigCheckDefaultsTimeout keeps the defaulting behavior
+// intact: when neither level sets a timeout it still falls back to 10.
+func TestAggregatorLevelConfigCheckDefaultsTimeout(t *testing.T) {
+	l := &Logging{}
+	l.Spec.ConfigCheck = ConfigCheck{Strategy: ConfigCheckStrategyTimeout}
+
+	l.AggregatorLevelConfigCheck(&ConfigCheck{Strategy: ConfigCheckStrategyDryRun})
+
+	assert.Equal(t, ConfigCheckStrategyDryRun, l.Spec.ConfigCheck.Strategy)
+	assert.Equal(t, 10, l.Spec.ConfigCheck.TimeoutSeconds)
+}

--- a/pkg/sdk/logging/api/v1beta1/syslogng_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_types.go
@@ -80,7 +80,7 @@ type SyslogNGSpec struct {
 	// Create [custom log metrics for sources and outputs]({{< relref "/docs/examples/custom-syslog-ng-metrics.md" >}}).
 	SourceMetrics []filter.MetricsProbe `json:"sourceMetrics,omitempty"`
 	// Overrides the default logging level configCheck setup.
-	// This field is not used directly, just copied over the field in the logging resource if defined.
+	// This field is not used directly, its fields are copied over the ones in the logging resource, field by field, so setting one field here does not discard the others set on the logging resource.
 	ConfigCheck *ConfigCheck `json:"configCheck,omitempty"`
 	// Duration in seconds for graceful pod termination. Set higher than expected cleanup time.
 	// +kubebuilder:validation:Minimum=0


### PR DESCRIPTION
### Description

`AggregatorLevelConfigCheck` replaces the whole `ConfigCheck` struct:

```go
func (l *Logging) AggregatorLevelConfigCheck(check *ConfigCheck) {
	if check != nil {
		l.Spec.ConfigCheck = *check
		l.configCheckDefaults()
	}
}
```

So if a `FluentdConfig` or `SyslogNGConfig` sets *any* `configCheck` field, every field set on the `Logging` resource is silently dropped. With this on the `Logging`:

```yaml
configCheck:
  timeoutSeconds: 42
  labels:
    from: logging-level
fluentd:
  configCheck:
    strategy: StartWithTimeout   # the aggregator only overrides the strategy
```

`labels` is discarded and `timeoutSeconds` falls back to the default of 10. Both are user visible: `ConfigCheck.Labels` feeds `configCheckPodObjectMeta`, so the configcheck pod loses labels that were explicitly asked for, and `StartWithTimeout` runs with a timeout the user did not configure.

This PR overrides each field on its own. That matches what the `LoggingSpec.ConfigCheck` doc comment already promises — *"Can be overridden on the fluentd / syslog-ng level"* — and it is the same shape as the image spec fix in #2283. An aggregator that sets nothing, or sets an empty struct, now leaves the logging level settings alone.

I also updated the doc comments on the two aggregator side `ConfigCheck` fields, which described the old whole-struct copy and would otherwise contradict the code. Those regenerate into `docs/`; the CRDs are unaffected because the project builds them with `crd:maxDescLen=0`.

### Link to the issue in case of a bug fix.

Refs #2228

That issue reports the configcheck pod missing configured settings. I found this while investigating it and [wrote it up there](https://github.com/kube-logging/logging-operator/issues/2228#issuecomment-5091371764), offering a patch — this is that patch. It is independent of #2285, which fixes the `dnsPolicy` gap in the same area, so the two can land in either order. Happy to close this if you would rather keep the current replace semantics.

### Testing details

1. Manual - verified on a kind cluster (v1.33.1), A/B against the released operator, using the `Logging` above:

   | | configcheck pod label `from` | configcheck container args |
   |---|---|---|
   | released 6.7.0 | *(absent)* | `["timeout","10","fluentd",...]` |
   | this PR | `logging-level` | `["timeout","42","fluentd",...]` |

   The `Logging` was deleted and recreated between runs so the result was not served from `status.configCheckResults`, and I confirmed the "after" pod had a new UID and a `creationTimestamp` later than the operator rollout. The check still passed (`configCheckResults: {"893225a7": true}`, no `status.problems`) and the aggregator StatefulSet came up.

2. Unit tests - added `TestAggregatorLevelConfigCheck`, a table over nil / empty / strategy-only / timeout-only / labels-only / all-fields, and `TestAggregatorLevelConfigCheckDefaultsTimeout` pinning the fallback to 10 when neither level sets one.

   As a negative control I restored the whole-struct assignment and confirmed 4 of the 6 cases fail. The nil and all-fields cases pass either way by design — they are the boundaries where replace and per-field merge agree.

3. `go test ./pkg/... ./controllers/...` passes with envtest assets, `make lint` reports 0 issues in both modules, and `make generate` produces no diff beyond the files in this PR.

### Any backward incompatible change? If so, please explain.

Yes in principle, and it is worth an explicit decision.

An aggregator level `configCheck` that previously blanked a logging level field now leaves it in place. Anything relying on that blanking sees a change — but the only way to depend on it was to set a field on the `Logging` resource and expect it to be ignored, which is the bug being reported. Installations that set `configCheck` in only one place, or set every field in both, are unaffected.

There is one judgement call I want to flag rather than bury: the aggregator side doc comment used to say the field is *"just copied over the field in the logging resource if defined"*, which does describe the old behaviour. My reading is that the `LoggingSpec` side comment is the intended contract and `Labels` vanishing was never deliberate, but if you disagree, the alternative is to keep replace semantics and document it clearly instead.
