### PR TITLE
fix(e2e): make coverage collection uniform and cover every cluster

### DIFF
--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -792,7 +792,8 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 		if err != nil {
 			t.Logf("Failed collecting coverage files: %s", err)
 		}
-		return err
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -226,11 +226,23 @@ func TestFluentdAggregator_NamespaceLabel(t *testing.T) {
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
-		return c.PrintLogs(common.PrintLogConfig{
+		err := c.PrintLogs(common.PrintLogConfig{
 			Namespaces: []string{ns, "default"},
 			FilePath:   path,
 			Limit:      100 * 1000,
 		})
+		if err != nil {
+			return err
+		}
+
+		loggingOperatorName := "logging-operator-" + releaseNameOverride
+		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
+		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
+		if err != nil {
+			t.Logf("Failed collecting coverage files: %s", err)
+		}
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -440,11 +440,23 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
-		return c.PrintLogs(common.PrintLogConfig{
+		err := c.PrintLogs(common.PrintLogConfig{
 			Namespaces: []string{ns, "default"},
 			FilePath:   path,
 			Limit:      100 * 1000,
 		})
+		if err != nil {
+			return err
+		}
+
+		loggingOperatorName := "logging-operator-" + releaseNameOverride
+		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
+		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
+		if err != nil {
+			t.Logf("Failed collecting coverage files: %s", err)
+		}
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()
@@ -628,11 +640,23 @@ func TestFluentdAggregator_ConfigChecks_DryRunWhenReadOnlyRootFilesystemIsConfig
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
-		return c.PrintLogs(common.PrintLogConfig{
+		err := c.PrintLogs(common.PrintLogConfig{
 			Namespaces: []string{ns, "default"},
 			FilePath:   path,
 			Limit:      100 * 1000,
 		})
+		if err != nil {
+			return err
+		}
+
+		loggingOperatorName := "logging-operator-" + releaseNameOverride
+		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
+		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
+		if err != nil {
+			t.Logf("Failed collecting coverage files: %s", err)
+		}
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()
@@ -817,11 +841,23 @@ func TestFluentdAggregator_ConfigChecks_StartWithTimeoutWhenReadOnlyRootFilesyst
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
-		return c.PrintLogs(common.PrintLogConfig{
+		err := c.PrintLogs(common.PrintLogConfig{
 			Namespaces: []string{ns, "default"},
 			FilePath:   path,
 			Limit:      100 * 1000,
 		})
+		if err != nil {
+			return err
+		}
+
+		loggingOperatorName := "logging-operator-" + releaseNameOverride
+		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
+		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
+		if err != nil {
+			t.Logf("Failed collecting coverage files: %s", err)
+		}
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()

--- a/e2e/logging_metrics_monitoring/logging_metrics_monitoring_test.go
+++ b/e2e/logging_metrics_monitoring/logging_metrics_monitoring_test.go
@@ -301,7 +301,8 @@ func TestLoggingMetrics_Monitoring(t *testing.T) {
 		if err != nil {
 			t.Logf("Failed collecting coverage files: %s", err)
 		}
-		return err
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()

--- a/e2e/volumedrain/volumedrain_test.go
+++ b/e2e/volumedrain/volumedrain_test.go
@@ -503,11 +503,23 @@ func TestVolumeDrain_Downscale_DeleteVolume(t *testing.T) {
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)
-		return c.PrintLogs(common.PrintLogConfig{
+		err := c.PrintLogs(common.PrintLogConfig{
 			Namespaces: []string{ns, "default"},
 			FilePath:   path,
 			Limit:      100 * 1000,
 		})
+		if err != nil {
+			return err
+		}
+
+		loggingOperatorName := "logging-operator-" + releaseNameOverride
+		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
+		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
+		if err != nil {
+			t.Logf("Failed collecting coverage files: %s", err)
+		}
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()

--- a/e2e/watch-selector/watch_selector_test.go
+++ b/e2e/watch-selector/watch_selector_test.go
@@ -189,7 +189,8 @@ func TestWatchSelectors(t *testing.T) {
 		if err != nil {
 			t.Logf("Failed collecting coverage files: %s", err)
 		}
-		return err
+
+		return nil
 	}, func(o *cluster.Options) {
 		if o.Scheme == nil {
 			o.Scheme = runtime.NewScheme()


### PR DESCRIPTION
Part of #2291 (bug 4), and independent of the restructure proposed there. Last of the independent fixes.

Coverage collection in `beforeCleanup` was inconsistent in two ways.

### 1. Three suites failed tests that had already passed

`elasticsearch-multiversion`, `logging_metrics_monitoring` and `watch-selector` all did this:

```go
err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
if err != nil {
    t.Logf("Failed collecting coverage files: %s", err)
}
return err          // <- logged as non-fatal, then returned anyway
```

`WithCluster` wraps that in `assert.NoError`, so a coverage-collection error failed a test whose assertions had all passed, for a reason unrelated to what it was testing. The other nine suites already logged and continued. These three now match them.

### 2. Five of the seventeen clusters never collected at all

Only 12 of the 17 clusters had a collection call. The gaps were in the multi-cluster suites, where the pattern had been copied into the first `WithCluster` and not the others:

| suite | clusters | collected before |
|---|---|---|
| `fluentd-aggregator` | 4 | 1 |
| `volumedrain` | 2 | 1 |
| `fluentd-aggregator-namespacelabel` | 1 | 0 |
| the other ten | 1 each | 1 each |

So the reported e2e coverage figure was measuring 12 clusters while appearing to measure all of them.

**This will move the reported number.** Five clusters' worth of operator execution starts contributing that was previously discarded. I would expect it to rise, but I have not tried to predict by how much, and the change is in what gets measured rather than in what the operator does. Flagging it explicitly so it does not look like unexplained drift on the next coverage report.

After this, every cluster collects:

```
$ for d in e2e/*/; do ... done      # clusters vs collection calls, per suite
elasticsearch-multiversion            clusters=1 coverage=1
fluentbit-agent-namespace             clusters=1 coverage=1
fluentbit-hotreload                   clusters=1 coverage=1
fluentbit-multitenant                 clusters=1 coverage=1
fluentd-aggregator-detached-multiple-failures  clusters=1 coverage=1
fluentd-aggregator-detached           clusters=1 coverage=1
fluentd-aggregator-namespacelabel     clusters=1 coverage=1
fluentd-aggregator                    clusters=4 coverage=4
logging_metrics_monitoring            clusters=1 coverage=1
syslog-ng-aggregator-detached         clusters=1 coverage=1
syslog-ng-aggregator                  clusters=1 coverage=1
volumedrain                           clusters=2 coverage=2
watch-selector                        clusters=1 coverage=1
```

### Commits

| | |
|---|---|
| `fix(e2e): stop coverage collection failing an otherwise passing test` | the three `return err` sites |
| `test(e2e): collect coverage from every cluster` | the five missing collections |

They are separable: if you want only the first, the second can be dropped without touching it.

### Verification

`make check` passes. `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` in `e2e/` reports 0 issues. Both commits build independently.

The added blocks are the same log-and-continue shape already used by the other twelve, so there is one coverage policy in the module now rather than three.

### Scope

6 files, +71 −8. No change to what any test asserts — only to what happens in `beforeCleanup` after the assertions have run.
