### PR TITLE
fix(e2e): bound kind CLI invocations with a timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ test: codegen fmt vet manifests ${ENVTEST_BINARY_ASSETS} ${KUBEBUILDER} ## Run t
 	cd pkg/sdk/logging/model/syslogng/config && go test ./...  -coverprofile ${TEST_COV_DIR}/cover_syslogng.out
 	ENVTEST_BINARY_ASSETS=${ENVTEST_BINARY_ASSETS} go test -v ./controllers/logging/... ./pkg/...  -coverprofile ${TEST_COV_DIR}/cover_controllers_logging.out
 	ENVTEST_BINARY_ASSETS=${ENVTEST_BINARY_ASSETS} go test -v ./controllers/extensions/... ./pkg/...  -coverprofile ${TEST_COV_DIR}/cover_controllers_extensions.out
+	cd e2e && go test -v ./common/...
 
 .PHONY: generate-test-coverage
 generate-test-coverage: test
@@ -239,7 +240,7 @@ test-e2e-nodeps:
 		KIND_IMAGE="$(KIND_IMAGE)" \
 		PROJECT_DIR="$(PWD)" \
 		E2E_TEST_COV_DIR=${TEST_COV_DIR} \
-		go test -count=1 -v -timeout ${E2E_TEST_TIMEOUT} ./${E2E_TEST}/...
+		go test -count=1 -v -timeout ${E2E_TEST_TIMEOUT} $$(go list ./${E2E_TEST}/... | grep -v '/e2e/common')
 		go tool covdata textfmt -i=${TEST_COV_DIR}/covdatafiles -o ${TEST_COV_DIR}/coverage_e2e.out
 	@echo "--- E2E test coverage report"
 	go tool covdata percent -i=${TEST_COV_DIR}/covdatafiles

--- a/e2e/common/cluster.go
+++ b/e2e/common/cluster.go
@@ -113,7 +113,7 @@ func GetTestCluster(clusterName string, opts ...cluster.Option) (Cluster, error)
 }
 
 func DeleteTestCluster(clusterName string) error {
-	return errors.WrapIfWithDetails(kind.DeleteCluster(kind.DeleteClusterOptions{
+	return errors.WrapIfWithDetails(kindCLI.DeleteCluster(kind.DeleteClusterOptions{
 		Name: clusterName,
 	}), "deleting kind cluster", "clusterName", clusterName)
 }
@@ -169,7 +169,7 @@ func (c kindCluster) Cleanup() error {
 }
 
 func (c kindCluster) LoadImages(images ...string) error {
-	return kind.LoadDockerImage(images, kind.LoadDockerImageOptions{
+	return kindCLI.LoadDockerImage(images, kind.LoadDockerImageOptions{
 		Name: c.clusterName,
 	})
 }

--- a/e2e/common/kind.go
+++ b/e2e/common/kind.go
@@ -21,20 +21,21 @@ import (
 )
 
 // KindClusterCreationTimeout is passed to `kind create cluster --wait`, which
-// bounds only the final action: waiting for the control plane to report ready.
-// It does not bound provisioning the node containers or pulling the node
-// image. The whole invocation is bounded by kind.CommandTimeout instead.
+// bounds only the last of kind's actions, waiting for control plane readiness.
+// The whole invocation is bounded by Kind.CommandTimeout instead.
 const KindClusterCreationTimeout = "3m"
 
+var kindCLI = kind.New()
+
 func KindClusterKubeconfig(name string) ([]byte, error) {
-	err := kind.CreateCluster(kind.CreateClusterOptions{
+	err := kindCLI.CreateCluster(kind.CreateClusterOptions{
 		Name: name,
 		Wait: KindClusterCreationTimeout,
 	})
 	if err != nil && !isClusterAlreadyExistsError(err) {
 		return nil, err
 	}
-	return kind.GetKubeconfig(kind.GetKubeconfigOptions{
+	return kindCLI.GetKubeconfig(kind.GetKubeconfigOptions{
 		Name: name,
 	})
 }

--- a/e2e/common/kind.go
+++ b/e2e/common/kind.go
@@ -20,6 +20,10 @@ import (
 	"github.com/kube-logging/logging-operator/e2e/common/kind"
 )
 
+// KindClusterCreationTimeout is passed to `kind create cluster --wait`, which
+// bounds only the final action: waiting for the control plane to report ready.
+// It does not bound provisioning the node containers or pulling the node
+// image. The whole invocation is bounded by kind.CommandTimeout instead.
 const KindClusterCreationTimeout = "3m"
 
 func KindClusterKubeconfig(name string) ([]byte, error) {

--- a/e2e/common/kind/commands.go
+++ b/e2e/common/kind/commands.go
@@ -28,91 +28,179 @@ import (
 	"time"
 )
 
-var (
-	KindPath  string
-	KindImage string
-)
-
-// ErrTimeout is returned when a kind invocation is stopped by its deadline
-// rather than by kind itself.
+// ErrTimeout reports that an invocation was stopped by its deadline rather than
+// by kind itself.
 var ErrTimeout = errors.New("timed out")
 
-// CommandTimeout bounds a single kind invocation. Zero means it is derived
-// from the test binary's own -timeout on first use; see commandTimeout.
-//
-// kind's own --wait only covers the last of its create actions, waiting for
-// control plane readiness. Provisioning the node containers, pulling the node
-// image and `kind load docker-image` are bounded by nothing. When several
-// clusters are built at once on a busy CI runner those phases can stall for
-// longer than the whole test budget, and with no deadline here the only thing
-// that ends the stall is `go test` panicking on its own -timeout. That kills
-// every other test in the package and skips the deferred cluster cleanup, so
-// one stalled cluster takes the rest of the package down with it.
-//
-// Set it directly, or with KIND_COMMAND_TIMEOUT, to pin a value.
-var CommandTimeout time.Duration
+const (
+	pathEnv           = "KIND_PATH"
+	imageEnv          = "KIND_IMAGE"
+	commandTimeoutEnv = "KIND_COMMAND_TIMEOUT"
 
-// timeoutFraction is how much of the enclosing -timeout a single kind call may
-// consume before we call it stalled.
-//
-// The deadline has to be derived from the budget it sits inside, not guessed
-// from how long a healthy run takes. Healthy timings are the wrong reference:
-// this only fires when the runner is degraded, and that is exactly when every
-// step legitimately takes several times longer than healthy. A cap chosen from
-// healthy numbers ends up inside the range where real work still completes,
-// and then it fails runs that would have passed.
-//
-// Anything still running this late has left too little of the budget for the
-// rest of the test to finish, so cutting it can only replace an anonymous
-// whole-binary panic with a named failure and a cleaned-up cluster. It cannot
-// turn a passing run red.
-const timeoutFraction = 0.8
+	defaultPath = "../../bin/kind"
 
-// fallbackTimeout applies when the enclosing deadline cannot be read, which
-// means the binary was started with -timeout 0 and has no deadline of its own.
-const fallbackTimeout = 15 * time.Minute
+	// timeoutFraction is the share of the enclosing -timeout that one invocation
+	// may consume. The cap is derived from the surrounding budget rather than
+	// from healthy timings because a stall only matters on a degraded runner,
+	// which is exactly when every step legitimately takes several times longer.
+	timeoutFraction = 0.8
 
-// CleanupTimeout bounds the best-effort delete issued after a command times
-// out. It is much shorter than CommandTimeout: the runner is already
-// struggling by then, and the caller still has to report the failure inside
-// the remaining test budget.
-var CleanupTimeout = 2 * time.Minute
+	// fallbackTimeout applies when the binary has no deadline to derive from.
+	fallbackTimeout = 15 * time.Minute
 
-const commandTimeoutEnv = "KIND_COMMAND_TIMEOUT"
+	defaultCleanupTimeout = 2 * time.Minute
+	defaultWaitDelay      = 10 * time.Second
+)
 
-// waitDelay is how long Wait may keep waiting on inherited output pipes after
-// the process itself has been killed. A variable so the tests can shorten it.
-var waitDelay = 10 * time.Second
+// Kind runs kind subcommands against one installation of the binary.
+type Kind struct {
+	Path  string
+	Image string
 
-func init() {
-	KindPath = os.Getenv("KIND_PATH")
-	if KindPath == "" {
-		KindPath = "../../bin/kind"
-		fmt.Println("KIND_PATH is not set, defaulting to ../../bin/kind")
+	// CommandTimeout bounds a single invocation. Zero derives it from the test
+	// binary's own -timeout on first use.
+	CommandTimeout time.Duration
+
+	// CleanupTimeout bounds the delete issued after a timeout. It is short
+	// because the runner is already struggling by then and the caller still has
+	// to report the failure within what is left of the budget.
+	CleanupTimeout time.Duration
+
+	// waitDelay caps how long Wait blocks on inherited pipes after the process
+	// has been killed.
+	waitDelay   time.Duration
+	resolveOnce sync.Once
+}
+
+// New returns a Kind configured from KIND_PATH, KIND_IMAGE and
+// KIND_COMMAND_TIMEOUT.
+func New() *Kind {
+	path := os.Getenv(pathEnv)
+	if path == "" {
+		path = defaultPath
+		fmt.Printf("%s is not set, defaulting to %s\n", pathEnv, defaultPath)
 	}
-	KindImage = os.Getenv("KIND_IMAGE")
-	// Not resolved here: the enclosing -timeout is only readable once the
-	// testing package has parsed flags, which happens after init.
-	CommandTimeout = resolveCommandTimeout(os.Getenv(commandTimeoutEnv), 0)
+
+	return &Kind{
+		Path:  path,
+		Image: os.Getenv(imageEnv),
+		// Left to be derived: the enclosing -timeout only becomes readable once
+		// the testing package has parsed flags, which is after initialisation.
+		CommandTimeout: resolveCommandTimeout(os.Getenv(commandTimeoutEnv), 0),
+		CleanupTimeout: defaultCleanupTimeout,
+		waitDelay:      defaultWaitDelay,
+	}
 }
 
-// commandTimeout is the deadline for one kind call, worked out once.
-func commandTimeout() time.Duration {
-	resolveOnce.Do(func() {
-		if CommandTimeout > 0 {
-			return // pinned by KIND_COMMAND_TIMEOUT or by a caller
-		}
-		CommandTimeout = deriveCommandTimeout(enclosingTestTimeout())
-		fmt.Printf("kind command timeout: %s (override with %s)\n", CommandTimeout, commandTimeoutEnv)
+func (k *Kind) CreateCluster(options CreateClusterOptions) error {
+	if k.Image != "" && options.Image == "" {
+		options.Image = k.Image
+	}
+	args := options.AppendToArgs([]string{"create", "cluster"})
+
+	cmderr := &bytes.Buffer{}
+	err := k.run(k.commandTimeout(), args, func(cmd *exec.Cmd) {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = io.MultiWriter(os.Stderr, cmderr)
 	})
-	return CommandTimeout
+
+	switch {
+	case err == nil:
+		return nil
+
+	case errors.Is(err, ErrTimeout):
+		// kind removes a half-built cluster when one of its own actions fails,
+		// but not when we kill it, so the leftovers have to go explicitly.
+		cleanupErr := k.deleteCluster(k.CleanupTimeout, DeleteClusterOptions{Name: options.Name})
+		if cleanupErr != nil {
+			return fmt.Errorf("%w; deleting the partial cluster also failed: %w", err, cleanupErr)
+		}
+		return err
+
+	case cmderr.Len() == 0:
+		// An empty stderr means kind never ran, and the buffer on its own would
+		// produce an error with no message.
+		return err
+
+	default:
+		// common.isClusterAlreadyExistsError matches against kind's own wording.
+		return errors.New(cmderr.String())
+	}
 }
 
-var resolveOnce sync.Once
+func (k *Kind) DeleteCluster(options DeleteClusterOptions) error {
+	return k.deleteCluster(k.commandTimeout(), options)
+}
 
-// deriveCommandTimeout turns the enclosing test deadline into a per-command
-// one. It must always come out strictly below enclosing, so that cutting a
-// command short can never be the reason a package misses its own deadline.
+func (k *Kind) deleteCluster(timeout time.Duration, options DeleteClusterOptions) error {
+	return k.run(timeout, options.AppendToArgs([]string{"delete", "cluster"}), nil)
+}
+
+func (k *Kind) GetKubeconfig(options GetKubeconfigOptions) ([]byte, error) {
+	args := options.AppendToArgs([]string{"get", "kubeconfig"})
+
+	stdout := &bytes.Buffer{}
+	err := k.run(k.commandTimeout(), args, func(cmd *exec.Cmd) {
+		cmd.Stdout = stdout
+		cmd.Stderr = os.Stderr
+	})
+	return stdout.Bytes(), err
+}
+
+func (k *Kind) LoadDockerImage(images []string, options LoadDockerImageOptions) error {
+	if len(images) == 0 {
+		return nil
+	}
+	args := append(options.AppendToArgs([]string{"load", "docker-image"}), images...)
+
+	output := &bytes.Buffer{}
+	err := k.run(k.commandTimeout(), args, func(cmd *exec.Cmd) {
+		cmd.Stdout = output
+		cmd.Stderr = output
+	})
+	if err != nil {
+		return fmt.Errorf("kind load failed: %w\nOutput: %s", err, output.String())
+	}
+	return nil
+}
+
+// run executes a kind subcommand under the given deadline. configure wires up
+// the command's output and may be nil.
+func (k *Kind) run(timeout time.Duration, args []string, configure func(*exec.Cmd)) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, k.Path, args...)
+	// kind shells out to docker and killing kind does not kill its children, so
+	// without this Wait would block until every writer closed the pipe it
+	// inherited.
+	cmd.WaitDelay = k.waitDelay
+	if configure != nil {
+		configure(cmd)
+	}
+
+	err := cmd.Run()
+	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		// exec reports only "signal: killed", which does not say what stalled.
+		return fmt.Errorf("kind %s %w after %s (override with %s)",
+			strings.Join(args, " "), ErrTimeout, timeout, commandTimeoutEnv)
+	}
+	return err
+}
+
+func (k *Kind) commandTimeout() time.Duration {
+	k.resolveOnce.Do(func() {
+		if k.CommandTimeout > 0 {
+			return
+		}
+		k.CommandTimeout = deriveCommandTimeout(enclosingTestTimeout())
+		fmt.Printf("kind command timeout: %s (override with %s)\n", k.CommandTimeout, commandTimeoutEnv)
+	})
+	return k.CommandTimeout
+}
+
+// deriveCommandTimeout must always return less than enclosing, so that cutting
+// an invocation short can never be why a package misses its own deadline.
 func deriveCommandTimeout(enclosing time.Duration) time.Duration {
 	if enclosing <= 0 {
 		return fallbackTimeout
@@ -120,8 +208,8 @@ func deriveCommandTimeout(enclosing time.Duration) time.Duration {
 	return time.Duration(float64(enclosing) * timeoutFraction)
 }
 
-// enclosingTestTimeout reports the -timeout this test binary was started with,
-// or zero if there is none to read.
+// enclosingTestTimeout reports the -timeout this binary was started with, or
+// zero if there is none to read.
 func enclosingTestTimeout() time.Duration {
 	f := flag.Lookup("test.timeout")
 	if f == nil {
@@ -138,93 +226,34 @@ func enclosingTestTimeout() time.Duration {
 	return timeout
 }
 
-// resolveCommandTimeout reads the timeout from raw, keeping fallback when raw
-// is empty, unparseable, or not positive. A bad value is not worth failing the
-// run over, but it is worth saying out loud.
-//
-// Non-positive is rejected rather than read as "no timeout". A zero deadline
-// is already expired, so KIND_COMMAND_TIMEOUT=0 would fail every kind call
-// instantly — the opposite of what anyone writing that would mean by it. Pass
-// a large duration if you want an effectively unbounded run.
+// resolveCommandTimeout keeps fallback when raw is empty, unparseable or not
+// positive. Non-positive is rejected rather than read as "no timeout" because a
+// zero deadline has already expired, so it would fail every invocation at once.
 func resolveCommandTimeout(raw string, fallback time.Duration) time.Duration {
 	if raw == "" {
 		return fallback
 	}
+
 	timeout, err := time.ParseDuration(raw)
-	if err != nil {
-		fmt.Printf("%s=%q is not a valid duration, keeping %s\n", commandTimeoutEnv, raw, fallback)
-		return fallback
-	}
-	if timeout <= 0 {
-		fmt.Printf("%s=%q is not a positive duration, keeping %s\n", commandTimeoutEnv, raw, fallback)
-		return fallback
-	}
-	return timeout
-}
-
-// runKind runs a kind subcommand under the given deadline. configure wires up
-// the command's output and may be nil.
-//
-// When the deadline is what stopped the process, exec only reports
-// "signal: killed", which says nothing about what was stuck. So that case is
-// reported as an error wrapping ErrTimeout and naming the subcommand.
-func runKind(timeout time.Duration, args []string, configure func(*exec.Cmd)) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, KindPath, args...)
-	// kind shells out to docker, and killing kind does not kill its children.
-	// Whenever output is wired to something other than a file, exec pipes it
-	// and Wait blocks until every writer closes that pipe, so a surviving
-	// docker would keep us here well past the deadline. WaitDelay caps that.
-	cmd.WaitDelay = waitDelay
-	if configure != nil {
-		configure(cmd)
-	}
-
-	err := cmd.Run()
-	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return fmt.Errorf("kind %s %w after %s (override with %s)", strings.Join(args, " "), ErrTimeout, timeout, commandTimeoutEnv)
-	}
-	return err
-}
-
-func CreateCluster(options CreateClusterOptions) error {
-	args := []string{"create", "cluster"}
-	if KindImage != "" && options.Image == "" {
-		options.Image = KindImage
-	}
-	args = options.AppendToArgs(args)
-
-	cmderr := &bytes.Buffer{}
-	err := runKind(commandTimeout(), args, func(cmd *exec.Cmd) {
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = io.MultiWriter(os.Stderr, cmderr)
-	})
-
 	switch {
-	case err == nil:
-		return nil
-	case errors.Is(err, ErrTimeout):
-		// kind removes a half-built cluster when one of its own actions fails,
-		// but not when we kill it, so the leftovers have to go explicitly.
-		// Otherwise the node containers hold their share of the runner for the
-		// rest of the job and make the next cluster likelier to stall too.
-		if deleteErr := deleteCluster(CleanupTimeout, DeleteClusterOptions{Name: options.Name}); deleteErr != nil {
-			return fmt.Errorf("%w; deleting the partial cluster also failed: %w", err, deleteErr)
-		}
-		return err
+	case err != nil:
+		fmt.Printf("%s=%q is not a valid duration, %s\n", commandTimeoutEnv, raw, keeping(fallback))
+		return fallback
+	case timeout <= 0:
+		fmt.Printf("%s=%q is not a positive duration, %s\n", commandTimeoutEnv, raw, keeping(fallback))
+		return fallback
 	default:
-		// kind's own diagnosis is on stderr, and isClusterAlreadyExistsError
-		// matches against it, so that is what callers need to see. But stderr
-		// is empty when the failure was starting the process at all — a
-		// KIND_PATH pointing at nothing, say — and an error with an empty
-		// message tells nobody anything.
-		if cmderr.Len() == 0 {
-			return err
-		}
-		return errors.New(cmderr.String())
+		return timeout
 	}
+}
+
+// keeping describes what a rejected value falls back to. A zero fallback is not
+// a timeout of 0s, it is the signal to derive one from -timeout later.
+func keeping(fallback time.Duration) string {
+	if fallback <= 0 {
+		return "deriving it from -timeout instead"
+	}
+	return fmt.Sprintf("keeping %s", fallback)
 }
 
 type CreateClusterOptions struct {
@@ -260,16 +289,6 @@ func (options CreateClusterOptions) AppendToArgs(args []string) []string {
 	return args
 }
 
-func DeleteCluster(options DeleteClusterOptions) error {
-	return deleteCluster(commandTimeout(), options)
-}
-
-func deleteCluster(timeout time.Duration, options DeleteClusterOptions) error {
-	args := []string{"delete", "cluster"}
-	args = options.AppendToArgs(args)
-	return runKind(timeout, args, nil)
-}
-
 type DeleteClusterOptions struct {
 	GlobalOptions
 	Kubeconfig string
@@ -287,18 +306,6 @@ func (options DeleteClusterOptions) AppendToArgs(args []string) []string {
 	return args
 }
 
-func GetKubeconfig(options GetKubeconfigOptions) ([]byte, error) {
-	args := []string{"get", "kubeconfig"}
-	args = options.AppendToArgs(args)
-
-	stdout := &bytes.Buffer{}
-	err := runKind(commandTimeout(), args, func(cmd *exec.Cmd) {
-		cmd.Stdout = stdout
-		cmd.Stderr = os.Stderr
-	})
-	return stdout.Bytes(), err
-}
-
 type GetKubeconfigOptions struct {
 	GlobalOptions
 	Internal bool
@@ -314,27 +321,6 @@ func (options GetKubeconfigOptions) AppendToArgs(args []string) []string {
 		args = append(args, "--name", options.Name)
 	}
 	return args
-}
-
-func LoadDockerImage(images []string, options LoadDockerImageOptions) error {
-	if len(images) == 0 {
-		return nil
-	}
-
-	args := []string{"load", "docker-image"}
-	args = options.AppendToArgs(args)
-	args = append(args, images...)
-
-	output := &bytes.Buffer{}
-	err := runKind(commandTimeout(), args, func(cmd *exec.Cmd) {
-		cmd.Stdout = output
-		cmd.Stderr = output
-	})
-	if err != nil {
-		return fmt.Errorf("kind load failed: %w\nOutput: %s", err, output.String())
-	}
-
-	return nil
 }
 
 type LoadDockerImageOptions struct {

--- a/e2e/common/kind/commands.go
+++ b/e2e/common/kind/commands.go
@@ -73,8 +73,13 @@ func init() {
 }
 
 // resolveCommandTimeout reads the timeout from raw, keeping fallback when raw
-// is empty or unparseable. A bad value is not worth failing the run over, but
-// it is worth saying out loud.
+// is empty, unparseable, or not positive. A bad value is not worth failing the
+// run over, but it is worth saying out loud.
+//
+// Non-positive is rejected rather than read as "no timeout". A zero deadline
+// is already expired, so KIND_COMMAND_TIMEOUT=0 would fail every kind call
+// instantly — the opposite of what anyone writing that would mean by it. Pass
+// a large duration if you want an effectively unbounded run.
 func resolveCommandTimeout(raw string, fallback time.Duration) time.Duration {
 	if raw == "" {
 		return fallback
@@ -82,6 +87,10 @@ func resolveCommandTimeout(raw string, fallback time.Duration) time.Duration {
 	timeout, err := time.ParseDuration(raw)
 	if err != nil {
 		fmt.Printf("%s=%q is not a valid duration, keeping %s\n", commandTimeoutEnv, raw, fallback)
+		return fallback
+	}
+	if timeout <= 0 {
+		fmt.Printf("%s=%q is not a positive duration, keeping %s\n", commandTimeoutEnv, raw, fallback)
 		return fallback
 	}
 	return timeout
@@ -140,6 +149,14 @@ func CreateCluster(options CreateClusterOptions) error {
 		}
 		return err
 	default:
+		// kind's own diagnosis is on stderr, and isClusterAlreadyExistsError
+		// matches against it, so that is what callers need to see. But stderr
+		// is empty when the failure was starting the process at all — a
+		// KIND_PATH pointing at nothing, say — and an error with an empty
+		// message tells nobody anything.
+		if cmderr.Len() == 0 {
+			return err
+		}
 		return errors.New(cmderr.String())
 	}
 }

--- a/e2e/common/kind/commands.go
+++ b/e2e/common/kind/commands.go
@@ -18,11 +18,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -35,7 +37,8 @@ var (
 // rather than by kind itself.
 var ErrTimeout = errors.New("timed out")
 
-// CommandTimeout bounds a single kind invocation.
+// CommandTimeout bounds a single kind invocation. Zero means it is derived
+// from the test binary's own -timeout on first use; see commandTimeout.
 //
 // kind's own --wait only covers the last of its create actions, waiting for
 // control plane readiness. Provisioning the node containers, pulling the node
@@ -46,9 +49,28 @@ var ErrTimeout = errors.New("timed out")
 // every other test in the package and skips the deferred cluster cleanup, so
 // one stalled cluster takes the rest of the package down with it.
 //
-// The value is deliberately far above anything a healthy run needs, so that
-// it only fires on a genuine stall. Override it with KIND_COMMAND_TIMEOUT.
-var CommandTimeout = 10 * time.Minute
+// Set it directly, or with KIND_COMMAND_TIMEOUT, to pin a value.
+var CommandTimeout time.Duration
+
+// timeoutFraction is how much of the enclosing -timeout a single kind call may
+// consume before we call it stalled.
+//
+// The deadline has to be derived from the budget it sits inside, not guessed
+// from how long a healthy run takes. Healthy timings are the wrong reference:
+// this only fires when the runner is degraded, and that is exactly when every
+// step legitimately takes several times longer than healthy. A cap chosen from
+// healthy numbers ends up inside the range where real work still completes,
+// and then it fails runs that would have passed.
+//
+// Anything still running this late has left too little of the budget for the
+// rest of the test to finish, so cutting it can only replace an anonymous
+// whole-binary panic with a named failure and a cleaned-up cluster. It cannot
+// turn a passing run red.
+const timeoutFraction = 0.8
+
+// fallbackTimeout applies when the enclosing deadline cannot be read, which
+// means the binary was started with -timeout 0 and has no deadline of its own.
+const fallbackTimeout = 15 * time.Minute
 
 // CleanupTimeout bounds the best-effort delete issued after a command times
 // out. It is much shorter than CommandTimeout: the runner is already
@@ -69,7 +91,51 @@ func init() {
 		fmt.Println("KIND_PATH is not set, defaulting to ../../bin/kind")
 	}
 	KindImage = os.Getenv("KIND_IMAGE")
-	CommandTimeout = resolveCommandTimeout(os.Getenv(commandTimeoutEnv), CommandTimeout)
+	// Not resolved here: the enclosing -timeout is only readable once the
+	// testing package has parsed flags, which happens after init.
+	CommandTimeout = resolveCommandTimeout(os.Getenv(commandTimeoutEnv), 0)
+}
+
+// commandTimeout is the deadline for one kind call, worked out once.
+func commandTimeout() time.Duration {
+	resolveOnce.Do(func() {
+		if CommandTimeout > 0 {
+			return // pinned by KIND_COMMAND_TIMEOUT or by a caller
+		}
+		CommandTimeout = deriveCommandTimeout(enclosingTestTimeout())
+		fmt.Printf("kind command timeout: %s (override with %s)\n", CommandTimeout, commandTimeoutEnv)
+	})
+	return CommandTimeout
+}
+
+var resolveOnce sync.Once
+
+// deriveCommandTimeout turns the enclosing test deadline into a per-command
+// one. It must always come out strictly below enclosing, so that cutting a
+// command short can never be the reason a package misses its own deadline.
+func deriveCommandTimeout(enclosing time.Duration) time.Duration {
+	if enclosing <= 0 {
+		return fallbackTimeout
+	}
+	return time.Duration(float64(enclosing) * timeoutFraction)
+}
+
+// enclosingTestTimeout reports the -timeout this test binary was started with,
+// or zero if there is none to read.
+func enclosingTestTimeout() time.Duration {
+	f := flag.Lookup("test.timeout")
+	if f == nil {
+		return 0
+	}
+	getter, ok := f.Value.(flag.Getter)
+	if !ok {
+		return 0
+	}
+	timeout, ok := getter.Get().(time.Duration)
+	if !ok {
+		return 0
+	}
+	return timeout
 }
 
 // resolveCommandTimeout reads the timeout from raw, keeping fallback when raw
@@ -131,7 +197,7 @@ func CreateCluster(options CreateClusterOptions) error {
 	args = options.AppendToArgs(args)
 
 	cmderr := &bytes.Buffer{}
-	err := runKind(CommandTimeout, args, func(cmd *exec.Cmd) {
+	err := runKind(commandTimeout(), args, func(cmd *exec.Cmd) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = io.MultiWriter(os.Stderr, cmderr)
 	})
@@ -195,7 +261,7 @@ func (options CreateClusterOptions) AppendToArgs(args []string) []string {
 }
 
 func DeleteCluster(options DeleteClusterOptions) error {
-	return deleteCluster(CommandTimeout, options)
+	return deleteCluster(commandTimeout(), options)
 }
 
 func deleteCluster(timeout time.Duration, options DeleteClusterOptions) error {
@@ -226,7 +292,7 @@ func GetKubeconfig(options GetKubeconfigOptions) ([]byte, error) {
 	args = options.AppendToArgs(args)
 
 	stdout := &bytes.Buffer{}
-	err := runKind(CommandTimeout, args, func(cmd *exec.Cmd) {
+	err := runKind(commandTimeout(), args, func(cmd *exec.Cmd) {
 		cmd.Stdout = stdout
 		cmd.Stderr = os.Stderr
 	})
@@ -260,7 +326,7 @@ func LoadDockerImage(images []string, options LoadDockerImageOptions) error {
 	args = append(args, images...)
 
 	output := &bytes.Buffer{}
-	err := runKind(CommandTimeout, args, func(cmd *exec.Cmd) {
+	err := runKind(commandTimeout(), args, func(cmd *exec.Cmd) {
 		cmd.Stdout = output
 		cmd.Stderr = output
 	})

--- a/e2e/common/kind/commands.go
+++ b/e2e/common/kind/commands.go
@@ -16,16 +16,51 @@ package kind
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
-var KindPath string
-var KindImage string
+var (
+	KindPath  string
+	KindImage string
+)
+
+// ErrTimeout is returned when a kind invocation is stopped by its deadline
+// rather than by kind itself.
+var ErrTimeout = errors.New("timed out")
+
+// CommandTimeout bounds a single kind invocation.
+//
+// kind's own --wait only covers the last of its create actions, waiting for
+// control plane readiness. Provisioning the node containers, pulling the node
+// image and `kind load docker-image` are bounded by nothing. When several
+// clusters are built at once on a busy CI runner those phases can stall for
+// longer than the whole test budget, and with no deadline here the only thing
+// that ends the stall is `go test` panicking on its own -timeout. That kills
+// every other test in the package and skips the deferred cluster cleanup, so
+// one stalled cluster takes the rest of the package down with it.
+//
+// The value is deliberately far above anything a healthy run needs, so that
+// it only fires on a genuine stall. Override it with KIND_COMMAND_TIMEOUT.
+var CommandTimeout = 10 * time.Minute
+
+// CleanupTimeout bounds the best-effort delete issued after a command times
+// out. It is much shorter than CommandTimeout: the runner is already
+// struggling by then, and the caller still has to report the failure inside
+// the remaining test budget.
+var CleanupTimeout = 2 * time.Minute
+
+const commandTimeoutEnv = "KIND_COMMAND_TIMEOUT"
+
+// waitDelay is how long Wait may keep waiting on inherited output pipes after
+// the process itself has been killed. A variable so the tests can shorten it.
+var waitDelay = 10 * time.Second
 
 func init() {
 	KindPath = os.Getenv("KIND_PATH")
@@ -34,6 +69,49 @@ func init() {
 		fmt.Println("KIND_PATH is not set, defaulting to ../../bin/kind")
 	}
 	KindImage = os.Getenv("KIND_IMAGE")
+	CommandTimeout = resolveCommandTimeout(os.Getenv(commandTimeoutEnv), CommandTimeout)
+}
+
+// resolveCommandTimeout reads the timeout from raw, keeping fallback when raw
+// is empty or unparseable. A bad value is not worth failing the run over, but
+// it is worth saying out loud.
+func resolveCommandTimeout(raw string, fallback time.Duration) time.Duration {
+	if raw == "" {
+		return fallback
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil {
+		fmt.Printf("%s=%q is not a valid duration, keeping %s\n", commandTimeoutEnv, raw, fallback)
+		return fallback
+	}
+	return timeout
+}
+
+// runKind runs a kind subcommand under the given deadline. configure wires up
+// the command's output and may be nil.
+//
+// When the deadline is what stopped the process, exec only reports
+// "signal: killed", which says nothing about what was stuck. So that case is
+// reported as an error wrapping ErrTimeout and naming the subcommand.
+func runKind(timeout time.Duration, args []string, configure func(*exec.Cmd)) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, KindPath, args...)
+	// kind shells out to docker, and killing kind does not kill its children.
+	// Whenever output is wired to something other than a file, exec pipes it
+	// and Wait blocks until every writer closes that pipe, so a surviving
+	// docker would keep us here well past the deadline. WaitDelay caps that.
+	cmd.WaitDelay = waitDelay
+	if configure != nil {
+		configure(cmd)
+	}
+
+	err := cmd.Run()
+	if err != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("kind %s %w after %s (override with %s)", strings.Join(args, " "), ErrTimeout, timeout, commandTimeoutEnv)
+	}
+	return err
 }
 
 func CreateCluster(options CreateClusterOptions) error {
@@ -42,14 +120,28 @@ func CreateCluster(options CreateClusterOptions) error {
 		options.Image = KindImage
 	}
 	args = options.AppendToArgs(args)
-	cmd := exec.Command(KindPath, args...)
+
 	cmderr := &bytes.Buffer{}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = io.MultiWriter(os.Stderr, cmderr)
-	if err := cmd.Run(); err != nil {
+	err := runKind(CommandTimeout, args, func(cmd *exec.Cmd) {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = io.MultiWriter(os.Stderr, cmderr)
+	})
+
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrTimeout):
+		// kind removes a half-built cluster when one of its own actions fails,
+		// but not when we kill it, so the leftovers have to go explicitly.
+		// Otherwise the node containers hold their share of the runner for the
+		// rest of the job and make the next cluster likelier to stall too.
+		if deleteErr := deleteCluster(CleanupTimeout, DeleteClusterOptions{Name: options.Name}); deleteErr != nil {
+			return fmt.Errorf("%w; deleting the partial cluster also failed: %w", err, deleteErr)
+		}
+		return err
+	default:
 		return errors.New(cmderr.String())
 	}
-	return nil
 }
 
 type CreateClusterOptions struct {
@@ -86,9 +178,13 @@ func (options CreateClusterOptions) AppendToArgs(args []string) []string {
 }
 
 func DeleteCluster(options DeleteClusterOptions) error {
+	return deleteCluster(CommandTimeout, options)
+}
+
+func deleteCluster(timeout time.Duration, options DeleteClusterOptions) error {
 	args := []string{"delete", "cluster"}
 	args = options.AppendToArgs(args)
-	return exec.Command(KindPath, args...).Run()
+	return runKind(timeout, args, nil)
 }
 
 type DeleteClusterOptions struct {
@@ -111,7 +207,13 @@ func (options DeleteClusterOptions) AppendToArgs(args []string) []string {
 func GetKubeconfig(options GetKubeconfigOptions) ([]byte, error) {
 	args := []string{"get", "kubeconfig"}
 	args = options.AppendToArgs(args)
-	return exec.Command(KindPath, args...).Output()
+
+	stdout := &bytes.Buffer{}
+	err := runKind(CommandTimeout, args, func(cmd *exec.Cmd) {
+		cmd.Stdout = stdout
+		cmd.Stderr = os.Stderr
+	})
+	return stdout.Bytes(), err
 }
 
 type GetKubeconfigOptions struct {
@@ -139,9 +241,14 @@ func LoadDockerImage(images []string, options LoadDockerImageOptions) error {
 	args := []string{"load", "docker-image"}
 	args = options.AppendToArgs(args)
 	args = append(args, images...)
-	output, err := exec.Command(KindPath, args...).CombinedOutput()
+
+	output := &bytes.Buffer{}
+	err := runKind(CommandTimeout, args, func(cmd *exec.Cmd) {
+		cmd.Stdout = output
+		cmd.Stderr = output
+	})
 	if err != nil {
-		return fmt.Errorf("kind load failed: %w\nOutput: %s", err, string(output))
+		return fmt.Errorf("kind load failed: %w\nOutput: %s", err, output.String())
 	}
 
 	return nil

--- a/e2e/common/kind/commands.go
+++ b/e2e/common/kind/commands.go
@@ -199,8 +199,10 @@ func (k *Kind) commandTimeout() time.Duration {
 	return k.CommandTimeout
 }
 
-// deriveCommandTimeout must always return less than enclosing, so that cutting
-// an invocation short can never be why a package misses its own deadline.
+// deriveCommandTimeout returns a cap strictly below enclosing, so a stall is
+// cut while there is still budget left to clean up and name it. It does not
+// bound the package as a whole: several invocations can each stay under the cap
+// and still add up past the enclosing deadline.
 func deriveCommandTimeout(enclosing time.Duration) time.Duration {
 	if enclosing <= 0 {
 		return fallbackTimeout

--- a/e2e/common/kind/commands_test.go
+++ b/e2e/common/kind/commands_test.go
@@ -55,8 +55,15 @@ fi
 exit "${FAKE_KIND_EXIT:-0}"
 `
 
-// shortTimeout is the deadline used by the tests that stall the stub.
-const shortTimeout = 200 * time.Millisecond
+const (
+	// shortTimeout is the deadline used by the tests that stall the stub.
+	shortTimeout = 200 * time.Millisecond
+
+	// stubStall is how long the stub sleeps when a test wants it to hang. It
+	// only has to outlast shortTimeout: the sleep is orphaned when the stub is
+	// killed, so a longer one would just linger on the runner.
+	stubStall = "5"
+)
 
 // newFakeKind returns a Kind pointed at the stub, and the path of its
 // invocation log.
@@ -129,7 +136,7 @@ func TestCommandsTimeOut(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			k, _ := newFakeKind(t)
 			k.CommandTimeout = shortTimeout
-			t.Setenv(testCase.sleepEnv, "60")
+			t.Setenv(testCase.sleepEnv, stubStall)
 
 			started := time.Now()
 			err := testCase.invoke(k)
@@ -167,7 +174,7 @@ func TestCreateClusterErrorReporting(t *testing.T) {
 			contains:    "kind-is-not-installed-here",
 		},
 		"a failed cleanup is reported alongside the timeout": {
-			env:       map[string]string{"FAKE_KIND_CREATE_SLEEP": "60", "FAKE_KIND_DELETE_SLEEP": "60"},
+			env:       map[string]string{"FAKE_KIND_CREATE_SLEEP": stubStall, "FAKE_KIND_DELETE_SLEEP": stubStall},
 			timeouts:  shortTimeout,
 			isTimeout: true,
 			contains:  "deleting the partial cluster also failed",
@@ -235,7 +242,7 @@ func TestInvocations(t *testing.T) {
 			k, logPath := newFakeKind(t)
 			k.CommandTimeout = testCase.timeout
 			if testCase.sleepEnv != "" {
-				t.Setenv(testCase.sleepEnv, "60")
+				t.Setenv(testCase.sleepEnv, stubStall)
 			}
 
 			err := testCase.invoke(k)
@@ -333,9 +340,9 @@ func TestDeriveCommandTimeout(t *testing.T) {
 	}
 }
 
-// The invariant that matters. A per-command deadline at or above the deadline it
-// sits inside would cut off work that still had time to finish, turning runs
-// that would have passed into failures.
+// The invariant that matters. A cap at or above the deadline it sits inside
+// would never fire in time to be useful: the binary would panic on its own
+// deadline first, with nothing named and no cluster cleaned up.
 func TestDerivedTimeoutStaysBelowTheEnclosingDeadline(t *testing.T) {
 	for _, enclosing := range []time.Duration{
 		30 * time.Second, 2 * time.Minute, 10 * time.Minute,

--- a/e2e/common/kind/commands_test.go
+++ b/e2e/common/kind/commands_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Cisco Systems, Inc. and/or its affiliates
+// Copyright © 2026 Kube logging authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,13 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeKind stands in for the kind binary. It appends every invocation to
-// $FAKE_KIND_LOG and then behaves as the remaining variables ask, which lets
-// these tests exercise the stall path without building a real cluster.
+// fakeKind stands in for the kind binary: it records every invocation and then
+// behaves as the FAKE_KIND_* variables ask, so the stall paths can be exercised
+// without building a cluster.
 //
-// Killing this script leaves its `sleep` running, so the sleep drops the
-// inherited output: otherwise the orphan would hold the test binary's own
-// pipes open and `go test` would sit on them long after the run finished.
+// The sleep drops its inherited output because killing this script leaves the
+// sleep running, and an orphan holding the test binary's pipes would keep
+// `go test` waiting long after the run finished.
 const fakeKind = `#!/bin/sh
 echo "$*" >> "$FAKE_KIND_LOG"
 stall() {
@@ -55,9 +55,12 @@ fi
 exit "${FAKE_KIND_EXIT:-0}"
 `
 
-// installFakeKind points KindPath at the stub for the duration of the test and
-// returns the path of its invocation log.
-func installFakeKind(t *testing.T) string {
+// shortTimeout is the deadline used by the tests that stall the stub.
+const shortTimeout = 200 * time.Millisecond
+
+// newFakeKind returns a Kind pointed at the stub, and the path of its
+// invocation log.
+func newFakeKind(t *testing.T) (*Kind, string) {
 	t.Helper()
 
 	dir := t.TempDir()
@@ -67,25 +70,14 @@ func installFakeKind(t *testing.T) string {
 	logPath := filepath.Join(dir, "invocations.log")
 	t.Setenv("FAKE_KIND_LOG", logPath)
 
-	originalPath, originalImage := KindPath, KindImage
-	// KindImage would otherwise leak into the recorded argument lists.
-	KindPath, KindImage = binary, ""
-	t.Cleanup(func() { KindPath, KindImage = originalPath, originalImage })
-
-	return logPath
-}
-
-// withTimeouts shortens the deadlines so a stall surfaces in test time. The
-// wait delay comes down too: the stub leaves a `sleep` holding the output
-// pipe, so the production 10s would be paid on every stalling test.
-func withTimeouts(t *testing.T, command, cleanup time.Duration) {
-	t.Helper()
-
-	originalCommand, originalCleanup, originalDelay := CommandTimeout, CleanupTimeout, waitDelay
-	CommandTimeout, CleanupTimeout, waitDelay = command, cleanup, 250*time.Millisecond
-	t.Cleanup(func() {
-		CommandTimeout, CleanupTimeout, waitDelay = originalCommand, originalCleanup, originalDelay
-	})
+	return &Kind{
+		Path:           binary,
+		CommandTimeout: time.Minute,
+		CleanupTimeout: time.Minute,
+		// The stub leaves a sleep holding the output pipe, so the production
+		// delay would be paid by every test that stalls.
+		waitDelay: 250 * time.Millisecond,
+	}, logPath
 }
 
 func invocations(t *testing.T, logPath string) []string {
@@ -100,171 +92,250 @@ func invocations(t *testing.T, logPath string) []string {
 	return strings.Split(strings.TrimSpace(string(contents)), "\n")
 }
 
-func TestCreateClusterTimesOut(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, 200*time.Millisecond, time.Minute)
-	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
+func TestCommandsTimeOut(t *testing.T) {
+	testCases := map[string]struct {
+		sleepEnv string
+		invoke   func(*Kind) error
+		names    string
+	}{
+		"create cluster": {
+			sleepEnv: "FAKE_KIND_CREATE_SLEEP",
+			invoke:   func(k *Kind) error { return k.CreateCluster(CreateClusterOptions{Name: "stuck"}) },
+			names:    "create cluster --name stuck",
+		},
+		"delete cluster": {
+			sleepEnv: "FAKE_KIND_DELETE_SLEEP",
+			invoke:   func(k *Kind) error { return k.DeleteCluster(DeleteClusterOptions{Name: "stuck"}) },
+			names:    "delete cluster --name stuck",
+		},
+		"load docker-image": {
+			sleepEnv: "FAKE_KIND_LOAD_SLEEP",
+			invoke: func(k *Kind) error {
+				return k.LoadDockerImage([]string{"some/image:latest"}, LoadDockerImageOptions{Name: "stuck"})
+			},
+			names: "load docker-image --name stuck some/image:latest",
+		},
+		"get kubeconfig": {
+			sleepEnv: "FAKE_KIND_GET_SLEEP",
+			invoke: func(k *Kind) error {
+				_, err := k.GetKubeconfig(GetKubeconfigOptions{Name: "stuck"})
+				return err
+			},
+			names: "get kubeconfig --name stuck",
+		},
+	}
 
-	started := time.Now()
-	err := CreateCluster(CreateClusterOptions{Name: "stuck"})
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			k, _ := newFakeKind(t)
+			k.CommandTimeout = shortTimeout
+			t.Setenv(testCase.sleepEnv, "60")
 
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrTimeout)
-	// The point of the change: the caller finds out promptly instead of
-	// hanging until `go test` panics on its own -timeout.
-	assert.Less(t, time.Since(started), 30*time.Second)
+			started := time.Now()
+			err := testCase.invoke(k)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrTimeout)
+			// "signal: killed" alone would not say what was stuck.
+			assert.Contains(t, err.Error(), testCase.names)
+			assert.Contains(t, err.Error(), commandTimeoutEnv)
+			// The point of the change: the caller finds out promptly instead of
+			// hanging until go test panics on its own -timeout.
+			assert.Less(t, time.Since(started), 30*time.Second)
+		})
+	}
 }
 
-func TestCreateClusterTimeoutNamesTheCommand(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, 200*time.Millisecond, time.Minute)
-	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
+func TestCreateClusterErrorReporting(t *testing.T) {
+	const alreadyExists = "ERROR: failed to create cluster: node(s) already exist for a cluster with the name"
 
-	err := CreateCluster(CreateClusterOptions{Name: "stuck"})
+	testCases := map[string]struct {
+		env         map[string]string
+		missingKind bool
+		timeouts    time.Duration
+		isTimeout   bool
+		contains    string
+	}{
+		// Negative control: a failure that is not a stall keeps reporting kind's
+		// own stderr rather than being relabelled as a timeout.
+		"kind's own diagnosis is passed through": {
+			env:      map[string]string{"FAKE_KIND_EXIT": "1", "FAKE_KIND_STDERR": alreadyExists},
+			contains: "failed to create cluster: node(s) already exist for a cluster with the name",
+		},
+		"the exec error stands in when kind writes nothing": {
+			missingKind: true,
+			contains:    "kind-is-not-installed-here",
+		},
+		"a failed cleanup is reported alongside the timeout": {
+			env:       map[string]string{"FAKE_KIND_CREATE_SLEEP": "60", "FAKE_KIND_DELETE_SLEEP": "60"},
+			timeouts:  shortTimeout,
+			isTimeout: true,
+			contains:  "deleting the partial cluster also failed",
+		},
+	}
 
-	require.Error(t, err)
-	// "signal: killed" on its own says nothing about what was stuck.
-	assert.Contains(t, err.Error(), "create cluster")
-	assert.Contains(t, err.Error(), "--name stuck")
-	assert.Contains(t, err.Error(), commandTimeoutEnv)
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			k, _ := newFakeKind(t)
+			if testCase.timeouts > 0 {
+				k.CommandTimeout, k.CleanupTimeout = testCase.timeouts, testCase.timeouts
+			}
+			if testCase.missingKind {
+				k.Path = filepath.Join(t.TempDir(), "kind-is-not-installed-here")
+			}
+			for key, value := range testCase.env {
+				t.Setenv(key, value)
+			}
+
+			err := k.CreateCluster(CreateClusterOptions{Name: "cluster"})
+
+			require.Error(t, err)
+			assert.NotEmpty(t, err.Error(), "the error must say something")
+			assert.Contains(t, err.Error(), testCase.contains)
+			if testCase.isTimeout {
+				assert.ErrorIs(t, err, ErrTimeout)
+			} else {
+				assert.NotErrorIs(t, err, ErrTimeout)
+			}
+		})
+	}
 }
 
-func TestCreateClusterDeletesThePartialClusterOnTimeout(t *testing.T) {
-	logPath := installFakeKind(t)
-	withTimeouts(t, 200*time.Millisecond, time.Minute)
-	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
+func TestInvocations(t *testing.T) {
+	testCases := map[string]struct {
+		sleepEnv string
+		timeout  time.Duration
+		invoke   func(*Kind) error
+		wantErr  bool
+		want     []string
+	}{
+		"a successful create is the only call": {
+			invoke:  func(k *Kind) error { return k.CreateCluster(CreateClusterOptions{Name: "fine"}) },
+			timeout: time.Minute,
+			want:    []string{"create cluster --name fine"},
+		},
+		// kind tears down a half-built cluster when one of its own actions
+		// fails, but not when we kill it, so the delete has to be ours.
+		"a stalled create deletes the partial cluster": {
+			sleepEnv: "FAKE_KIND_CREATE_SLEEP",
+			timeout:  shortTimeout,
+			invoke:   func(k *Kind) error { return k.CreateCluster(CreateClusterOptions{Name: "stuck"}) },
+			wantErr:  true,
+			want:     []string{"create cluster --name stuck", "delete cluster --name stuck"},
+		},
+		"an empty image list runs nothing": {
+			invoke:  func(k *Kind) error { return k.LoadDockerImage(nil, LoadDockerImageOptions{Name: "c"}) },
+			timeout: time.Minute,
+			want:    nil,
+		},
+	}
 
-	require.Error(t, CreateCluster(CreateClusterOptions{Name: "stuck"}))
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			k, logPath := newFakeKind(t)
+			k.CommandTimeout = testCase.timeout
+			if testCase.sleepEnv != "" {
+				t.Setenv(testCase.sleepEnv, "60")
+			}
 
-	// kind tears down a half-built cluster when one of its own actions fails,
-	// but not when we kill it, so the delete has to be ours.
-	assert.Contains(t, invocations(t, logPath), "delete cluster --name stuck")
+			err := testCase.invoke(k)
+
+			if testCase.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, testCase.want, invocations(t, logPath))
+		})
+	}
 }
 
-func TestCreateClusterDoesNotDeleteOnSuccess(t *testing.T) {
-	logPath := installFakeKind(t)
-	withTimeouts(t, time.Minute, time.Minute)
+func TestCreateClusterAppliesTheDefaultImage(t *testing.T) {
+	testCases := map[string]struct {
+		image        string
+		optionsImage string
+		want         string
+	}{
+		"the default image is applied": {
+			image: "kindest/node:v1.30.0",
+			want:  "create cluster --image kindest/node:v1.30.0 --name c",
+		},
+		"an explicit image wins": {
+			image:        "kindest/node:v1.30.0",
+			optionsImage: "kindest/node:v1.31.0",
+			want:         "create cluster --image kindest/node:v1.31.0 --name c",
+		},
+		"no image is passed when none is set": {
+			want: "create cluster --name c",
+		},
+	}
 
-	require.NoError(t, CreateCluster(CreateClusterOptions{Name: "fine"}))
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			k, logPath := newFakeKind(t)
+			k.Image = testCase.image
 
-	assert.Equal(t, []string{"create cluster --name fine"}, invocations(t, logPath))
-}
+			require.NoError(t, k.CreateCluster(CreateClusterOptions{Name: "c", Image: testCase.optionsImage}))
 
-// Negative control: a kind failure that is not a stall must keep reporting
-// kind's own stderr, not be relabelled as a timeout.
-func TestCreateClusterReportsKindErrorsUnchanged(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, time.Minute, time.Minute)
-	t.Setenv("FAKE_KIND_EXIT", "1")
-	t.Setenv("FAKE_KIND_STDERR", "ERROR: node(s) already exist for a cluster with the name")
-
-	err := CreateCluster(CreateClusterOptions{Name: "existing"})
-
-	require.Error(t, err)
-	assert.NotErrorIs(t, err, ErrTimeout)
-	assert.Contains(t, err.Error(), "node(s) already exist for a cluster with the name")
-}
-
-// kind writes nothing to stderr when the failure is that it never started, so
-// the stderr buffer alone would make an error with an empty message.
-func TestCreateClusterReportsTheExecErrorWhenKindWritesNothing(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, time.Minute, time.Minute)
-	KindPath = filepath.Join(t.TempDir(), "kind-is-not-installed-here")
-
-	err := CreateCluster(CreateClusterOptions{Name: "cluster"})
-
-	require.Error(t, err)
-	assert.NotEmpty(t, err.Error(), "the error must say something")
-	assert.Contains(t, err.Error(), "kind-is-not-installed-here")
-}
-
-// The counterpart: when kind does explain itself, that explanation is what
-// callers get. common.isClusterAlreadyExistsError matches on this text.
-func TestCreateClusterPrefersKindsStderrWhenThereIsAny(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, time.Minute, time.Minute)
-	t.Setenv("FAKE_KIND_EXIT", "1")
-	t.Setenv("FAKE_KIND_STDERR", "ERROR: failed to create cluster: node(s) already exist for a cluster with the name")
-
-	err := CreateCluster(CreateClusterOptions{Name: "existing"})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create cluster: node(s) already exist for a cluster with the name")
-}
-
-func TestCreateClusterReportsAFailedCleanup(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, 200*time.Millisecond, 200*time.Millisecond)
-	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
-	t.Setenv("FAKE_KIND_DELETE_SLEEP", "60")
-
-	err := CreateCluster(CreateClusterOptions{Name: "stuck"})
-
-	require.Error(t, err)
-	// The original stall is still the headline; the failed cleanup is extra.
-	assert.ErrorIs(t, err, ErrTimeout)
-	assert.Contains(t, err.Error(), "deleting the partial cluster also failed")
-}
-
-func TestLoadDockerImageTimesOut(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, 200*time.Millisecond, time.Minute)
-	t.Setenv("FAKE_KIND_LOAD_SLEEP", "60")
-
-	err := LoadDockerImage([]string{"some/image:latest"}, LoadDockerImageOptions{Name: "cluster"})
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrTimeout)
-	assert.Contains(t, err.Error(), "load docker-image")
-}
-
-func TestLoadDockerImageSkipsAnEmptyList(t *testing.T) {
-	logPath := installFakeKind(t)
-
-	require.NoError(t, LoadDockerImage(nil, LoadDockerImageOptions{Name: "cluster"}))
-
-	assert.Empty(t, invocations(t, logPath))
+			assert.Equal(t, []string{testCase.want}, invocations(t, logPath))
+		})
+	}
 }
 
 func TestGetKubeconfigReturnsStdout(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, time.Minute, time.Minute)
+	k, _ := newFakeKind(t)
 	t.Setenv("FAKE_KIND_KUBECONFIG", "apiVersion: v1")
 
-	kubeconfig, err := GetKubeconfig(GetKubeconfigOptions{Name: "cluster"})
+	kubeconfig, err := k.GetKubeconfig(GetKubeconfigOptions{Name: "cluster"})
 
 	require.NoError(t, err)
 	assert.Equal(t, "apiVersion: v1", string(kubeconfig))
 }
 
-func TestGetKubeconfigTimesOut(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, 200*time.Millisecond, time.Minute)
-	t.Setenv("FAKE_KIND_GET_SLEEP", "60")
+func TestCommandTimeoutIsResolvedOnce(t *testing.T) {
+	t.Run("an explicit value is kept", func(t *testing.T) {
+		k := &Kind{CommandTimeout: 42 * time.Second}
 
-	_, err := GetKubeconfig(GetKubeconfigOptions{Name: "cluster"})
+		assert.Equal(t, 42*time.Second, k.commandTimeout())
+		assert.Equal(t, 42*time.Second, k.commandTimeout(), "resolving twice must not change it")
+	})
 
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrTimeout)
-	assert.Contains(t, err.Error(), "get kubeconfig")
+	t.Run("zero is derived from the enclosing deadline", func(t *testing.T) {
+		k := &Kind{}
+		enclosing := enclosingTestTimeout()
+		require.Positive(t, enclosing)
+
+		resolved := k.commandTimeout()
+
+		assert.Positive(t, resolved)
+		assert.Less(t, resolved, enclosing)
+		assert.Equal(t, resolved, k.commandTimeout(), "resolving twice must not change it")
+	})
 }
 
-func TestDeleteClusterTimesOut(t *testing.T) {
-	installFakeKind(t)
-	withTimeouts(t, 200*time.Millisecond, time.Minute)
-	t.Setenv("FAKE_KIND_DELETE_SLEEP", "60")
+func TestDeriveCommandTimeout(t *testing.T) {
+	testCases := map[string]struct {
+		enclosing time.Duration
+		expected  time.Duration
+	}{
+		"the suite's own 20m budget": {enclosing: 20 * time.Minute, expected: 16 * time.Minute},
+		"a short budget":             {enclosing: 30 * time.Second, expected: 24 * time.Second},
+		// -timeout 0 means the binary has no deadline, so there is nothing to
+		// derive from and a fixed backstop is all that is left.
+		"no deadline falls back": {enclosing: 0, expected: fallbackTimeout},
+		"a negative one too":     {enclosing: -1, expected: fallbackTimeout},
+	}
 
-	err := DeleteCluster(DeleteClusterOptions{Name: "cluster"})
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrTimeout)
-	assert.Contains(t, err.Error(), "delete cluster")
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, deriveCommandTimeout(testCase.enclosing))
+		})
+	}
 }
 
-// The invariant that matters. A per-command deadline at or above the deadline
-// it sits inside would cut off work that still had time to finish, and turn
-// runs that would have passed into failures.
+// The invariant that matters. A per-command deadline at or above the deadline it
+// sits inside would cut off work that still had time to finish, turning runs
+// that would have passed into failures.
 func TestDerivedTimeoutStaysBelowTheEnclosingDeadline(t *testing.T) {
 	for _, enclosing := range []time.Duration{
 		30 * time.Second, 2 * time.Minute, 10 * time.Minute,
@@ -274,18 +345,6 @@ func TestDerivedTimeoutStaysBelowTheEnclosingDeadline(t *testing.T) {
 		assert.Less(t, derived, enclosing, "a %s budget derived %s", enclosing, derived)
 		assert.Positive(t, derived)
 	}
-}
-
-func TestDerivedTimeoutLeavesRoomForTheRestOfTheTest(t *testing.T) {
-	// The suite runs at -timeout 20m, so this is the value that will apply.
-	assert.Equal(t, 16*time.Minute, deriveCommandTimeout(20*time.Minute))
-}
-
-// -timeout 0 means the binary has no deadline, so there is nothing to derive
-// from and a fixed backstop is all that is left.
-func TestDerivedTimeoutFallsBackWithoutAnEnclosingDeadline(t *testing.T) {
-	assert.Equal(t, fallbackTimeout, deriveCommandTimeout(0))
-	assert.Equal(t, fallbackTimeout, deriveCommandTimeout(-1))
 }
 
 // Guards the plumbing: the value really does come from this binary's -timeout.
@@ -306,8 +365,8 @@ func TestResolveCommandTimeout(t *testing.T) {
 		"a duration is honored":           {raw: "90s", expected: 90 * time.Second},
 		"a bare number is not a duration": {raw: "600", expected: fallback},
 		"nonsense keeps the default":      {raw: "soon", expected: fallback},
-		// A zero deadline is already expired, so honoring these would fail
-		// every kind call instantly instead of disabling the timeout.
+		// A zero deadline has already expired, so honoring these would fail
+		// every invocation instantly instead of disabling the timeout.
 		"zero keeps the default":         {raw: "0", expected: fallback},
 		"zero seconds keeps the default": {raw: "0s", expected: fallback},
 		"negative keeps the default":     {raw: "-1s", expected: fallback},

--- a/e2e/common/kind/commands_test.go
+++ b/e2e/common/kind/commands_test.go
@@ -262,6 +262,39 @@ func TestDeleteClusterTimesOut(t *testing.T) {
 	assert.Contains(t, err.Error(), "delete cluster")
 }
 
+// The invariant that matters. A per-command deadline at or above the deadline
+// it sits inside would cut off work that still had time to finish, and turn
+// runs that would have passed into failures.
+func TestDerivedTimeoutStaysBelowTheEnclosingDeadline(t *testing.T) {
+	for _, enclosing := range []time.Duration{
+		30 * time.Second, 2 * time.Minute, 10 * time.Minute,
+		20 * time.Minute, time.Hour,
+	} {
+		derived := deriveCommandTimeout(enclosing)
+		assert.Less(t, derived, enclosing, "a %s budget derived %s", enclosing, derived)
+		assert.Positive(t, derived)
+	}
+}
+
+func TestDerivedTimeoutLeavesRoomForTheRestOfTheTest(t *testing.T) {
+	// The suite runs at -timeout 20m, so this is the value that will apply.
+	assert.Equal(t, 16*time.Minute, deriveCommandTimeout(20*time.Minute))
+}
+
+// -timeout 0 means the binary has no deadline, so there is nothing to derive
+// from and a fixed backstop is all that is left.
+func TestDerivedTimeoutFallsBackWithoutAnEnclosingDeadline(t *testing.T) {
+	assert.Equal(t, fallbackTimeout, deriveCommandTimeout(0))
+	assert.Equal(t, fallbackTimeout, deriveCommandTimeout(-1))
+}
+
+// Guards the plumbing: the value really does come from this binary's -timeout.
+func TestEnclosingTestTimeoutIsReadable(t *testing.T) {
+	enclosing := enclosingTestTimeout()
+	t.Logf("this binary was started with -timeout %s", enclosing)
+	assert.Positive(t, enclosing, "go test always sets a deadline unless -timeout 0")
+}
+
 func TestResolveCommandTimeout(t *testing.T) {
 	fallback := 10 * time.Minute
 

--- a/e2e/common/kind/commands_test.go
+++ b/e2e/common/kind/commands_test.go
@@ -165,6 +165,34 @@ func TestCreateClusterReportsKindErrorsUnchanged(t *testing.T) {
 	assert.Contains(t, err.Error(), "node(s) already exist for a cluster with the name")
 }
 
+// kind writes nothing to stderr when the failure is that it never started, so
+// the stderr buffer alone would make an error with an empty message.
+func TestCreateClusterReportsTheExecErrorWhenKindWritesNothing(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, time.Minute, time.Minute)
+	KindPath = filepath.Join(t.TempDir(), "kind-is-not-installed-here")
+
+	err := CreateCluster(CreateClusterOptions{Name: "cluster"})
+
+	require.Error(t, err)
+	assert.NotEmpty(t, err.Error(), "the error must say something")
+	assert.Contains(t, err.Error(), "kind-is-not-installed-here")
+}
+
+// The counterpart: when kind does explain itself, that explanation is what
+// callers get. common.isClusterAlreadyExistsError matches on this text.
+func TestCreateClusterPrefersKindsStderrWhenThereIsAny(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, time.Minute, time.Minute)
+	t.Setenv("FAKE_KIND_EXIT", "1")
+	t.Setenv("FAKE_KIND_STDERR", "ERROR: failed to create cluster: node(s) already exist for a cluster with the name")
+
+	err := CreateCluster(CreateClusterOptions{Name: "existing"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create cluster: node(s) already exist for a cluster with the name")
+}
+
 func TestCreateClusterReportsAFailedCleanup(t *testing.T) {
 	installFakeKind(t)
 	withTimeouts(t, 200*time.Millisecond, 200*time.Millisecond)
@@ -245,6 +273,11 @@ func TestResolveCommandTimeout(t *testing.T) {
 		"a duration is honored":           {raw: "90s", expected: 90 * time.Second},
 		"a bare number is not a duration": {raw: "600", expected: fallback},
 		"nonsense keeps the default":      {raw: "soon", expected: fallback},
+		// A zero deadline is already expired, so honoring these would fail
+		// every kind call instantly instead of disabling the timeout.
+		"zero keeps the default":         {raw: "0", expected: fallback},
+		"zero seconds keeps the default": {raw: "0s", expected: fallback},
+		"negative keeps the default":     {raw: "-1s", expected: fallback},
 	}
 
 	for name, testCase := range testCases {

--- a/e2e/common/kind/commands_test.go
+++ b/e2e/common/kind/commands_test.go
@@ -1,0 +1,255 @@
+// Copyright © 2021 Cisco Systems, Inc. and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kind
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKind stands in for the kind binary. It appends every invocation to
+// $FAKE_KIND_LOG and then behaves as the remaining variables ask, which lets
+// these tests exercise the stall path without building a real cluster.
+//
+// Killing this script leaves its `sleep` running, so the sleep drops the
+// inherited output: otherwise the orphan would hold the test binary's own
+// pipes open and `go test` would sit on them long after the run finished.
+const fakeKind = `#!/bin/sh
+echo "$*" >> "$FAKE_KIND_LOG"
+stall() {
+	if [ "${1:-0}" = "0" ]; then
+		return
+	fi
+	sleep "$1" >/dev/null 2>&1
+}
+case "$1" in
+create) stall "${FAKE_KIND_CREATE_SLEEP:-0}" ;;
+delete) stall "${FAKE_KIND_DELETE_SLEEP:-0}" ;;
+load)   stall "${FAKE_KIND_LOAD_SLEEP:-0}" ;;
+get)
+	stall "${FAKE_KIND_GET_SLEEP:-0}"
+	printf '%s' "${FAKE_KIND_KUBECONFIG:-}"
+	;;
+esac
+if [ -n "${FAKE_KIND_STDERR:-}" ]; then
+	echo "$FAKE_KIND_STDERR" >&2
+fi
+exit "${FAKE_KIND_EXIT:-0}"
+`
+
+// installFakeKind points KindPath at the stub for the duration of the test and
+// returns the path of its invocation log.
+func installFakeKind(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "kind")
+	require.NoError(t, os.WriteFile(binary, []byte(fakeKind), 0o700))
+
+	logPath := filepath.Join(dir, "invocations.log")
+	t.Setenv("FAKE_KIND_LOG", logPath)
+
+	originalPath, originalImage := KindPath, KindImage
+	// KindImage would otherwise leak into the recorded argument lists.
+	KindPath, KindImage = binary, ""
+	t.Cleanup(func() { KindPath, KindImage = originalPath, originalImage })
+
+	return logPath
+}
+
+// withTimeouts shortens the deadlines so a stall surfaces in test time. The
+// wait delay comes down too: the stub leaves a `sleep` holding the output
+// pipe, so the production 10s would be paid on every stalling test.
+func withTimeouts(t *testing.T, command, cleanup time.Duration) {
+	t.Helper()
+
+	originalCommand, originalCleanup, originalDelay := CommandTimeout, CleanupTimeout, waitDelay
+	CommandTimeout, CleanupTimeout, waitDelay = command, cleanup, 250*time.Millisecond
+	t.Cleanup(func() {
+		CommandTimeout, CleanupTimeout, waitDelay = originalCommand, originalCleanup, originalDelay
+	})
+}
+
+func invocations(t *testing.T, logPath string) []string {
+	t.Helper()
+
+	contents, err := os.ReadFile(logPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+
+	return strings.Split(strings.TrimSpace(string(contents)), "\n")
+}
+
+func TestCreateClusterTimesOut(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, 200*time.Millisecond, time.Minute)
+	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
+
+	started := time.Now()
+	err := CreateCluster(CreateClusterOptions{Name: "stuck"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTimeout)
+	// The point of the change: the caller finds out promptly instead of
+	// hanging until `go test` panics on its own -timeout.
+	assert.Less(t, time.Since(started), 30*time.Second)
+}
+
+func TestCreateClusterTimeoutNamesTheCommand(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, 200*time.Millisecond, time.Minute)
+	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
+
+	err := CreateCluster(CreateClusterOptions{Name: "stuck"})
+
+	require.Error(t, err)
+	// "signal: killed" on its own says nothing about what was stuck.
+	assert.Contains(t, err.Error(), "create cluster")
+	assert.Contains(t, err.Error(), "--name stuck")
+	assert.Contains(t, err.Error(), commandTimeoutEnv)
+}
+
+func TestCreateClusterDeletesThePartialClusterOnTimeout(t *testing.T) {
+	logPath := installFakeKind(t)
+	withTimeouts(t, 200*time.Millisecond, time.Minute)
+	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
+
+	require.Error(t, CreateCluster(CreateClusterOptions{Name: "stuck"}))
+
+	// kind tears down a half-built cluster when one of its own actions fails,
+	// but not when we kill it, so the delete has to be ours.
+	assert.Contains(t, invocations(t, logPath), "delete cluster --name stuck")
+}
+
+func TestCreateClusterDoesNotDeleteOnSuccess(t *testing.T) {
+	logPath := installFakeKind(t)
+	withTimeouts(t, time.Minute, time.Minute)
+
+	require.NoError(t, CreateCluster(CreateClusterOptions{Name: "fine"}))
+
+	assert.Equal(t, []string{"create cluster --name fine"}, invocations(t, logPath))
+}
+
+// Negative control: a kind failure that is not a stall must keep reporting
+// kind's own stderr, not be relabelled as a timeout.
+func TestCreateClusterReportsKindErrorsUnchanged(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, time.Minute, time.Minute)
+	t.Setenv("FAKE_KIND_EXIT", "1")
+	t.Setenv("FAKE_KIND_STDERR", "ERROR: node(s) already exist for a cluster with the name")
+
+	err := CreateCluster(CreateClusterOptions{Name: "existing"})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrTimeout)
+	assert.Contains(t, err.Error(), "node(s) already exist for a cluster with the name")
+}
+
+func TestCreateClusterReportsAFailedCleanup(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, 200*time.Millisecond, 200*time.Millisecond)
+	t.Setenv("FAKE_KIND_CREATE_SLEEP", "60")
+	t.Setenv("FAKE_KIND_DELETE_SLEEP", "60")
+
+	err := CreateCluster(CreateClusterOptions{Name: "stuck"})
+
+	require.Error(t, err)
+	// The original stall is still the headline; the failed cleanup is extra.
+	assert.ErrorIs(t, err, ErrTimeout)
+	assert.Contains(t, err.Error(), "deleting the partial cluster also failed")
+}
+
+func TestLoadDockerImageTimesOut(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, 200*time.Millisecond, time.Minute)
+	t.Setenv("FAKE_KIND_LOAD_SLEEP", "60")
+
+	err := LoadDockerImage([]string{"some/image:latest"}, LoadDockerImageOptions{Name: "cluster"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTimeout)
+	assert.Contains(t, err.Error(), "load docker-image")
+}
+
+func TestLoadDockerImageSkipsAnEmptyList(t *testing.T) {
+	logPath := installFakeKind(t)
+
+	require.NoError(t, LoadDockerImage(nil, LoadDockerImageOptions{Name: "cluster"}))
+
+	assert.Empty(t, invocations(t, logPath))
+}
+
+func TestGetKubeconfigReturnsStdout(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, time.Minute, time.Minute)
+	t.Setenv("FAKE_KIND_KUBECONFIG", "apiVersion: v1")
+
+	kubeconfig, err := GetKubeconfig(GetKubeconfigOptions{Name: "cluster"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "apiVersion: v1", string(kubeconfig))
+}
+
+func TestGetKubeconfigTimesOut(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, 200*time.Millisecond, time.Minute)
+	t.Setenv("FAKE_KIND_GET_SLEEP", "60")
+
+	_, err := GetKubeconfig(GetKubeconfigOptions{Name: "cluster"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTimeout)
+	assert.Contains(t, err.Error(), "get kubeconfig")
+}
+
+func TestDeleteClusterTimesOut(t *testing.T) {
+	installFakeKind(t)
+	withTimeouts(t, 200*time.Millisecond, time.Minute)
+	t.Setenv("FAKE_KIND_DELETE_SLEEP", "60")
+
+	err := DeleteCluster(DeleteClusterOptions{Name: "cluster"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTimeout)
+	assert.Contains(t, err.Error(), "delete cluster")
+}
+
+func TestResolveCommandTimeout(t *testing.T) {
+	fallback := 10 * time.Minute
+
+	testCases := map[string]struct {
+		raw      string
+		expected time.Duration
+	}{
+		"unset keeps the default":         {raw: "", expected: fallback},
+		"a duration is honored":           {raw: "90s", expected: 90 * time.Second},
+		"a bare number is not a duration": {raw: "600", expected: fallback},
+		"nonsense keeps the default":      {raw: "soon", expected: fallback},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, resolveCommandTimeout(testCase.raw, fallback))
+		})
+	}
+}


### PR DESCRIPTION
Fixes part 1 of #2287.

Nothing bounds the `kind` calls the e2e harness makes. When a cluster build stalls, the only thing that ends it is `go test` hitting its own `-timeout` and panicking — which kills every other test in that package binary and skips the deferred cluster cleanup, so the leftover node containers make the next wave likelier to stall too. Ten of the thirteen packages going down together is the usual result.

This gives every `kind` invocation a deadline.

## What changes

`Kind` is the central object: it carries the binary path, the node image and both deadlines, and `CreateCluster`, `DeleteCluster`, `GetKubeconfig` and `LoadDockerImage` are methods on it. Its `run` helper wraps each invocation in `exec.CommandContext`. When the deadline is what stopped the process, the error wraps a new `ErrTimeout` and names the subcommand, because exec on its own only reports `signal: killed`:

```
kind create cluster --name fluentd-configcheck --wait 3m timed out after 16m0s (override with KIND_COMMAND_TIMEOUT)
```

`CreateCluster` also deletes the half-built cluster on timeout. kind cleans up after itself when one of *its* actions fails, but not when we kill it, so those containers would otherwise sit there holding their share of the runner. That delete gets its own shorter `CleanupTimeout`, since the runner is already struggling by then and the caller still has to report the failure inside the remaining test budget.

`cmd.WaitDelay` is set because kind shells out to docker and killing kind does not kill its children. Whenever output goes somewhere other than a file, exec pipes it and `Wait` blocks until every writer closes that pipe — so a surviving docker would keep us there well past the deadline. I measured this with a stub: 3.01s without the delay against a 100ms context, 352ms with it.

## Why `--wait` was never going to do this

`KindClusterCreationTimeout = "3m"` reads like it already bounds cluster creation. It does not. In kind v0.31.0, `p.Provision` — the "Preparing nodes" phase — runs *before* the action list, and `waitforready.NewAction(opts.WaitForReady)` is the last action in it. So `--wait` bounds the control plane readiness poll and nothing else, while the phase that actually stalls is unbounded. I have left the flag alone and put a comment on the const saying what it does and does not cover.

`kind load docker-image` has no `--wait` at all, and 5–6 of the stuck goroutines in each bad run are sitting in it.

## On the default

Derived, not chosen. `flag.Lookup("test.timeout")` reads the deadline the test binary was actually started with, and the cap is 80% of it — 16m under the suite's `-timeout 20m`, following `E2E_TEST_TIMEOUT` automatically if that changes. `KIND_COMMAND_TIMEOUT` still overrides it; a binary started with no deadline falls back to 15m.

An earlier revision of this PR hard-coded 10 minutes, picked by comparison with healthy timings. That was wrong, and it made the PR a regression: both e2e runs on the branch failed with the cap firing on `kind load docker-image`. Healthy timings are the wrong reference — the cap only matters on a degraded runner, which is exactly when every step legitimately takes several times longer. In the second run every package that passed took 1.6×–6.2× its healthy time, one of them 878s. Deriving from the enclosing budget means the cap can only convert an anonymous 20-minute panic into a named failure with cleanup, and cannot turn a passing run red.

## What this does and does not do

It does not stop the stalls. I proposed serialising the image loads on #2287 and then measured it: concurrency is 2.16× faster on an idle host, and serialising makes the tail ~3× worse under saturation — which is what a per-command deadline trips on, so it would have caused *more* timeouts, not fewer. Retracted there. What the numbers point at instead is loading *less*: `setup.LoggingOperator` puts all six images into every cluster regardless of the test, ~779 MB × 17 ≈ 13 GB per run, `fluentd-full` alone 67% of it. Left on the issue, as it is too big to bolt on here.

What it does: the failure arrives at 16 minutes instead of 20, says which command stalled instead of `panic: test timed out`, does not take the other tests in the package down with it, and does not leak node containers into the next wave.

## Testing

**Unit tests**, `e2e/common/kind/commands_test.go`, 10 tests / 36 counting subtests, table-driven. Each case builds its own `Kind` pointed at a stub binary, so the stall path is exercised without building anything; the suite runs in ~3.2s. They run under `make test` rather than the e2e job — `E2E_TEST` has no default, so the e2e recipe expanded to `./...` and swept them in; the Makefile change moves them to the unit target and filters `common` out of the e2e package list. The stub is POSIX-only — I ran the suite with its shebang switched to `dash`, since that is `/bin/sh` on the runners and not what I have locally.

Negative controls, to check the tests actually catch this:

| mutation | result |
|---|---|
| deadline removed (back to `exec.Command`) | `panic: test timed out after 40s` — the production symptom, in miniature |
| partial-cluster cleanup removed | 2 failures, incl. `[]string{"create cluster --name stuck"} does not contain "delete cluster --name stuck"` |

There is one thing I tried and dropped: a test that an orphaned grandchild holding the output pipe cannot outlast the deadline. Whether the shell leaves such an orphan turns out to depend on its fork/exec optimisation — I got 3.01s and 101ms from scripts differing by one line — so the test would have been a coin flip on someone else's runner. `WaitDelay` stays, measured but not asserted on.

**Against real kind** (v0.29.0, Docker 29.6.2, arm64), driving the changed functions directly:

```
create ok in 28s
kubeconfig ok, 5659 bytes
load ok in 1s
delete ok in 1s
```

and the case this PR is about, with the deadline set below a real cluster build:

```
create stopped after 20s with: kind create cluster --name timeout-verify-stall --wait 3m
  timed out after 20s (override with KIND_COMMAND_TIMEOUT)
no "timeout-verify-stall" cluster left behind
```

A full `make test-e2e E2E_TEST=watch-selector` is building locally as I write this, to confirm the normal `WithCluster` path is unaffected; I will report the result below. The e2e job on this PR covers the same ground more thoroughly.

While verifying I hit a `kind load` failure on `busybox:latest` (`content digest ... not found`) that turned out to be a local arm64 multi-platform quirk — `kind load docker-image busybox:latest` fails identically with none of this code involved. Worth mentioning only because the new code surfaced kind's real error in full rather than mislabelling it a timeout, which is the passthrough path working.

`golangci-lint` is clean on `e2e/common/kind`, and `make lint` still reports 0 issues. Note that `make lint` does not cover the `e2e` module — it runs at the repo root and in `pkg/sdk` only — so I ran it there by hand. It has 7 pre-existing findings in files I have not touched; I left those alone. I compared against a worktree of unmodified HEAD: the same 7 before and after, none introduced here.

