### PR TITLE
refactor(e2e): move common/cond to internal/wait and take plain values

### DIFF
--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -39,8 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/filter"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
@@ -488,17 +488,17 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 
 		t.Log("Waiting for Elasticsearch 7 deployment to be ready...")
 		require.Eventually(t, func() bool {
-			return cond.DeploymentAvailable(t, c.GetClient(), &ctx, ns, "elasticsearch7")()
+			return wait.DeploymentAvailable(t, c.GetClient(), ctx, ns, "elasticsearch7")()
 		}, esReadyBudget(t), 10*time.Second)
 
 		t.Log("Waiting for Elasticsearch 8 deployment to be ready...")
 		require.Eventually(t, func() bool {
-			return cond.DeploymentAvailable(t, c.GetClient(), &ctx, ns, "elasticsearch8")()
+			return wait.DeploymentAvailable(t, c.GetClient(), ctx, ns, "elasticsearch8")()
 		}, esReadyBudget(t), 10*time.Second)
 
 		t.Log("Waiting for Elasticsearch 9 deployment to be ready...")
 		require.Eventually(t, func() bool {
-			return cond.DeploymentAvailable(t, c.GetClient(), &ctx, ns, "elasticsearch9")()
+			return wait.DeploymentAvailable(t, c.GetClient(), ctx, ns, "elasticsearch9")()
 		}, esReadyBudget(t), 10*time.Second)
 
 		logging := v1beta1.Logging{
@@ -714,15 +714,15 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 
 		t.Log("Waiting for components to be ready...")
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}

--- a/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
+++ b/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
@@ -38,8 +38,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	v1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -191,19 +191,19 @@ func TestFluentbitAgentDedicatedNamespace(t *testing.T) {
 		}
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsControl)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsControl)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator in control namespace")
 				return false
 			}
-			if fluentbitRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(fluentBitLabels), client.InNamespace(nsAgents)); !fluentbitRunning() {
+			if fluentbitRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(fluentBitLabels), client.InNamespace(nsAgents)); !fluentbitRunning() {
 				t.Log("waiting for the fluentbit daemonset in fluentbit agent namespace")
 				return false
 			}

--- a/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
+++ b/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
@@ -39,8 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -113,19 +113,19 @@ func TestFluentbitHotReload(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsInfra)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsInfra)); !aggregatorRunning() {
 				t.Log("waiting for the infra aggregator")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsTenant)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsTenant)); !aggregatorRunning() {
 				t.Log("waiting for the tenant aggregator")
 				return false
 			}

--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -37,8 +37,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -112,19 +112,19 @@ func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsInfra)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsInfra)); !aggregatorRunning() {
 				t.Log("waiting for the infra aggregator")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsTenant)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsTenant)); !aggregatorRunning() {
 				t.Log("waiting for the tenant aggregator")
 				return false
 			}

--- a/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
+++ b/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -235,10 +235,10 @@ func TestFluentdAggregator_detached_multiple_failure(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if rv := cond.CheckExcessFluentdStatus(t, &c, &ctx, &fluentd1); !rv {
+			if rv := wait.CheckExcessFluentdStatus(t, c.GetClient(), ctx, &fluentd1); !rv {
 				return false
 			}
-			if rv := cond.CheckExcessFluentdStatus(t, &c, &ctx, &fluentd2); !rv {
+			if rv := wait.CheckExcessFluentdStatus(t, c.GetClient(), ctx, &fluentd2); !rv {
 				return false
 			}
 			return true

--- a/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
+++ b/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
@@ -39,8 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -246,15 +246,15 @@ func TestFluentdAggregator_detached_MultiWorker(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}
@@ -263,7 +263,7 @@ func TestFluentdAggregator_detached_MultiWorker(t *testing.T) {
 				t.Logf("logging should use the detached fluentd configuration (name=%s), found: %v", fluentd.Name, logging.Status.FluentdConfigName)
 				return false
 			}
-			if isValid := cond.CheckFluentdStatus(t, &c, &ctx, &fluentd, logging.Name); !isValid {
+			if isValid := wait.CheckFluentdStatus(t, c.GetClient(), ctx, &fluentd, logging.Name); !isValid {
 				t.Log("checking detached fluentd status")
 				return false
 			}
@@ -274,7 +274,7 @@ func TestFluentdAggregator_detached_MultiWorker(t *testing.T) {
 				common.RequireNoError(t, c.GetClient().Create(ctx, &excessFluentd))
 				t.Log("creating excess detached fluentd")
 				return false
-			} else if isValid := cond.CheckExcessFluentdStatus(t, &c, &ctx, &excessFluentd); !isValid && len(detachedFluentds.Items) == 2 {
+			} else if isValid := wait.CheckExcessFluentdStatus(t, c.GetClient(), ctx, &excessFluentd); !isValid && len(detachedFluentds.Items) == 2 {
 				t.Log("checking excess detached fluentd status")
 				common.RequireNoError(t, c.GetClient().Get(ctx, utils.ObjectKeyFromObjectMeta(&excessFluentd), &excessFluentd))
 				return false

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -38,8 +38,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -198,15 +198,15 @@ func TestFluentdAggregator_NamespaceLabel(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -40,8 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -197,15 +197,15 @@ func TestFluentdAggregator_MultiWorker(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}
@@ -386,15 +386,15 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}
@@ -614,19 +614,19 @@ func TestFluentdAggregator_ConfigChecks_DryRunWhenReadOnlyRootFilesystemIsConfig
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if configCheckFinished := cond.AnyPodShouldBeFinished(t, c.GetClient(), client.MatchingLabels(configCheckLabels)); !configCheckFinished() {
+			if configCheckFinished := wait.AnyPodShouldBeFinished(t, c.GetClient(), client.MatchingLabels(configCheckLabels)); !configCheckFinished() {
 				t.Log("waiting for the config check")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}
@@ -815,19 +815,19 @@ func TestFluentdAggregator_ConfigChecks_StartWithTimeoutWhenReadOnlyRootFilesyst
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if configCheckFinished := cond.AnyPodShouldBeFinished(t, c.GetClient(), client.MatchingLabels(configCheckLabels)); !configCheckFinished() {
+			if configCheckFinished := wait.AnyPodShouldBeFinished(t, c.GetClient(), client.MatchingLabels(configCheckLabels)); !configCheckFinished() {
 				t.Log("waiting for the config check")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
+	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/e2e-framework v0.7.0
 )
@@ -145,7 +146,6 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260512234627-ef417d054102 // indirect
 	k8s.io/kubectl v0.36.1 // indirect
-	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/e2e/internal/wait/conditions.go
+++ b/e2e/internal/wait/conditions.go
@@ -16,12 +16,12 @@ package wait
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
@@ -102,22 +102,6 @@ func ResourceShouldBePresent(t *testing.T, cl client.Reader, obj client.Object) 
 	}
 }
 
-// activeIs reports whether Status.Active has been written and equals want. The
-// field is optional, so a nil pointer means the controller has not set it yet:
-// neither true nor false, and the caller should keep polling. Dereferencing it
-// blindly would panic on testify's condition goroutine and take the whole
-// package binary down with it.
-func activeIs(v *bool, want bool) bool { return v != nil && *v == want }
-
-// activeState renders Status.Active for logs, keeping "not written yet"
-// distinguishable from an explicit false.
-func activeState(v *bool) string {
-	if v == nil {
-		return "unset"
-	}
-	return strconv.FormatBool(*v)
-}
-
 // refresh re-reads obj so the next poll sees current status. A failed read is
 // logged and ignored on purpose: the caller is about to return false and be
 // retried, and these conditions run on testify's own goroutine, where failing
@@ -141,9 +125,9 @@ func CheckFluentdStatus(t *testing.T, cl client.Client, ctx context.Context, flu
 		t.Logf("%s should have it's logging field filled, found: %s, expect:%s", fluentdInstanceName, fluentd.Status.Logging, loggingName)
 		return false
 	}
-	if !activeIs(fluentd.Status.Active, true) {
+	if !ptr.Deref(fluentd.Status.Active, false) {
 		refresh(t, cl, ctx, fluentd)
-		t.Logf("%s should have it's active field set as true, found: %v", fluentdInstanceName, activeState(fluentd.Status.Active))
+		t.Logf("%s should have it's active field set as true", fluentdInstanceName)
 		return false
 	}
 
@@ -163,9 +147,9 @@ func CheckExcessFluentdStatus(t *testing.T, cl client.Client, ctx context.Contex
 		t.Logf("%s should have it's logging field empty, found: %s", fluentdInstanceName, fluentd.Status.Logging)
 		return false
 	}
-	if !activeIs(fluentd.Status.Active, false) {
+	if ptr.Deref(fluentd.Status.Active, true) {
 		refresh(t, cl, ctx, fluentd)
-		t.Logf("%s should have it's active field set as false, found: %v", fluentdInstanceName, activeState(fluentd.Status.Active))
+		t.Logf("%s should have it's active field set as false", fluentdInstanceName)
 		return false
 	}
 
@@ -185,9 +169,9 @@ func CheckSyslogNGStatus(t *testing.T, cl client.Client, ctx context.Context, sy
 		t.Logf("%s should have it's logging field filled, found: %s, expect:%s", instanceName, syslogNG.Status.Logging, loggingName)
 		return false
 	}
-	if !activeIs(syslogNG.Status.Active, true) {
+	if !ptr.Deref(syslogNG.Status.Active, false) {
 		refresh(t, cl, ctx, syslogNG)
-		t.Logf("%s should have it's active field set as true, found: %v", instanceName, activeState(syslogNG.Status.Active))
+		t.Logf("%s should have it's active field set as true", instanceName)
 		return false
 	}
 
@@ -207,9 +191,9 @@ func CheckExcessSyslogNGStatus(t *testing.T, cl client.Client, ctx context.Conte
 		t.Logf("%s should have it's logging field empty, found: %s", instanceName, syslogNG.Status.Logging)
 		return false
 	}
-	if !activeIs(syslogNG.Status.Active, false) {
+	if ptr.Deref(syslogNG.Status.Active, true) {
 		refresh(t, cl, ctx, syslogNG)
-		t.Logf("%s should have it's active field set as false, found: %v", instanceName, activeState(syslogNG.Status.Active))
+		t.Logf("%s should have it's active field set as false", instanceName)
 		return false
 	}
 

--- a/e2e/internal/wait/conditions.go
+++ b/e2e/internal/wait/conditions.go
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cond
+package wait
 
 import (
 	"context"
 	"testing"
 
-	"github.com/cisco-open/operator-tools/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kube-logging/logging-operator/e2e/common"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
@@ -103,22 +101,31 @@ func ResourceShouldBePresent(t *testing.T, cl client.Reader, obj client.Object) 
 	}
 }
 
-func CheckFluentdStatus(t *testing.T, c *common.Cluster, ctx *context.Context, fluentd *v1beta1.FluentdConfig, loggingName string) bool {
+// refresh re-reads obj so the next poll sees current status. A failed read is
+// logged and ignored on purpose: the caller is about to return false and be
+// retried, and these conditions run on testify's own goroutine, where failing
+// the test is undefined.
+func refresh(t *testing.T, cl client.Client, ctx context.Context, obj client.Object) {
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		t.Logf("could not refresh %s: %v", obj.GetName(), err)
+	}
+}
+
+func CheckFluentdStatus(t *testing.T, cl client.Client, ctx context.Context, fluentd *v1beta1.FluentdConfig, loggingName string) bool {
 	fluentdInstanceName := fluentd.Name
-	cluster := *c
 
 	if len(fluentd.Status.Problems) != 0 {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(fluentd), fluentd))
+		refresh(t, cl, ctx, fluentd)
 		t.Logf("%s should have 0 problems, problems=%v", fluentdInstanceName, fluentd.Status.Problems)
 		return false
 	}
 	if fluentd.Status.Logging != loggingName {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(fluentd), fluentd))
+		refresh(t, cl, ctx, fluentd)
 		t.Logf("%s should have it's logging field filled, found: %s, expect:%s", fluentdInstanceName, fluentd.Status.Logging, loggingName)
 		return false
 	}
 	if !*fluentd.Status.Active {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(fluentd), fluentd))
+		refresh(t, cl, ctx, fluentd)
 		t.Logf("%s should have it's active field set as true, found: %v", fluentdInstanceName, *fluentd.Status.Active)
 		return false
 	}
@@ -126,22 +133,21 @@ func CheckFluentdStatus(t *testing.T, c *common.Cluster, ctx *context.Context, f
 	return true
 }
 
-func CheckExcessFluentdStatus(t *testing.T, c *common.Cluster, ctx *context.Context, fluentd *v1beta1.FluentdConfig) bool {
+func CheckExcessFluentdStatus(t *testing.T, cl client.Client, ctx context.Context, fluentd *v1beta1.FluentdConfig) bool {
 	fluentdInstanceName := fluentd.Name
-	cluster := *c
 
 	if len(fluentd.Status.Problems) == 0 {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(fluentd), fluentd))
+		refresh(t, cl, ctx, fluentd)
 		t.Logf("%s should have it's problems field filled", fluentdInstanceName)
 		return false
 	}
 	if fluentd.Status.Logging != "" {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(fluentd), fluentd))
+		refresh(t, cl, ctx, fluentd)
 		t.Logf("%s should have it's logging field empty, found: %s", fluentdInstanceName, fluentd.Status.Logging)
 		return false
 	}
 	if *fluentd.Status.Active {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(fluentd), fluentd))
+		refresh(t, cl, ctx, fluentd)
 		t.Logf("%s should have it's active field set as false, found: %v", fluentdInstanceName, *fluentd.Status.Active)
 		return false
 	}
@@ -149,22 +155,21 @@ func CheckExcessFluentdStatus(t *testing.T, c *common.Cluster, ctx *context.Cont
 	return true
 }
 
-func CheckSyslogNGStatus(t *testing.T, c *common.Cluster, ctx *context.Context, syslogNG *v1beta1.SyslogNGConfig, loggingName string) bool {
+func CheckSyslogNGStatus(t *testing.T, cl client.Client, ctx context.Context, syslogNG *v1beta1.SyslogNGConfig, loggingName string) bool {
 	instanceName := syslogNG.Name
-	cluster := *c
 
 	if len(syslogNG.Status.Problems) != 0 {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(syslogNG), syslogNG))
+		refresh(t, cl, ctx, syslogNG)
 		t.Logf("%s should have 0 problems, problems=%v", instanceName, syslogNG.Status.Problems)
 		return false
 	}
 	if syslogNG.Status.Logging != loggingName {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(syslogNG), syslogNG))
+		refresh(t, cl, ctx, syslogNG)
 		t.Logf("%s should have it's logging field filled, found: %s, expect:%s", instanceName, syslogNG.Status.Logging, loggingName)
 		return false
 	}
 	if !*syslogNG.Status.Active {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(syslogNG), syslogNG))
+		refresh(t, cl, ctx, syslogNG)
 		t.Logf("%s should have it's active field set as true, found: %v", instanceName, *syslogNG.Status.Active)
 		return false
 	}
@@ -172,22 +177,21 @@ func CheckSyslogNGStatus(t *testing.T, c *common.Cluster, ctx *context.Context, 
 	return true
 }
 
-func CheckExcessSyslogNGStatus(t *testing.T, c *common.Cluster, ctx *context.Context, syslogNG *v1beta1.SyslogNGConfig) bool {
+func CheckExcessSyslogNGStatus(t *testing.T, cl client.Client, ctx context.Context, syslogNG *v1beta1.SyslogNGConfig) bool {
 	instanceName := syslogNG.Name
-	cluster := *c
 
 	if len(syslogNG.Status.Problems) == 0 {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(syslogNG), syslogNG))
+		refresh(t, cl, ctx, syslogNG)
 		t.Logf("%s should have it's problems field filled", instanceName)
 		return false
 	}
 	if syslogNG.Status.Logging != "" {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(syslogNG), syslogNG))
+		refresh(t, cl, ctx, syslogNG)
 		t.Logf("%s should have it's logging field empty, found: %s", instanceName, syslogNG.Status.Logging)
 		return false
 	}
 	if *syslogNG.Status.Active {
-		common.RequireNoError(t, cluster.GetClient().Get(*ctx, utils.ObjectKeyFromObjectMeta(syslogNG), syslogNG))
+		refresh(t, cl, ctx, syslogNG)
 		t.Logf("%s should have it's active field set as false, found: %v", instanceName, *syslogNG.Status.Active)
 		return false
 	}
@@ -197,10 +201,10 @@ func CheckExcessSyslogNGStatus(t *testing.T, c *common.Cluster, ctx *context.Con
 
 // DeploymentAvailable returns a condition function that checks if a deployment
 // is available with all replicas ready.
-func DeploymentAvailable(t *testing.T, c client.Client, ctx *context.Context, namespace, name string) func() bool {
+func DeploymentAvailable(t *testing.T, cl client.Client, ctx context.Context, namespace, name string) func() bool {
 	return func() bool {
 		deployment := &appsv1.Deployment{}
-		if err := c.Get(*ctx, client.ObjectKey{
+		if err := cl.Get(ctx, client.ObjectKey{
 			Name:      name,
 			Namespace: namespace,
 		}, deployment); err != nil {

--- a/e2e/internal/wait/conditions.go
+++ b/e2e/internal/wait/conditions.go
@@ -16,6 +16,7 @@ package wait
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -101,6 +102,22 @@ func ResourceShouldBePresent(t *testing.T, cl client.Reader, obj client.Object) 
 	}
 }
 
+// activeIs reports whether Status.Active has been written and equals want. The
+// field is optional, so a nil pointer means the controller has not set it yet:
+// neither true nor false, and the caller should keep polling. Dereferencing it
+// blindly would panic on testify's condition goroutine and take the whole
+// package binary down with it.
+func activeIs(v *bool, want bool) bool { return v != nil && *v == want }
+
+// activeState renders Status.Active for logs, keeping "not written yet"
+// distinguishable from an explicit false.
+func activeState(v *bool) string {
+	if v == nil {
+		return "unset"
+	}
+	return strconv.FormatBool(*v)
+}
+
 // refresh re-reads obj so the next poll sees current status. A failed read is
 // logged and ignored on purpose: the caller is about to return false and be
 // retried, and these conditions run on testify's own goroutine, where failing
@@ -124,9 +141,9 @@ func CheckFluentdStatus(t *testing.T, cl client.Client, ctx context.Context, flu
 		t.Logf("%s should have it's logging field filled, found: %s, expect:%s", fluentdInstanceName, fluentd.Status.Logging, loggingName)
 		return false
 	}
-	if !*fluentd.Status.Active {
+	if !activeIs(fluentd.Status.Active, true) {
 		refresh(t, cl, ctx, fluentd)
-		t.Logf("%s should have it's active field set as true, found: %v", fluentdInstanceName, *fluentd.Status.Active)
+		t.Logf("%s should have it's active field set as true, found: %v", fluentdInstanceName, activeState(fluentd.Status.Active))
 		return false
 	}
 
@@ -146,9 +163,9 @@ func CheckExcessFluentdStatus(t *testing.T, cl client.Client, ctx context.Contex
 		t.Logf("%s should have it's logging field empty, found: %s", fluentdInstanceName, fluentd.Status.Logging)
 		return false
 	}
-	if *fluentd.Status.Active {
+	if !activeIs(fluentd.Status.Active, false) {
 		refresh(t, cl, ctx, fluentd)
-		t.Logf("%s should have it's active field set as false, found: %v", fluentdInstanceName, *fluentd.Status.Active)
+		t.Logf("%s should have it's active field set as false, found: %v", fluentdInstanceName, activeState(fluentd.Status.Active))
 		return false
 	}
 
@@ -168,9 +185,9 @@ func CheckSyslogNGStatus(t *testing.T, cl client.Client, ctx context.Context, sy
 		t.Logf("%s should have it's logging field filled, found: %s, expect:%s", instanceName, syslogNG.Status.Logging, loggingName)
 		return false
 	}
-	if !*syslogNG.Status.Active {
+	if !activeIs(syslogNG.Status.Active, true) {
 		refresh(t, cl, ctx, syslogNG)
-		t.Logf("%s should have it's active field set as true, found: %v", instanceName, *syslogNG.Status.Active)
+		t.Logf("%s should have it's active field set as true, found: %v", instanceName, activeState(syslogNG.Status.Active))
 		return false
 	}
 
@@ -190,9 +207,9 @@ func CheckExcessSyslogNGStatus(t *testing.T, cl client.Client, ctx context.Conte
 		t.Logf("%s should have it's logging field empty, found: %s", instanceName, syslogNG.Status.Logging)
 		return false
 	}
-	if *syslogNG.Status.Active {
+	if !activeIs(syslogNG.Status.Active, false) {
 		refresh(t, cl, ctx, syslogNG)
-		t.Logf("%s should have it's active field set as false, found: %v", instanceName, *syslogNG.Status.Active)
+		t.Logf("%s should have it's active field set as false, found: %v", instanceName, activeState(syslogNG.Status.Active))
 		return false
 	}
 

--- a/e2e/internal/wait/conditions_test.go
+++ b/e2e/internal/wait/conditions_test.go
@@ -171,22 +171,6 @@ func TestRefreshToleratesAMissingObject(t *testing.T) {
 	})
 }
 
-func TestActiveIs(t *testing.T) {
-	yes, no := true, false
-	require.True(t, activeIs(&yes, true))
-	require.False(t, activeIs(&yes, false))
-	require.True(t, activeIs(&no, false))
-	require.False(t, activeIs(&no, true))
-
-	// Unset is neither: both callers must keep polling rather than pass.
-	require.False(t, activeIs(nil, true))
-	require.False(t, activeIs(nil, false))
-
-	require.Equal(t, "true", activeState(&yes))
-	require.Equal(t, "false", activeState(&no))
-	require.Equal(t, "unset", activeState(nil))
-}
-
 // Status.Active is optional, so it is nil until the controller writes it.
 // Dereferencing it would panic on testify's condition goroutine and take the
 // whole package binary down, so every status check must survive it.
@@ -210,4 +194,48 @@ func TestStatusChecksSurviveUnsetActive(t *testing.T) {
 		require.False(t, CheckSyslogNGStatus(t, cl, t.Context(), &syslogNG, "lg"))
 		require.False(t, CheckExcessSyslogNGStatus(t, cl, t.Context(), &syslogNG))
 	})
+}
+
+// ptr.Deref's default has to be chosen per call site: false where the check
+// wants Active true, true where it wants Active false. Both make an unset field
+// unsatisfied so the caller polls again. Getting one backwards would either
+// pass on an unreconciled object or never pass at all, so cover all three states.
+func TestStatusChecksAcrossEveryActiveState(t *testing.T) {
+	cl := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
+	yes, no := true, false
+
+	for _, c := range []struct {
+		name   string
+		active *bool
+		ready  bool // CheckFluentdStatus / CheckSyslogNGStatus
+		excess bool // CheckExcessFluentdStatus / CheckExcessSyslogNGStatus
+	}{
+		{"active true", &yes, true, false},
+		{"active false", &no, false, true},
+		{"active unset", nil, false, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			fReady := v1beta1.FluentdConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "f", Namespace: "ns"},
+				Status:     v1beta1.FluentdConfigStatus{Logging: "lg", Active: c.active},
+			}
+			sReady := v1beta1.SyslogNGConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Status:     v1beta1.SyslogNGConfigStatus{Logging: "lg", Active: c.active},
+			}
+			require.Equal(t, c.ready, CheckFluentdStatus(t, cl, t.Context(), &fReady, "lg"))
+			require.Equal(t, c.ready, CheckSyslogNGStatus(t, cl, t.Context(), &sReady, "lg"))
+
+			fExcess := v1beta1.FluentdConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "f", Namespace: "ns"},
+				Status:     v1beta1.FluentdConfigStatus{Problems: []string{"x"}, Active: c.active},
+			}
+			sExcess := v1beta1.SyslogNGConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+				Status:     v1beta1.SyslogNGConfigStatus{Problems: []string{"x"}, Active: c.active},
+			}
+			require.Equal(t, c.excess, CheckExcessFluentdStatus(t, cl, t.Context(), &fExcess))
+			require.Equal(t, c.excess, CheckExcessSyslogNGStatus(t, cl, t.Context(), &sExcess))
+		})
+	}
 }

--- a/e2e/internal/wait/conditions_test.go
+++ b/e2e/internal/wait/conditions_test.go
@@ -1,0 +1,169 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func scheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	return s
+}
+
+func pod(name string, phase corev1.PodPhase, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns", Labels: labels},
+		Status:     corev1.PodStatus{Phase: phase},
+	}
+}
+
+func deployment(desired, ready, available int32, cond *appsv1.DeploymentCondition) *appsv1.Deployment {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "d", Namespace: "ns"},
+		Spec:       appsv1.DeploymentSpec{Replicas: &desired},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: ready, AvailableReplicas: available},
+	}
+	if cond != nil {
+		d.Status.Conditions = []appsv1.DeploymentCondition{*cond}
+	}
+	return d
+}
+
+func available(status corev1.ConditionStatus) *appsv1.DeploymentCondition {
+	return &appsv1.DeploymentCondition{Type: appsv1.DeploymentAvailable, Status: status}
+}
+
+func TestPodShouldBeRunning(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		objects []client.Object
+		want    bool
+	}{
+		{"running", []client.Object{pod("p", corev1.PodRunning, nil)}, true},
+		{"pending", []client.Object{pod("p", corev1.PodPending, nil)}, false},
+		{"absent", nil, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(c.objects...).Build()
+			got := PodShouldBeRunning(t, cl, client.ObjectKey{Namespace: "ns", Name: "p"})()
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestAnyPodShouldBeRunning(t *testing.T) {
+	lbl := map[string]string{"app": "x"}
+	for _, c := range []struct {
+		name    string
+		objects []client.Object
+		want    bool
+	}{
+		{"one running among several", []client.Object{
+			pod("a", corev1.PodPending, lbl), pod("b", corev1.PodRunning, lbl),
+		}, true},
+		{"none running", []client.Object{
+			pod("a", corev1.PodPending, lbl), pod("b", corev1.PodFailed, lbl),
+		}, false},
+		{"running but not matching the selector", []client.Object{
+			pod("a", corev1.PodRunning, map[string]string{"app": "other"}),
+		}, false},
+		{"no pods at all", nil, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(c.objects...).Build()
+			got := AnyPodShouldBeRunning(t, cl, client.MatchingLabels(lbl))()
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestAnyPodShouldBeFinished(t *testing.T) {
+	lbl := map[string]string{"app": "x"}
+	for _, c := range []struct {
+		name  string
+		phase corev1.PodPhase
+		want  bool
+	}{
+		{"succeeded counts as finished", corev1.PodSucceeded, true},
+		{"failed counts as finished", corev1.PodFailed, true},
+		{"running does not", corev1.PodRunning, false},
+		{"pending does not", corev1.PodPending, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(scheme(t)).
+				WithObjects(pod("a", c.phase, lbl)).Build()
+			got := AnyPodShouldBeFinished(t, cl, client.MatchingLabels(lbl))()
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestResourceShouldBeAbsentAndPresent(t *testing.T) {
+	existing := pod("p", corev1.PodRunning, nil)
+
+	withPod := fake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(existing).Build()
+	empty := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
+
+	require.False(t, ResourceShouldBeAbsent(t, withPod, pod("p", corev1.PodRunning, nil))())
+	require.True(t, ResourceShouldBeAbsent(t, empty, pod("p", corev1.PodRunning, nil))())
+
+	require.True(t, ResourceShouldBePresent(t, withPod, pod("p", corev1.PodRunning, nil))())
+	require.False(t, ResourceShouldBePresent(t, empty, pod("p", corev1.PodRunning, nil))())
+}
+
+func TestDeploymentAvailable(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		dep  *appsv1.Deployment
+		want bool
+	}{
+		{"ready, available and reporting Available", deployment(2, 2, 2, available(corev1.ConditionTrue)), true},
+		{"Available condition is False", deployment(1, 1, 1, available(corev1.ConditionFalse)), false},
+		{"no Available condition at all", deployment(1, 1, 1, nil), false},
+		{"not all replicas ready", deployment(2, 1, 2, available(corev1.ConditionTrue)), false},
+		{"not all replicas available", deployment(2, 2, 1, available(corev1.ConditionTrue)), false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().WithScheme(scheme(t)).WithObjects(c.dep).Build()
+			require.Equal(t, c.want, DeploymentAvailable(t, cl, t.Context(), "ns", "d")())
+		})
+	}
+
+	t.Run("deployment absent", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
+		require.False(t, DeploymentAvailable(t, cl, t.Context(), "ns", "d")())
+	})
+}
+
+// refresh must not fail the test when the object is gone: these conditions run
+// on testify's goroutine, where failing is undefined, and the caller retries.
+func TestRefreshToleratesAMissingObject(t *testing.T) {
+	cl := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
+	require.NotPanics(t, func() {
+		refresh(t, cl, t.Context(), pod("gone", corev1.PodRunning, nil))
+	})
+}

--- a/e2e/internal/wait/conditions_test.go
+++ b/e2e/internal/wait/conditions_test.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
 func scheme(t *testing.T) *runtime.Scheme {
@@ -31,6 +33,7 @@ func scheme(t *testing.T) *runtime.Scheme {
 	s := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(s))
 	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, v1beta1.AddToScheme(s))
 	return s
 }
 
@@ -165,5 +168,46 @@ func TestRefreshToleratesAMissingObject(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
 	require.NotPanics(t, func() {
 		refresh(t, cl, t.Context(), pod("gone", corev1.PodRunning, nil))
+	})
+}
+
+func TestActiveIs(t *testing.T) {
+	yes, no := true, false
+	require.True(t, activeIs(&yes, true))
+	require.False(t, activeIs(&yes, false))
+	require.True(t, activeIs(&no, false))
+	require.False(t, activeIs(&no, true))
+
+	// Unset is neither: both callers must keep polling rather than pass.
+	require.False(t, activeIs(nil, true))
+	require.False(t, activeIs(nil, false))
+
+	require.Equal(t, "true", activeState(&yes))
+	require.Equal(t, "false", activeState(&no))
+	require.Equal(t, "unset", activeState(nil))
+}
+
+// Status.Active is optional, so it is nil until the controller writes it.
+// Dereferencing it would panic on testify's condition goroutine and take the
+// whole package binary down, so every status check must survive it.
+func TestStatusChecksSurviveUnsetActive(t *testing.T) {
+	cl := fake.NewClientBuilder().WithScheme(scheme(t)).Build()
+
+	fluentd := v1beta1.FluentdConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "f", Namespace: "ns"},
+		Status:     v1beta1.FluentdConfigStatus{Problems: []string{"boom"}},
+	}
+	syslogNG := v1beta1.SyslogNGConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"},
+		Status:     v1beta1.SyslogNGConfigStatus{Problems: []string{"boom"}},
+	}
+	require.Nil(t, fluentd.Status.Active)
+	require.Nil(t, syslogNG.Status.Active)
+
+	require.NotPanics(t, func() {
+		require.False(t, CheckFluentdStatus(t, cl, t.Context(), &fluentd, "lg"))
+		require.False(t, CheckExcessFluentdStatus(t, cl, t.Context(), &fluentd))
+		require.False(t, CheckSyslogNGStatus(t, cl, t.Context(), &syslogNG, "lg"))
+		require.False(t, CheckExcessSyslogNGStatus(t, cl, t.Context(), &syslogNG))
 	})
 }

--- a/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
+++ b/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
@@ -40,8 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/resources/syslogng"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
@@ -280,15 +280,15 @@ func TestSyslogNGDetachedIsRunningAndForwardingLogs(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}
@@ -298,7 +298,7 @@ func TestSyslogNGDetachedIsRunningAndForwardingLogs(t *testing.T) {
 				return false
 			}
 
-			if isValid := cond.CheckSyslogNGStatus(t, &c, &ctx, &syslogNG, logging.Name); !isValid {
+			if isValid := wait.CheckSyslogNGStatus(t, c.GetClient(), ctx, &syslogNG, logging.Name); !isValid {
 				t.Log("checking detached SyslogNG status")
 				return false
 			}
@@ -309,7 +309,7 @@ func TestSyslogNGDetachedIsRunningAndForwardingLogs(t *testing.T) {
 				common.RequireNoError(t, c.GetClient().Create(ctx, &excessSyslogNG))
 				t.Log("creating excess detached syslog-ng")
 				return false
-			} else if isValid := cond.CheckExcessSyslogNGStatus(t, &c, &ctx, &excessSyslogNG); !isValid && len(detachedSyslogNGs.Items) == 2 {
+			} else if isValid := wait.CheckExcessSyslogNGStatus(t, c.GetClient(), ctx, &excessSyslogNG); !isValid && len(detachedSyslogNGs.Items) == 2 {
 				t.Log("checking excess detached SyslogNG status")
 				common.RequireNoError(t, c.GetClient().Get(ctx, utils.ObjectKeyFromObjectMeta(&excessSyslogNG), &excessSyslogNG))
 				return false

--- a/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
+++ b/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
@@ -39,8 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/resources/syslogng"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/filter"
@@ -210,15 +210,15 @@ func TestSyslogNGIsRunningAndForwardingLogs(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}

--- a/e2e/volumedrain/volumedrain_test.go
+++ b/e2e/volumedrain/volumedrain_test.go
@@ -39,8 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
@@ -193,15 +193,15 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}
@@ -248,11 +248,11 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 		drainerJobName := fluentdReplicaName + "-drainer"
 		require.Eventually(t, func() bool {
 			var job batchv1.Job
-			present := cond.ResourceShouldBePresent(t, c.GetClient(), common.Resource(&job, ns, drainerJobName))()
+			present := wait.ResourceShouldBePresent(t, c.GetClient(), common.Resource(&job, ns, drainerJobName))()
 			return present && job.Status.Active > 0
 		}, 1*time.Minute, 3*time.Second)
 
-		require.Eventually(t, cond.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: fluentdReplicaName}), 30*time.Second, time.Second/2)
+		require.Eventually(t, wait.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: fluentdReplicaName}), 30*time.Second, time.Second/2)
 
 		cmd = common.CmdEnv(exec.Command("kubectl", "scale",
 			fmt.Sprintf("deployment/%s-test-receiver", releaseNameOverride),
@@ -260,9 +260,9 @@ func TestVolumeDrain_Downscale(t *testing.T) {
 			"--replicas", "1"), c)
 		common.RequireNoError(t, cmd.Run())
 
-		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(batchv1.Job), ns, drainerJobName)), 3*time.Minute, 3*time.Second)
+		require.Eventually(t, wait.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(batchv1.Job), ns, drainerJobName)), 3*time.Minute, 3*time.Second)
 
-		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.Pod), ns, fluentdReplicaName)), 30*time.Second, time.Second)
+		require.Eventually(t, wait.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.Pod), ns, fluentdReplicaName)), 30*time.Second, time.Second)
 
 		pvc := common.Resource(new(corev1.PersistentVolumeClaim), ns, logging.Name+"-fluentd-buffer-"+fluentdReplicaName)
 		common.RequireNoError(t, c.GetClient().Get(ctx, client.ObjectKeyFromObject(pvc), pvc))
@@ -434,15 +434,15 @@ func TestVolumeDrain_Downscale_DeleteVolume(t *testing.T) {
 		}))
 
 		require.Eventually(t, func() bool {
-			if operatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
+			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
 				t.Log("waiting for the operator")
 				return false
 			}
-			if producerRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
+			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
 				t.Log("waiting for the producer")
 				return false
 			}
-			if aggregatorRunning := cond.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
+			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
 				t.Log("waiting for the aggregator")
 				return false
 			}
@@ -483,11 +483,11 @@ func TestVolumeDrain_Downscale_DeleteVolume(t *testing.T) {
 		drainerJobName := fluentdReplicaName + "-drainer"
 		require.Eventually(t, func() bool {
 			var job batchv1.Job
-			present := cond.ResourceShouldBePresent(t, c.GetClient(), common.Resource(&job, ns, drainerJobName))()
+			present := wait.ResourceShouldBePresent(t, c.GetClient(), common.Resource(&job, ns, drainerJobName))()
 			return present && job.Status.Active > 0
 		}, 2*time.Minute, 1*time.Second)
 
-		require.Eventually(t, cond.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: fluentdReplicaName}), 30*time.Second, time.Second/2)
+		require.Eventually(t, wait.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: fluentdReplicaName}), 30*time.Second, time.Second/2)
 
 		cmd = common.CmdEnv(exec.Command("kubectl", "scale",
 			fmt.Sprintf("deployment/%s-test-receiver", releaseNameOverride),
@@ -495,11 +495,11 @@ func TestVolumeDrain_Downscale_DeleteVolume(t *testing.T) {
 			"--replicas", "1"), c)
 		common.RequireNoError(t, cmd.Run())
 
-		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(batchv1.Job), ns, drainerJobName)), 3*time.Minute, 3*time.Second)
+		require.Eventually(t, wait.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(batchv1.Job), ns, drainerJobName)), 3*time.Minute, 3*time.Second)
 
-		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.Pod), ns, fluentdReplicaName)), 30*time.Second, time.Second/2)
+		require.Eventually(t, wait.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.Pod), ns, fluentdReplicaName)), 30*time.Second, time.Second/2)
 
-		require.Eventually(t, cond.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.PersistentVolumeClaim), ns, logging.Name+"-fluentd-buffer-"+fluentdReplicaName)), 30*time.Second, time.Second/2)
+		require.Eventually(t, wait.ResourceShouldBeAbsent(t, c.GetClient(), common.Resource(new(corev1.PersistentVolumeClaim), ns, logging.Name+"-fluentd-buffer-"+fluentdReplicaName)), 30*time.Second, time.Second/2)
 	}, func(t *testing.T, c common.Cluster) error {
 		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
 		t.Logf("Printing cluster logs to %s", path)

--- a/e2e/watch-selector/watch_selector_test.go
+++ b/e2e/watch-selector/watch_selector_test.go
@@ -35,8 +35,8 @@ import (
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/cond"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
@@ -124,12 +124,12 @@ func TestWatchSelectors(t *testing.T) {
 		common.RequireNoError(t, c.GetClient().Create(ctx, unmanagedSecret))
 
 		require.Eventually(t, func() bool {
-			if isManagedFluentdPodRunning := cond.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: logging.Name + "-fluentd-0"}); !isManagedFluentdPodRunning() {
+			if isManagedFluentdPodRunning := wait.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: logging.Name + "-fluentd-0"}); !isManagedFluentdPodRunning() {
 				t.Logf("managed fluentd pod is not running")
 				return false
 			}
 
-			if isUnmanagedFluentdPodRunning := cond.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: "fluentd", Name: "fluentd-0"}); !isUnmanagedFluentdPodRunning() {
+			if isUnmanagedFluentdPodRunning := wait.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: "fluentd", Name: "fluentd-0"}); !isUnmanagedFluentdPodRunning() {
 				t.Logf("unmanaged fluentd pod is not running")
 				return false
 			}


### PR DESCRIPTION
§5.2 of #2291, following #2297. Moves the conditions package to `internal/wait` and fixes two things about it on the way.

### The signatures took pointers to an interface and to a context

Four helpers looked like this:

```go
func CheckFluentdStatus(t *testing.T, c *common.Cluster, ctx *context.Context, ...) bool {
	cluster := *c
```

`common.Cluster` is an interface, so `*common.Cluster` is a pointer to an interface, dereferenced immediately. The `context.Context` pointer was dereferenced at every use. Neither pointer bought anything.

They only ever called `cluster.GetClient()`, so they now take a `client.Client` directly — which is what the five conditions sitting beside them in the same file already took. Nine call sites updated.

### They failed the test from testify's goroutine

Each of those helpers refreshed its object through `common.RequireNoError`, which calls `t.FailNow()`. All of them are invoked from inside `require.Eventually`, and testify runs the condition on a goroutine of its own — v1.11.1, `assert/assertions.go`:

```go
checkCond := func() { ch <- condition() }
...
go checkCond()
```

So that was `t.FailNow()` from a non-test goroutine, which the `testing` docs say must not happen — the same defect as #2295, in a second place. Twelve calls.

A transient read failure inside a polling condition should not end the run anyway; it should be retried. The refresh now logs and returns, and the condition returns false as it already did, so the next tick picks it up:

```go
func refresh(t *testing.T, cl client.Client, ctx context.Context, obj client.Object) {
	if err := cl.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
		t.Logf("could not refresh %s: %v", obj.GetName(), err)
	}
}
```

**This is not the whole problem.** Twenty more `RequireNoError` calls sit directly inside `Eventually` conditions in three suites — `fluentd-aggregator-detached`, `syslog-ng-aggregator-detached` and `fluentd-aggregator`. Those are suite-local and I have left them alone rather than widen this PR; happy to follow up.

### The package no longer imports `common`

Those were the only two things it used from `common` — the `Cluster` interface and `RequireNoError`. With both gone, `internal/wait` imports nothing from `common`. #2291 describes that upward dependency as the thing preventing `common` from being split, so this is one package out from under it.

### Tests

Six table-driven tests, sixteen cases, over `fake.NewClientBuilder()` — no cluster, 0.07 s. These and `internal/kind` are the module's only unit tests.

They are picked up automatically by the `./internal/...` selector added in #2297, so `make check` now reports 28 packages rather than 27.

Checked they actually catch something: replacing the ready-replica comparison with `if false` fails exactly `TestDeploymentAvailable/not_all_replicas_ready`, and restoring it passes.

### What is deferred

§5.2 also calls for named wait budgets to replace the seventeen `5*time.Minute, 3*time.Second` literals. That is a change to timeout behaviour across suites, and the divergent values (`syslog-ng-*` poll at 2 s, `volumedrain` uses eight distinct pairs) need measuring before anything is homogenised. It belongs in its own PR.

Function names are unchanged. `wait.CheckFluentdStatus` reads oddly, but renaming sixty-seven call sites for style, in the same PR that moves them, would bury the two real fixes.

### Verification

`make check` passes. `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` in `e2e/` reports 0 issues. Both commits build on their own.

### Scope

14 files. The package itself, plus an import path and a `cond.` → `wait.` qualifier in each of the twelve suites that use it.
