### PR TITLE
fix(e2e): call LogProducer on the test goroutine

### DIFF
--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -707,7 +707,7 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 			types.NameLabel: releaseNameOverride,
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))

--- a/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
+++ b/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
@@ -174,7 +174,7 @@ func TestFluentbitAgentDedicatedNamespace(t *testing.T) {
 		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
 
 		// Start a log producer in the default namespace
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = "default"
 			options.Labels = producerLabels
 		}))

--- a/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
+++ b/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
@@ -107,7 +107,7 @@ func TestFluentbitHotReload(t *testing.T) {
 		}
 
 		// start log producer in the tenant namespace
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = nsTenant
 			options.Labels = producerLabels
 		}))

--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -106,7 +106,7 @@ func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
 		}
 
 		// start log producer in the tenant namespace
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = nsTenant
 			options.Labels = producerLabels
 		}))

--- a/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
+++ b/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
@@ -229,7 +229,7 @@ func TestFluentdAggregator_detached_multiple_failure(t *testing.T) {
 		}
 		common.RequireNoError(t, c.GetClient().Create(ctx, &flow))
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))

--- a/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
+++ b/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
@@ -240,7 +240,7 @@ func TestFluentdAggregator_detached_MultiWorker(t *testing.T) {
 			types.NameLabel: releaseNameOverride,
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -192,7 +192,7 @@ func TestFluentdAggregator_NamespaceLabel(t *testing.T) {
 			"my-unique-label": "log-producer",
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = labeledNamespaceName
 			options.Labels = producerLabels
 		}))

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -191,7 +191,7 @@ func TestFluentdAggregator_MultiWorker(t *testing.T) {
 			types.NameLabel: releaseNameOverride,
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))
@@ -380,7 +380,7 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 			types.NameLabel: releaseNameOverride,
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))
@@ -596,7 +596,7 @@ func TestFluentdAggregator_ConfigChecks_DryRunWhenReadOnlyRootFilesystemIsConfig
 			types.NameLabel: releaseNameOverride,
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))
@@ -785,7 +785,7 @@ func TestFluentdAggregator_ConfigChecks_StartWithTimeoutWhenReadOnlyRootFilesyst
 			types.NameLabel: releaseNameOverride,
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))

--- a/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
+++ b/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
@@ -274,7 +274,7 @@ func TestSyslogNGDetachedIsRunningAndForwardingLogs(t *testing.T) {
 		producerLabels := map[string]string{
 			"my-unique-label": "log-producer",
 		}
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))

--- a/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
+++ b/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
@@ -204,7 +204,7 @@ func TestSyslogNGIsRunningAndForwardingLogs(t *testing.T) {
 		producerLabels := map[string]string{
 			"my-unique-label": "log-producer",
 		}
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))

--- a/e2e/volumedrain/volumedrain_test.go
+++ b/e2e/volumedrain/volumedrain_test.go
@@ -187,7 +187,7 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 			types.NameLabel: releaseNameOverride,
 		}
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))
@@ -428,7 +428,7 @@ func TestVolumeDrain_Downscale_DeleteVolume(t *testing.T) {
 
 		fluentdReplicaName := logging.Name + "-fluentd-1"
 
-		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
+		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
 			options.Namespace = ns
 			options.Labels = producerLabels
 		}))


### PR DESCRIPTION
Part of #2291 (bug 2), and independent of the restructure proposed there.

`setup.LogProducer` is called as `go setup.LogProducer(t, ...)` at 15 sites across 11 suites. It ends with

```go
common.RequireNoError(t, c.Create(context.Background(), &logProducerConfig))
common.RequireNoError(t, c.Create(context.Background(), &logProducerDeployment))
```

and `common.RequireNoError` (`common/helpers.go:53-58`) calls `t.FailNow()`. The `testing` documentation is explicit that `FailNow` must be called from the goroutine running the test, not from ones created during it.

What that costs in practice: if either `Create` fails, the failure is not reported where it happened. The test carries on, and dies some minutes later at a `require.Eventually` waiting for a pod that was never going to appear — pointing at the wrong thing. The actual error is lost.

There was never anything to gain from the goroutine. `LogProducer` builds two objects and issues two `Create` calls; it does not block or poll. Calling it synchronously also closes a smaller race, where the `Eventually` that follows could begin before the Deployment existed.

### Why `go vet` does not catch this

Worth recording, because it is the obvious question. The `testinggoroutine` analyzer reports `t.Fatal`/`t.FailNow` reached from a goroutine started by a test, but only when it can see the call. Here it sees `go setup.LogProducer(t, ...)`, and the `FailNow` is two calls deep and in another package. On unmodified `master`:

```
$ cd e2e && go vet ./volumedrain/... ./fluentd-aggregator/...
$ echo $?
0
```

Clean, with the bug present. `make lint` is equally clean, so nothing in CI would have flagged it.

### The change

Removing `go ` from the 15 call sites. Fifteen identical one-line edits, +15 −15 across 11 files.

### What I deliberately did not do

#2291 sketches this helper eventually returning an `error` rather than failing the test itself. I have not changed the signature here, for two reasons: removing the goroutine is by itself a complete fix for the undefined behaviour, and `LogProducer`'s sibling in the same package, `setup.LoggingOperator(t, c, ...)`, also takes `t` and fails internally — so changing one and not the other would leave the package inconsistent for no gain. The signature belongs with the harness work in #2291, where both move together.

### Verification

`make check` passes. `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` in `e2e/` reports 0 issues.

The diff is uniform — every changed line is the same edit:

```
$ git diff master | grep -E "^[+-][^+-]" | sort | uniq -c
     15 -		go setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
     15 +		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
```

### Scope

11 files, +15 −15. No signature change, no change to what any test asserts.
