### PR TITLE
fix(e2e): derive the elasticsearch readiness budget from the test deadline

### DIFF
--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -46,6 +46,15 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
+const (
+	// esReadyFallback applies when the binary has no deadline to derive from.
+	esReadyFallback = 15 * time.Minute
+
+	// esReadyMargin is the room left before the deadline for the wait to report
+	// its own failure. It does not cover teardown, which can outlast it.
+	esReadyMargin = 30 * time.Second
+)
+
 var TestTempDir string
 
 func init() {
@@ -58,6 +67,44 @@ func init() {
 	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
 	if err != nil {
 		panic(err)
+	}
+}
+
+// esReadyBudget caps a wait strictly below the enclosing -timeout, so an
+// Elasticsearch deployment that never becomes ready fails by name instead of
+// letting the package binary panic and report only a goroutine dump.
+func esReadyBudget(t *testing.T) time.Duration {
+	deadline, ok := t.Deadline()
+	if !ok {
+		return esReadyFallback
+	}
+	return budgetWithin(time.Until(deadline))
+}
+
+// budgetWithin never returns a non-positive duration: require.Eventually treats
+// one as already expired, which would fail every run instead of only stalled ones.
+func budgetWithin(remaining time.Duration) time.Duration {
+	if budget := remaining - esReadyMargin; budget > 0 {
+		return budget
+	}
+	return time.Second
+}
+
+func TestBudgetWithin(t *testing.T) {
+	for _, c := range []struct {
+		name      string
+		remaining time.Duration
+		want      time.Duration
+	}{
+		{"ample", 20 * time.Minute, 20*time.Minute - esReadyMargin},
+		{"just above the margin", esReadyMargin + time.Second, time.Second},
+		{"exactly the margin", esReadyMargin, time.Second},
+		{"already past the deadline", -time.Minute, time.Second},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, budgetWithin(c.remaining))
+			require.Positive(t, budgetWithin(c.remaining))
+		})
 	}
 }
 
@@ -442,17 +489,17 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 		t.Log("Waiting for Elasticsearch 7 deployment to be ready...")
 		require.Eventually(t, func() bool {
 			return cond.DeploymentAvailable(t, c.GetClient(), &ctx, ns, "elasticsearch7")()
-		}, 30*time.Minute, 10*time.Second)
+		}, esReadyBudget(t), 10*time.Second)
 
 		t.Log("Waiting for Elasticsearch 8 deployment to be ready...")
 		require.Eventually(t, func() bool {
 			return cond.DeploymentAvailable(t, c.GetClient(), &ctx, ns, "elasticsearch8")()
-		}, 30*time.Minute, 10*time.Second)
+		}, esReadyBudget(t), 10*time.Second)
 
 		t.Log("Waiting for Elasticsearch 9 deployment to be ready...")
 		require.Eventually(t, func() bool {
 			return cond.DeploymentAvailable(t, c.GetClient(), &ctx, ns, "elasticsearch9")()
-		}, 30*time.Minute, 10*time.Second)
+		}, esReadyBudget(t), 10*time.Second)
 
 		logging := v1beta1.Logging{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Part of #2291 (bug 3), and independent of the restructure proposed there.

The three Elasticsearch readiness waits in `elasticsearch-multiversion` each allow `30*time.Minute`. The package runs under `-timeout 20m` (`E2E_TEST_TIMEOUT`, `Makefile:55`, applied at `Makefile:243`), so those ceilings can never be reached — the binary panics first. The "give up and say which deployment never became ready" path is unreachable.

This is not theoretical. It fired on the CI run for #2292 two hours before this PR: `TestElasticsearch_MultiVersion` polled `elasticsearch8: 0/1 replicas ready` about 105 times and then produced

```
panic: test timed out after 20m0s
	running tests:
		TestElasticsearch_MultiVersion (20m0s)
```

— a goroutine dump instead of a diagnosis. (The underlying stall that run was #2287's `kind load` contention, which is a separate problem; the point here is only that the suite could not report it.)

### Why not simply a smaller constant

That is what I tried first, and the numbers say it is wrong. Elasticsearch readiness is highly variable. Counting the 10-second poll lines in three green runs on `master`:

| run | ES package | es7 | es8 | es9 |
|---|---|---|---|---|
| [30358685184](https://github.com/kube-logging/logging-operator/actions/runs/30358685184) | 597 s | 80 s | 330 s | 0 s |
| [30353824896](https://github.com/kube-logging/logging-operator/actions/runs/30353824896) | 1024 s | 680 s | 190 s | 0 s |
| [30419254071](https://github.com/kube-logging/logging-operator/actions/runs/30419254071) | 992 s | 840 s | 0 s | 0 s |

The worst single wait observed is 840 s against a 1200 s package ceiling, and the package as a whole has used up to 1024 s of it. A round number like `10*time.Minute` would have failed two of those three runs. Any constant is either still unreachable or liable to cut a run that would have passed.

### What this does instead

Derives the budget from the enclosing deadline, the same idea `common/kind` already uses for `kind` invocations — "a cap strictly below enclosing, so a stall is cut while there is still budget left to clean up and name it":

```go
func esReadyBudget(t *testing.T) time.Duration {
	deadline, ok := t.Deadline()
	if !ok {
		return esReadyFallback
	}
	return budgetWithin(time.Until(deadline))
}
```

A run that would have passed still passes — the budget only shrinks by the 30 s margin. A run that would have panicked now fails with `Condition never satisfied` naming the deployment, before the binary dies.

To be precise about what the margin buys: it is enough for the wait to report its own failure, not enough to guarantee teardown finishes. Cluster deletion can outlast it and the binary may still be killed during cleanup. That is no worse than today, where nothing gets to run at all.

`budgetWithin` is split out from the clock so the arithmetic is unit-testable, and it never returns a non-positive duration — `require.Eventually` treats one as already expired, which would fail every run rather than only stalled ones. `TestBudgetWithin` covers that; with the guard removed it fails on the `exactly the margin` and `already past the deadline` cases.

Note that `TestBudgetWithin` is a pure unit test but lives in a suite package, so `make test` (which selects `./common/...`) does not pick it up — it runs as part of the e2e job and locally. Fixing that selector is #2291's §5.9 territory, not this PR.

### Verification

`make check` passes.

```
$ cd e2e && go test ./elasticsearch-multiversion/... -run TestBudgetWithin -v
--- PASS: TestBudgetWithin (0.00s)
    --- PASS: TestBudgetWithin/ample
    --- PASS: TestBudgetWithin/just_above_the_margin
    --- PASS: TestBudgetWithin/exactly_the_margin
    --- PASS: TestBudgetWithin/already_past_the_deadline
```

`golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` in `e2e/` reports 0 issues.

### Scope

One file, +50/−3. Only the three unreachable 30-minute waits change; the suite's other budgets (one 5 m, three 3 m) are all reachable under the 20 m ceiling and are left alone. No change to what the test asserts.
