### PR TITLE
build(e2e): run the linter on the e2e module, and fix what it reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,11 +158,13 @@ license-cache: ${LICENSEI} ## Generate license cache
 lint: ${GOLANGCI_LINT} ## Run linter
 	${GOLANGCI_LINT} run ${LINTER_FLAGS}
 	cd pkg/sdk && ${GOLANGCI_LINT} run ${LINTER_FLAGS}
+	cd e2e && ${GOLANGCI_LINT} run ${LINTER_FLAGS}
 
 .PHONY: lint-fix
 lint-fix: ${GOLANGCI_LINT} ## Run linter
 	${GOLANGCI_LINT} run --fix
 	cd pkg/sdk && ${GOLANGCI_LINT} run --fix
+	cd e2e && ${GOLANGCI_LINT} run --fix
 
 .PHONY: list
 list: ## List all make targets

--- a/e2e/common/cluster.go
+++ b/e2e/common/cluster.go
@@ -156,16 +156,12 @@ func (c kindCluster) PrintLogs(config PrintLogConfig) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = f.Close() }()
+
 	cmd.Stdout = f
 	cmd.Stderr = os.Stderr
 
-	// f is the log file stern writes into, so a failed Close means truncated output.
-	if err := cmd.Run(); err != nil {
-		_ = f.Close()
-		return err
-	}
-
-	return f.Close()
+	return cmd.Run()
 }
 
 func (c kindCluster) Cleanup() error {

--- a/e2e/common/cluster.go
+++ b/e2e/common/cluster.go
@@ -156,12 +156,16 @@ func (c kindCluster) PrintLogs(config PrintLogConfig) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
 	cmd.Stdout = f
 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	// f is the log file stern writes into, so a failed Close means truncated output.
+	if err := cmd.Run(); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	return f.Close()
 }
 
 func (c kindCluster) Cleanup() error {

--- a/e2e/common/cluster.go
+++ b/e2e/common/cluster.go
@@ -92,7 +92,7 @@ func GetTestCluster(clusterName string, opts ...cluster.Option) (Cluster, error)
 	if err != nil {
 		return nil, errors.WrapIfWithDetails(err, "unable to create temp file for kubeconfig", "clusterName", clusterName)
 	}
-	err = os.WriteFile(kubeconfigFile.Name(), kubeconfig, os.FileMode(0600))
+	err = os.WriteFile(kubeconfigFile.Name(), kubeconfig, os.FileMode(0o600))
 	if err != nil {
 		return nil, errors.WrapIfWithDetails(err, "failed to write kubeconfig", "clusterName", clusterName, "path", kubeconfigFile.Name())
 	}

--- a/e2e/common/cond/conditions.go
+++ b/e2e/common/cond/conditions.go
@@ -19,12 +19,13 @@ import (
 	"testing"
 
 	"github.com/cisco-open/operator-tools/pkg/utils"
-	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kube-logging/logging-operator/e2e/common"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
 func PodShouldBeRunning(t *testing.T, cl client.Reader, key client.ObjectKey) func() bool {
@@ -101,6 +102,7 @@ func ResourceShouldBePresent(t *testing.T, cl client.Reader, obj client.Object) 
 		return false
 	}
 }
+
 func CheckFluentdStatus(t *testing.T, c *common.Cluster, ctx *context.Context, fluentd *v1beta1.FluentdConfig, loggingName string) bool {
 	fluentdInstanceName := fluentd.Name
 	cluster := *c

--- a/e2e/common/helpers.go
+++ b/e2e/common/helpers.go
@@ -77,8 +77,8 @@ func LoggingInfra(
 	release string,
 	tag string,
 	buffer *output.Buffer,
-	producerLabels map[string]string) {
-
+	producerLabels map[string]string,
+) {
 	output := v1beta1.ClusterOutput{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "http",
@@ -181,7 +181,8 @@ func LoggingTenant(
 	release,
 	tag string,
 	buffer *output.Buffer,
-	producerLabels map[string]string) {
+	producerLabels map[string]string,
+) {
 	output := v1beta1.Output{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "http",

--- a/e2e/common/panicobject.go
+++ b/e2e/common/panicobject.go
@@ -38,96 +38,127 @@ var _ metav1.Object = (*PanicObject)(nil)
 func (*PanicObject) GetNamespace() string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetNamespace(namespace string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetName() string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetName(name string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetGenerateName() string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetGenerateName(name string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetUID() types.UID {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetUID(uid types.UID) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetResourceVersion() string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetResourceVersion(version string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetGeneration() int64 {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetGeneration(generation int64) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetSelfLink() string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetSelfLink(selfLink string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetCreationTimestamp() metav1.Time {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetCreationTimestamp(timestamp metav1.Time) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetDeletionTimestamp() *metav1.Time {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetDeletionTimestamp(timestamp *metav1.Time) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetDeletionGracePeriodSeconds() *int64 {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetDeletionGracePeriodSeconds(*int64) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetLabels() map[string]string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetLabels(labels map[string]string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetAnnotations() map[string]string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetAnnotations(annotations map[string]string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetFinalizers() []string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetFinalizers(finalizers []string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetOwnerReferences() []metav1.OwnerReference {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetOwnerReferences([]metav1.OwnerReference) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetZZZ_DeprecatedClusterName() string {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetZZZ_DeprecatedClusterName(clusterName string) {
 	panic("not implemented")
 }
+
 func (*PanicObject) GetManagedFields() []metav1.ManagedFieldsEntry {
 	panic("not implemented")
 }
+
 func (*PanicObject) SetManagedFields(managedFields []metav1.ManagedFieldsEntry) {
 	panic("not implemented")
 }

--- a/e2e/common/setup/loggingoperator.go
+++ b/e2e/common/setup/loggingoperator.go
@@ -90,10 +90,9 @@ func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOpti
 	}
 	actionConfig := new(action.Configuration)
 
-	err = actionConfig.Init(restClientGetter, opt.Namespace, "memory", func(format string, v ...interface{}) {
+	if err := actionConfig.Init(restClientGetter, opt.Namespace, "memory", func(format string, v ...interface{}) {
 		t.Logf(format, v...)
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("helm action config init: %s", err)
 	}
 

--- a/e2e/common/setup/loggingoperator.go
+++ b/e2e/common/setup/loggingoperator.go
@@ -29,40 +29,38 @@ import (
 	"github.com/kube-logging/logging-operator/e2e/common"
 )
 
-var (
-	defaultImages = []e2eImage{
-		{
-			lookupEnv:  "LOGGING_OPERATOR_IMAGE",
-			repository: "controller",
-			tag:        "local",
-		},
-		{
-			lookupEnv:  "CONFIG_RELOADER_IMAGE",
-			repository: "config-reloader",
-			tag:        "local",
-		},
-		{
-			lookupEnv:  "SYSLOG_NG_RELOADER_IMAGE",
-			repository: "syslogng-reload",
-			tag:        "local",
-		},
-		{
-			lookupEnv:  "FLUENTD_DRAIN_WATCH_IMAGE",
-			repository: "fluentd-drain-watch",
-			tag:        "local",
-		},
-		{
-			lookupEnv:  "NODE_EXPORTER_IMAGE",
-			repository: "node-exporter",
-			tag:        "local",
-		},
-		{
-			lookupEnv:  "FLUENTD_IMAGE",
-			repository: "fluentd-full",
-			tag:        "local",
-		},
-	}
-)
+var defaultImages = []e2eImage{
+	{
+		lookupEnv:  "LOGGING_OPERATOR_IMAGE",
+		repository: "controller",
+		tag:        "local",
+	},
+	{
+		lookupEnv:  "CONFIG_RELOADER_IMAGE",
+		repository: "config-reloader",
+		tag:        "local",
+	},
+	{
+		lookupEnv:  "SYSLOG_NG_RELOADER_IMAGE",
+		repository: "syslogng-reload",
+		tag:        "local",
+	},
+	{
+		lookupEnv:  "FLUENTD_DRAIN_WATCH_IMAGE",
+		repository: "fluentd-drain-watch",
+		tag:        "local",
+	},
+	{
+		lookupEnv:  "NODE_EXPORTER_IMAGE",
+		repository: "node-exporter",
+		tag:        "local",
+	},
+	{
+		lookupEnv:  "FLUENTD_IMAGE",
+		repository: "fluentd-full",
+		tag:        "local",
+	},
+}
 
 type e2eImage struct {
 	lookupEnv  string
@@ -75,7 +73,6 @@ func (i e2eImage) Format() string {
 }
 
 func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOption) {
-
 	opt := &LoggingOperatorOptions{
 		Namespace:    "default",
 		NameOverride: "logging-operator",

--- a/e2e/common/setup/loggingoperator.go
+++ b/e2e/common/setup/loggingoperator.go
@@ -111,7 +111,7 @@ func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOpti
 		projectDir = "../.."
 	}
 
-	cp, err := installer.ChartPathOptions.LocateChart(fmt.Sprintf("%s/charts/logging-operator", projectDir), cli.New())
+	cp, err := installer.LocateChart(fmt.Sprintf("%s/charts/logging-operator", projectDir), cli.New())
 	if err != nil {
 		t.Fatalf("helm locate chart: %s", err)
 	}

--- a/e2e/common/setup/loggingoperator.go
+++ b/e2e/common/setup/loggingoperator.go
@@ -96,6 +96,9 @@ func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOpti
 	err = actionConfig.Init(restClientGetter, opt.Namespace, "memory", func(format string, v ...interface{}) {
 		t.Logf(format, v...)
 	})
+	if err != nil {
+		t.Fatalf("helm action config init: %s", err)
+	}
 
 	installer := action.NewInstall(actionConfig)
 

--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -55,7 +55,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -727,7 +727,6 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 			t.Logf("ES9 document count: %s", count)
 			return count != "" && count != "0"
 		}, 3*time.Minute, 10*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
@@ -747,7 +746,6 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 			t.Logf("Failed collecting coverage files: %s", err)
 		}
 		return err
-
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()

--- a/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
+++ b/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
@@ -53,18 +53,21 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
 }
 
-var tags = "time"
-var realTimeBuffer = &output.Buffer{
-	Tags:        &tags,
-	Timekey:     "1s",
-	TimekeyWait: "0s",
-}
+var (
+	tags           = "time"
+	realTimeBuffer = &output.Buffer{
+		Tags:        &tags,
+		Timekey:     "1s",
+		TimekeyWait: "0s",
+	}
+)
+
 var producerLabels = map[string]string{
 	"my-unique-label": "log-producer",
 }
@@ -218,7 +221,6 @@ func TestFluentbitAgentDedicatedNamespace(t *testing.T) {
 			t.Logf("log consumer logs: %s", rawOut)
 			return strings.Contains(string(rawOut), tag)
 		}, 5*time.Minute, 3*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
+++ b/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
@@ -54,18 +54,21 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
 }
 
-var tags = "time"
-var realTimeBuffer = &output.Buffer{
-	Tags:        &tags,
-	Timekey:     "1s",
-	TimekeyWait: "0s",
-}
+var (
+	tags           = "time"
+	realTimeBuffer = &output.Buffer{
+		Tags:        &tags,
+		Timekey:     "1s",
+		TimekeyWait: "0s",
+	}
+)
+
 var producerLabels = map[string]string{
 	"my-unique-label": "log-producer",
 }
@@ -169,7 +172,6 @@ func TestFluentbitHotReload(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, int64(1), ds.Generation, "generation should not be incremented for a reloadable agent")
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -52,18 +52,21 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
 }
 
-var tags = "time"
-var realTimeBuffer = &output.Buffer{
-	Tags:        &tags,
-	Timekey:     "1s",
-	TimekeyWait: "0s",
-}
+var (
+	tags           = "time"
+	realTimeBuffer = &output.Buffer{
+		Tags:        &tags,
+		Timekey:     "1s",
+		TimekeyWait: "0s",
+	}
+)
+
 var producerLabels = map[string]string{
 	"my-unique-label": "log-producer",
 }
@@ -139,7 +142,6 @@ func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
 			t.Logf("log consumer logs: %s", rawOut)
 			return strings.Contains(string(rawOut), tagTenant) && strings.Contains(string(rawOut), tagInfra)
 		}, 5*time.Minute, 3*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
+++ b/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
@@ -33,12 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
-
 	"github.com/kube-logging/logging-operator/e2e/common"
 	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
 var TestTempDirUnnamed string
@@ -50,7 +49,7 @@ func init() {
 		TestTempDirUnnamed = "../.."
 	}
 	TestTempDirUnnamed = filepath.Join(TestTempDirUnnamed, "build/_test")
-	err := os.MkdirAll(TestTempDirUnnamed, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDirUnnamed, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -244,7 +243,6 @@ func TestFluentdAggregator_detached_multiple_failure(t *testing.T) {
 			}
 			return true
 		}, 5*time.Minute, 3*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDirUnnamed, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
+++ b/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
@@ -54,7 +54,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -292,7 +292,6 @@ func TestFluentdAggregator_detached_MultiWorker(t *testing.T) {
 			t.Logf("log consumer logs: %s", rawOut)
 			return strings.Contains(string(rawOut), testTag)
 		}, 5*time.Minute, 3*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -53,7 +53,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -223,7 +223,6 @@ func TestFluentdAggregator_NamespaceLabel(t *testing.T) {
 			t.Logf("log consumer logs: %s", rawOut)
 			return strings.Contains(string(rawOut), testTag)
 		}, 5*time.Minute, 3*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -48,6 +48,8 @@ import (
 
 var TestTempDir string
 
+var configCheckFailure = regexp.MustCompile(`^Configuration with checksum (.+) has failed. .*`)
+
 func init() {
 	var ok bool
 	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
@@ -408,9 +410,7 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 			common.RequireNoError(t, c.GetClient().Get(ctx, utils.ObjectKeyFromObjectMeta(&logging), &logging))
 			if logging.Status.ProblemsCount > 0 {
 				for _, problem := range logging.Status.Problems {
-					match, err := regexp.MatchString(`^Configuration with checksum (.+) has failed. .*`, problem)
-					common.RequireNoError(t, err)
-					if match {
+					if configCheckFailure.MatchString(problem) {
 						t.Logf("Found the problem in Logging status: %v", logging.Status)
 						return true
 					}
@@ -428,9 +428,7 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 			common.RequireNoError(t, c.GetClient().Get(ctx, utils.ObjectKeyFromObjectMeta(&logging), &logging))
 			if logging.Status.ProblemsCount > 0 {
 				for _, problem := range logging.Status.Problems {
-					match, err := regexp.MatchString(`^Configuration with checksum (.+) has failed. .*`, problem)
-					common.RequireNoError(t, err)
-					if match {
+					if configCheckFailure.MatchString(problem) {
 						t.Logf("Waiting for the problem to be cleared in Logging status: %v", logging.Status.Problems)
 						return false
 					}

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -57,7 +57,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -222,7 +222,6 @@ func TestFluentdAggregator_MultiWorker(t *testing.T) {
 			t.Logf("log consumer logs: %s", rawOut)
 			return strings.Contains(string(rawOut), testTag)
 		}, 5*time.Minute, 3*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
@@ -255,6 +254,7 @@ func TestFluentdAggregator_MultiWorker(t *testing.T) {
 		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
 	})
 }
+
 func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 	common.Initialize(t)
 	ns := "testing-2"
@@ -457,6 +457,7 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
 	})
 }
+
 func TestFluentdAggregator_ConfigChecks_DryRunWhenReadOnlyRootFilesystemIsConfigured(t *testing.T) {
 	common.Initialize(t)
 	ns := "testing-3"
@@ -644,6 +645,7 @@ func TestFluentdAggregator_ConfigChecks_DryRunWhenReadOnlyRootFilesystemIsConfig
 		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
 	})
 }
+
 func TestFluentdAggregator_ConfigChecks_StartWithTimeoutWhenReadOnlyRootFilesystemIsConfigured(t *testing.T) {
 	common.Initialize(t)
 	ns := "testing-3"

--- a/e2e/logging_metrics_monitoring/logging_metrics_monitoring_test.go
+++ b/e2e/logging_metrics_monitoring/logging_metrics_monitoring_test.go
@@ -35,11 +35,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
-	"sigs.k8s.io/e2e-framework/third_party/helm"
 )
 
 type metricsTester struct {
@@ -97,7 +97,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -283,7 +283,6 @@ func TestLoggingMetrics_Monitoring(t *testing.T) {
 
 		serviceMonitors := append(serviceMonitorsFluentd.Items, serviceMonitorsSyslogNG.Items...)
 		common.RequireNoError(t, checkServiceMonitorAvailability(serviceMonitors))
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
@@ -303,7 +302,6 @@ func TestLoggingMetrics_Monitoring(t *testing.T) {
 			t.Logf("Failed collecting coverage files: %s", err)
 		}
 		return err
-
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()
@@ -361,7 +359,7 @@ func checkServiceMonitorAvailability(serviceMonitors []v1.ServiceMonitor) error 
 		return errors.New("no service monitors found")
 	}
 
-	var expectedServiceMonitors = map[string]bool{
+	expectedServiceMonitors := map[string]bool{
 		fluentbitServiceName:              false,
 		fluentbitBufferMetricsServiceName: false,
 		syslogNGServiceName:               false,

--- a/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
+++ b/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
@@ -57,7 +57,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -327,7 +327,6 @@ func TestSyslogNGDetachedIsRunningAndForwardingLogs(t *testing.T) {
 			t.Logf("log consumer logs: %s", rawOut)
 			return strings.Contains(string(rawOut), testTag)
 		}, 5*time.Minute, 2*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
+++ b/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
@@ -56,7 +56,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -235,7 +235,6 @@ func TestSyslogNGIsRunningAndForwardingLogs(t *testing.T) {
 			t.Logf("log consumer logs: %s", rawOut)
 			return strings.Contains(string(rawOut), testTag)
 		}, 5*time.Minute, 2*time.Second)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/volumedrain/volumedrain_test.go
+++ b/e2e/volumedrain/volumedrain_test.go
@@ -54,7 +54,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/watch-selector/watch_selector_test.go
+++ b/e2e/watch-selector/watch_selector_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +38,6 @@ import (
 	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
-	"github.com/stretchr/testify/require"
 )
 
 var TestTempDir string
@@ -49,7 +49,7 @@ func init() {
 		TestTempDir = "../.."
 	}
 	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0755))
+	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
 	}
@@ -171,7 +171,6 @@ func TestWatchSelectors(t *testing.T) {
 		common.RequireNoError(t, c.GetClient().Get(ctx, client.ObjectKeyFromObject(unmanagedSecret), secret))
 		secretOwnerRefMeta = metav1.GetControllerOf(secret)
 		require.Nil(t, secretOwnerRefMeta)
-
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
@@ -191,7 +190,6 @@ func TestWatchSelectors(t *testing.T) {
 			t.Logf("Failed collecting coverage files: %s", err)
 		}
 		return err
-
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()


### PR DESCRIPTION
Part of #2291, and independent of it — this stands on its own whether or not the restructure proposed there goes ahead.

`e2e` is a separate Go module, so the existing `make lint` — which covers the repo root and `pkg/sdk` — has never linted it. This adds it, and fixes everything that surfaces.

Enabling and fixing have to be one change: `make lint` is what CI runs at `.github/workflows/ci.yaml:53`, so turning the module on without clearing the backlog would just make CI red.

### The one finding that is not style

`e2e/common/setup/loggingoperator.go:96` assigned the error from `actionConfig.Init(...)` and never checked it:

```go
err = actionConfig.Init(restClientGetter, opt.Namespace, "memory", func(...) {...})

installer := action.NewInstall(actionConfig)          // err never checked
...
cp, err := installer.LocateChart(...)                 // err overwritten here
```

`err` is reassigned fifteen lines later by `LocateChart`, so a failed helm action-config init was silently discarded and every e2e run proceeded to install the chart through a half-initialized `action.Configuration`. `ineffassign` is the only reason this was visible at all, which is a fair argument for the rest of the change. It gets its own commit.

### How many findings there actually are

45, on `master` @ `a252292c`:

| linter | count |
|---|---|
| `gofumpt` | 18 |
| `whitespace` | 16 |
| `gci` | 4 |
| `staticcheck` | 3 |
| `goimports` | 2 |
| `errcheck` | 1 |
| `ineffassign` | 1 |

Worth knowing before anyone tries to reproduce that: **`golangci-lint run` prints only 12 of the 45 by default.** `max-same-issues` defaults to 3 and applies per unique message text; `gci`, `gofumpt` and `goimports` all emit the identical string "File is not properly formatted", so 24 findings collapse into 3 printed lines, and `whitespace`'s 16 collapse into 4. Fixing the visible 12 only uncovers the next batch — I did that first and had to go round again. The full list needs:

```bash
cd e2e && golangci-lint run --max-same-issues=0 --max-issues-per-linter=0
```

This also means issue #2287's "currently has 8 findings" was wrong twice over; I've corrected it there.

### Commits

| | |
|---|---|
| `fix(e2e): check the error returned by the helm action config init` | the bug above |
| `fix(e2e): report the log file close error from PrintLogs` | `errcheck` — the deferred `Close` on stern's output file dropped its error, so a truncated cluster log dump looked like a successful one |
| `refactor(e2e): precompile the config check pattern, drop a redundant selector` | `staticcheck` — `regexp.MatchString` recompiled the same pattern on every iteration of two `Eventually` loops (SA6000); `ChartPathOptions` is embedded in `action.Install`, so naming it was redundant (QF1008) |
| `chore(e2e): format the module with gofumpt, gci and goimports` | the 40 formatter and whitespace findings |
| `build(e2e): run the linter on the e2e module` | the `Makefile` change, in `lint` and `lint-fix` both |

The formatting commit is mechanical and carries no behaviour change: octal literals gain the `0o` prefix, `github.com/kube-logging/...` imports move into their own `gci` group, and `gofumpt` adds the blank lines and trailing commas it wants. I ran the formatter against the specific files the linter flagged rather than across the module, so nothing outside the reported set is touched — 18 files, all of them ones with findings.

### Verification

`make check` (`license-check lint test`) passes.

No new findings introduced — unmodified `master` checked out in a separate worktree, same command both sides:

```
BEFORE (master @ a252292c): 45 findings
AFTER  (this branch):        0 findings
findings present after but not before: none
```

`make lint` now covers all three modules and is clean:

```
$ make lint
bin/golangci-lint run --timeout 10m
0 issues.
cd pkg/sdk && bin/golangci-lint run --timeout 10m
0 issues.
cd e2e && bin/golangci-lint run --timeout 10m
0 issues.
```

Measured with the pinned linter, `golangci-lint 2.12.2` (`Makefile:11`), on Go 1.26.5.

### Scope

Lint enablement and the findings it reports, nothing else. No test behaviour changes, no restructuring. The `e2e` module has other problems — `t.FailNow()` called from a non-test goroutine at 15 sites, three `30*time.Minute` waits sitting under a 20-minute package timeout, and an inconsistent coverage-collection policy — but those are separate fixes and I have written them up in #2291 rather than folding them in here.
