### PR TITLE
refactor(e2e): add internal/fixture with the CR and tenancy builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ test-e2e-nodeps:
 		KIND_IMAGE="$(KIND_IMAGE)" \
 		PROJECT_DIR="$(PWD)" \
 		E2E_TEST_COV_DIR=${TEST_COV_DIR} \
-		go test -count=1 -v -timeout ${E2E_TEST_TIMEOUT} $$(go list ./${E2E_TEST}/... | grep -v '/e2e/common')
+		go test -count=1 -v -timeout ${E2E_TEST_TIMEOUT} $$(go list ./${E2E_TEST}/... | grep -vE '/e2e/(common|internal)(/|$$)')
 		go tool covdata textfmt -i=${TEST_COV_DIR}/covdatafiles -o ${TEST_COV_DIR}/coverage_e2e.out
 	@echo "--- E2E test coverage report"
 	go tool covdata percent -i=${TEST_COV_DIR}/covdatafiles

--- a/e2e/internal/fixture/fixture_test.go
+++ b/e2e/internal/fixture/fixture_test.go
@@ -95,8 +95,7 @@ func TestBufferDefaultsAndOverrides(t *testing.T) {
 	b := Buffer("time")
 	require.Equal(t, "file", b.Type)
 	require.Equal(t, "time", *b.Tags)
-	// Literals, not the constants: a constant asserted against itself proves
-	// nothing, and neither value is pinned by the literal test below.
+	// Literals, not the constants: a constant asserted against itself proves nothing.
 	require.Equal(t, "1s", b.Timekey)
 	require.Equal(t, "0s", b.TimekeyWait)
 
@@ -125,9 +124,8 @@ func TestHTTPOutputAndFlow(t *testing.T) {
 func TestBuilderReproducesTheMultiWorkerLiteral(t *testing.T) {
 	const ns = "testing-1"
 
-	// The Logging fluentd-aggregator's MultiWorker test writes by hand, minus the
-	// ObjectMeta.Namespace it sets: the API server clears that field for a
-	// cluster-scoped kind, so the builder does not set it.
+	// The literal fluentd-aggregator writes by hand, minus the ObjectMeta.Namespace
+	// the API server clears for a cluster-scoped kind.
 	want := &v1beta1.Logging{
 		ObjectMeta: metav1.ObjectMeta{Name: "fluentd-aggregator-multiworker-test"},
 		Spec: v1beta1.LoggingSpec{

--- a/e2e/internal/fixture/fixture_test.go
+++ b/e2e/internal/fixture/fixture_test.go
@@ -49,8 +49,8 @@ func TestLoggingDefaults(t *testing.T) {
 	l := Logging("ns", "lg")
 
 	require.Equal(t, "lg", l.Name)
-	require.Equal(t, "ns", l.Namespace)
 	require.Equal(t, "ns", l.Spec.ControlNamespace)
+	require.Empty(t, l.Namespace, "Logging is cluster-scoped")
 	require.True(t, l.Spec.EnableRecreateWorkloadOnImmutableFieldChange)
 
 	// Neither half is present until asked for: suites that want only an agent
@@ -138,11 +138,11 @@ func TestHTTPOutputAndFlow(t *testing.T) {
 func TestBuilderReproducesTheMultiWorkerLiteral(t *testing.T) {
 	const ns = "testing-1"
 
+	// The Logging fluentd-aggregator's MultiWorker test writes by hand, minus the
+	// ObjectMeta.Namespace it sets: the API server clears that field for a
+	// cluster-scoped kind, so the builder does not set it.
 	want := &v1beta1.Logging{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fluentd-aggregator-multiworker-test",
-			Namespace: ns,
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "fluentd-aggregator-multiworker-test"},
 		Spec: v1beta1.LoggingSpec{
 			EnableRecreateWorkloadOnImmutableFieldChange: true,
 			ControlNamespace: ns,

--- a/e2e/internal/fixture/fixture_test.go
+++ b/e2e/internal/fixture/fixture_test.go
@@ -1,0 +1,189 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/e2e/common"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+// The package deliberately does not import common, so the constants are
+// duplicated while both exist. This is the guard against them drifting:
+// setup.defaultImages and common disagreed on the syslog-ng reloader name for
+// as long as the Makefile happened to mask it.
+func TestImageNamesMatchCommon(t *testing.T) {
+	require.Equal(t, common.FluentdImageRepo, FluentdImageRepo)
+	require.Equal(t, common.ConfigReloaderRepo, ConfigReloaderRepo)
+	require.Equal(t, common.SyslogNGReloaderRepo, SyslogNGReloaderRepo)
+	require.Equal(t, common.FluentdDrainWatchRepo, FluentdDrainWatchRepo)
+	require.Equal(t, common.NodeExporterRepo, NodeExporterRepo)
+
+	for _, tag := range []string{
+		common.FluentdImageTag, common.ConfigReloaderTag, common.SyslogNGReloaderTag,
+		common.FluentdDrainWatchTag, common.NodeExporterTag,
+	} {
+		require.Equal(t, localTag, tag)
+	}
+}
+
+func TestLoggingDefaults(t *testing.T) {
+	l := Logging("ns", "lg")
+
+	require.Equal(t, "lg", l.Name)
+	require.Equal(t, "ns", l.Namespace)
+	require.Equal(t, "ns", l.Spec.ControlNamespace)
+	require.True(t, l.Spec.EnableRecreateWorkloadOnImmutableFieldChange)
+
+	// Neither half is present until asked for: suites that want only an agent
+	// must not silently get an aggregator.
+	require.Nil(t, l.Spec.FluentbitSpec)
+	require.Nil(t, l.Spec.FluentdSpec)
+}
+
+func TestWithFluentbit(t *testing.T) {
+	l := Logging("ns", "lg", WithFluentbit())
+	fb := l.Spec.FluentbitSpec
+
+	require.NotNil(t, fb)
+	require.False(t, *fb.Network.Keepalive)
+	require.Equal(t, "config-reloader", fb.ConfigHotReload.Image.Repository)
+	require.Equal(t, "node-exporter", fb.BufferVolumeImage.Repository)
+	require.Equal(t, "local", fb.BufferVolumeImage.Tag)
+}
+
+func TestWithFluentdDefaults(t *testing.T) {
+	l := Logging("ns", "lg", WithFluentd())
+	fd := l.Spec.FluentdSpec
+
+	require.NotNil(t, fd)
+	require.EqualValues(t, 2, fd.Workers, "the counted majority is 2, not 1")
+	require.Equal(t, FluentdImageRepo, fd.Image.Repository)
+	require.Equal(t, ConfigReloaderRepo, fd.ConfigReloaderImage.Repository)
+	require.Equal(t, NodeExporterRepo, fd.BufferVolumeImage.Repository)
+	require.NotNil(t, fd.BufferVolumeMetrics)
+
+	require.Equal(t, resource.MustParse("500m"), fd.Resources.Limits[corev1.ResourceCPU])
+	require.Equal(t, resource.MustParse("200M"), fd.Resources.Limits[corev1.ResourceMemory])
+	require.Equal(t, resource.MustParse("250m"), fd.Resources.Requests[corev1.ResourceCPU])
+	require.Equal(t, resource.MustParse("50M"), fd.Resources.Requests[corev1.ResourceMemory])
+
+	// Draining is opt-in: it is absent unless Drain() is passed.
+	require.Nil(t, fd.Scaling)
+}
+
+func TestFluentdOptions(t *testing.T) {
+	fd := FluentdSpec(Workers(1), Drain())
+
+	require.EqualValues(t, 1, fd.Workers)
+	require.NotNil(t, fd.Scaling)
+	require.EqualValues(t, 1, fd.Scaling.Replicas)
+	require.True(t, fd.Scaling.Drain.Enabled)
+	require.Equal(t, FluentdDrainWatchRepo, fd.Scaling.Drain.Image.Repository)
+}
+
+func TestBufferDefaultsAndOverrides(t *testing.T) {
+	b := Buffer("time")
+	require.Equal(t, "file", b.Type)
+	require.Equal(t, "time", *b.Tags)
+	// Literals, not the constants: asserting a constant against itself proves
+	// nothing, and these two are not pinned by the literal test below.
+	require.Equal(t, "1s", b.Timekey, "counted majority: 1s at eight sites")
+	require.Equal(t, "0s", b.TimekeyWait, "counted majority: 0s at nine sites")
+
+	o := Buffer("time", Timekey("1m"), TimekeyWait("10s"))
+	require.Equal(t, "1m", o.Timekey)
+	require.Equal(t, "10s", o.TimekeyWait)
+}
+
+func TestReceiverURL(t *testing.T) {
+	require.Equal(t, "http://e2e-test-receiver:8080/test.tag", ReceiverURL("e2e", "test.tag"))
+}
+
+func TestHTTPOutputAndFlow(t *testing.T) {
+	out := HTTPOutput("ns", "test-output", ReceiverURL("e2e", "tag"), Buffer("time"))
+	require.Equal(t, "ns", out.Namespace)
+	require.Equal(t, "application/json", out.Spec.HTTPOutput.ContentType)
+	require.Equal(t, "http://e2e-test-receiver:8080/tag", out.Spec.HTTPOutput.Endpoint)
+	require.Equal(t, "1s", out.Spec.HTTPOutput.Buffer.Timekey)
+
+	labels := map[string]string{"my-unique-label": "log-producer"}
+	f := Flow("ns", "test-flow", labels, out.Name)
+	require.Equal(t, labels, f.Spec.Match[0].Select.Labels)
+	require.Equal(t, []string{"test-output"}, f.Spec.LocalOutputRefs)
+}
+
+// The §6 safety net: build the Logging that fluentd-aggregator's MultiWorker
+// test writes by hand and assert the builder produces exactly it. A default
+// that quietly absorbed a divergence would show up here rather than after a
+// twenty minute cluster run.
+func TestBuilderReproducesTheMultiWorkerLiteral(t *testing.T) {
+	const ns = "testing-1"
+
+	want := &v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fluentd-aggregator-multiworker-test",
+			Namespace: ns,
+		},
+		Spec: v1beta1.LoggingSpec{
+			EnableRecreateWorkloadOnImmutableFieldChange: true,
+			ControlNamespace: ns,
+			FluentbitSpec: &v1beta1.FluentbitSpec{
+				Network: &v1beta1.FluentbitNetwork{Keepalive: new(false)},
+				ConfigHotReload: &v1beta1.HotReload{
+					Image: v1beta1.ImageSpec{Repository: common.ConfigReloaderRepo, Tag: common.ConfigReloaderTag},
+				},
+				BufferVolumeImage: v1beta1.ImageSpec{Repository: common.NodeExporterRepo, Tag: common.NodeExporterTag},
+			},
+			FluentdSpec: &v1beta1.FluentdSpec{
+				Image:               v1beta1.ImageSpec{Repository: common.FluentdImageRepo, Tag: common.FluentdImageTag},
+				ConfigReloaderImage: v1beta1.ImageSpec{Repository: common.ConfigReloaderRepo, Tag: common.ConfigReloaderTag},
+				BufferVolumeImage:   v1beta1.ImageSpec{Repository: common.NodeExporterRepo, Tag: common.NodeExporterTag},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("200M"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("50M"),
+					},
+				},
+				BufferVolumeMetrics: &v1beta1.Metrics{},
+				Scaling: &v1beta1.FluentdScaling{
+					Replicas: 1,
+					Drain: v1beta1.FluentdDrainConfig{
+						Enabled: true,
+						Image:   v1beta1.ImageSpec{Repository: common.FluentdDrainWatchRepo, Tag: common.FluentdDrainWatchTag},
+					},
+				},
+				Workers: 2,
+			},
+		},
+	}
+
+	got := Logging(ns, "fluentd-aggregator-multiworker-test",
+		WithFluentbit(),
+		WithFluentd(Drain()),
+	)
+
+	require.Equal(t, want, got)
+}

--- a/e2e/internal/fixture/fixture_test.go
+++ b/e2e/internal/fixture/fixture_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Kube logging authors
+// Copyright © 2026 Kube logging authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,10 +26,6 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
-// The package deliberately does not import common, so the constants are
-// duplicated while both exist. This is the guard against them drifting:
-// setup.defaultImages and common disagreed on the syslog-ng reloader name for
-// as long as the Makefile happened to mask it.
 func TestImageNamesMatchCommon(t *testing.T) {
 	require.Equal(t, common.FluentdImageRepo, FluentdImageRepo)
 	require.Equal(t, common.ConfigReloaderRepo, ConfigReloaderRepo)
@@ -52,9 +48,6 @@ func TestLoggingDefaults(t *testing.T) {
 	require.Equal(t, "ns", l.Spec.ControlNamespace)
 	require.Empty(t, l.Namespace, "Logging is cluster-scoped")
 	require.True(t, l.Spec.EnableRecreateWorkloadOnImmutableFieldChange)
-
-	// Neither half is present until asked for: suites that want only an agent
-	// must not silently get an aggregator.
 	require.Nil(t, l.Spec.FluentbitSpec)
 	require.Nil(t, l.Spec.FluentdSpec)
 }
@@ -75,7 +68,7 @@ func TestWithFluentdDefaults(t *testing.T) {
 	fd := l.Spec.FluentdSpec
 
 	require.NotNil(t, fd)
-	require.EqualValues(t, 2, fd.Workers, "the counted majority is 2, not 1")
+	require.EqualValues(t, 2, fd.Workers)
 	require.Equal(t, FluentdImageRepo, fd.Image.Repository)
 	require.Equal(t, ConfigReloaderRepo, fd.ConfigReloaderImage.Repository)
 	require.Equal(t, NodeExporterRepo, fd.BufferVolumeImage.Repository)
@@ -85,9 +78,7 @@ func TestWithFluentdDefaults(t *testing.T) {
 	require.Equal(t, resource.MustParse("200M"), fd.Resources.Limits[corev1.ResourceMemory])
 	require.Equal(t, resource.MustParse("250m"), fd.Resources.Requests[corev1.ResourceCPU])
 	require.Equal(t, resource.MustParse("50M"), fd.Resources.Requests[corev1.ResourceMemory])
-
-	// Draining is opt-in: it is absent unless Drain() is passed.
-	require.Nil(t, fd.Scaling)
+	require.Nil(t, fd.Scaling, "draining is opt-in")
 }
 
 func TestFluentdOptions(t *testing.T) {
@@ -104,10 +95,10 @@ func TestBufferDefaultsAndOverrides(t *testing.T) {
 	b := Buffer("time")
 	require.Equal(t, "file", b.Type)
 	require.Equal(t, "time", *b.Tags)
-	// Literals, not the constants: asserting a constant against itself proves
-	// nothing, and these two are not pinned by the literal test below.
-	require.Equal(t, "1s", b.Timekey, "counted majority: 1s at eight sites")
-	require.Equal(t, "0s", b.TimekeyWait, "counted majority: 0s at nine sites")
+	// Literals, not the constants: a constant asserted against itself proves
+	// nothing, and neither value is pinned by the literal test below.
+	require.Equal(t, "1s", b.Timekey)
+	require.Equal(t, "0s", b.TimekeyWait)
 
 	o := Buffer("time", Timekey("1m"), TimekeyWait("10s"))
 	require.Equal(t, "1m", o.Timekey)
@@ -131,10 +122,6 @@ func TestHTTPOutputAndFlow(t *testing.T) {
 	require.Equal(t, []string{"test-output"}, f.Spec.LocalOutputRefs)
 }
 
-// The §6 safety net: build the Logging that fluentd-aggregator's MultiWorker
-// test writes by hand and assert the builder produces exactly it. A default
-// that quietly absorbed a divergence would show up here rather than after a
-// twenty minute cluster run.
 func TestBuilderReproducesTheMultiWorkerLiteral(t *testing.T) {
 	const ns = "testing-1"
 

--- a/e2e/internal/fixture/flow.go
+++ b/e2e/internal/fixture/flow.go
@@ -23,21 +23,17 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-// Buffer defaults. Suites that need other values pass Timekey or TimekeyWait.
 const (
 	DefaultTimekey     = "1s"
 	DefaultTimekeyWait = "0s"
 )
 
-// ReceiverURL is the endpoint the test receiver serves.
 func ReceiverURL(release, tag string) string {
 	return fmt.Sprintf("http://%s-test-receiver:8080/%s", release, tag)
 }
 
-// BufferOption modifies a Buffer under construction.
 type BufferOption func(*output.Buffer)
 
-// Buffer builds the file buffer the HTTP outputs share.
 func Buffer(tags string, opts ...BufferOption) *output.Buffer {
 	b := &output.Buffer{
 		Type:        "file",
@@ -51,17 +47,14 @@ func Buffer(tags string, opts ...BufferOption) *output.Buffer {
 	return b
 }
 
-// Timekey overrides the buffer flush interval.
 func Timekey(v string) BufferOption {
 	return func(b *output.Buffer) { b.Timekey = v }
 }
 
-// TimekeyWait overrides the buffer flush delay.
 func TimekeyWait(v string) BufferOption {
 	return func(b *output.Buffer) { b.TimekeyWait = v }
 }
 
-// HTTPOutput builds a namespaced Output posting JSON to the test receiver.
 func HTTPOutput(namespace, name, endpoint string, buffer *output.Buffer) *v1beta1.Output {
 	return &v1beta1.Output{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -75,8 +68,6 @@ func HTTPOutput(namespace, name, endpoint string, buffer *output.Buffer) *v1beta
 	}
 }
 
-// Flow builds a namespaced Flow selecting pods by label and routing to the
-// named local outputs.
 func Flow(namespace, name string, selector map[string]string, outputRefs ...string) *v1beta1.Flow {
 	return &v1beta1.Flow{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},

--- a/e2e/internal/fixture/flow.go
+++ b/e2e/internal/fixture/flow.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Kube logging authors
+// Copyright © 2026 Kube logging authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,16 +23,13 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-// Buffer defaults, counted across the suites: Timekey "1s" at eight sites
-// against "1m" at three and "10s" at one; TimekeyWait "0s" at nine against
-// "10s" at three.
+// Buffer defaults. Suites that need other values pass Timekey or TimekeyWait.
 const (
 	DefaultTimekey     = "1s"
 	DefaultTimekeyWait = "0s"
 )
 
-// ReceiverURL is the endpoint the test receiver serves, built the same way at
-// nine call sites.
+// ReceiverURL is the endpoint the test receiver serves.
 func ReceiverURL(release, tag string) string {
 	return fmt.Sprintf("http://%s-test-receiver:8080/%s", release, tag)
 }

--- a/e2e/internal/fixture/flow.go
+++ b/e2e/internal/fixture/flow.go
@@ -1,0 +1,93 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
+)
+
+// Buffer defaults, counted across the suites: Timekey "1s" at eight sites
+// against "1m" at three and "10s" at one; TimekeyWait "0s" at nine against
+// "10s" at three.
+const (
+	DefaultTimekey     = "1s"
+	DefaultTimekeyWait = "0s"
+)
+
+// ReceiverURL is the endpoint the test receiver serves, built the same way at
+// nine call sites.
+func ReceiverURL(release, tag string) string {
+	return fmt.Sprintf("http://%s-test-receiver:8080/%s", release, tag)
+}
+
+// BufferOption modifies a Buffer under construction.
+type BufferOption func(*output.Buffer)
+
+// Buffer builds the file buffer the HTTP outputs share.
+func Buffer(tags string, opts ...BufferOption) *output.Buffer {
+	b := &output.Buffer{
+		Type:        "file",
+		Tags:        &tags,
+		Timekey:     DefaultTimekey,
+		TimekeyWait: DefaultTimekeyWait,
+	}
+	for _, o := range opts {
+		o(b)
+	}
+	return b
+}
+
+// Timekey overrides the buffer flush interval.
+func Timekey(v string) BufferOption {
+	return func(b *output.Buffer) { b.Timekey = v }
+}
+
+// TimekeyWait overrides the buffer flush delay.
+func TimekeyWait(v string) BufferOption {
+	return func(b *output.Buffer) { b.TimekeyWait = v }
+}
+
+// HTTPOutput builds a namespaced Output posting JSON to the test receiver.
+func HTTPOutput(namespace, name, endpoint string, buffer *output.Buffer) *v1beta1.Output {
+	return &v1beta1.Output{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1beta1.OutputSpec{
+			HTTPOutput: &output.HTTPOutputConfig{
+				Endpoint:    endpoint,
+				ContentType: "application/json",
+				Buffer:      buffer,
+			},
+		},
+	}
+}
+
+// Flow builds a namespaced Flow selecting pods by label and routing to the
+// named local outputs.
+func Flow(namespace, name string, selector map[string]string, outputRefs ...string) *v1beta1.Flow {
+	return &v1beta1.Flow{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1beta1.FlowSpec{
+			Match: []v1beta1.Match{
+				{Select: &v1beta1.Select{Labels: selector}},
+			},
+			LocalOutputRefs: outputRefs,
+		},
+	}
+}

--- a/e2e/internal/fixture/images.go
+++ b/e2e/internal/fixture/images.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Kube logging authors
+// Copyright © 2026 Kube logging authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,8 @@ package fixture
 
 import "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 
-// The locally built images the suites load into each cluster. These are
-// duplicated from common while both exist; images_test.go asserts they stay
-// equal, so the two cannot drift the way the syslog-ng reloader name did.
+// Duplicated from common rather than imported, for as long as both packages
+// exist. TestImageNamesMatchCommon asserts they stay equal.
 const (
 	FluentdImageRepo      = "fluentd-full"
 	ConfigReloaderRepo    = "config-reloader"

--- a/e2e/internal/fixture/images.go
+++ b/e2e/internal/fixture/images.go
@@ -16,8 +16,7 @@ package fixture
 
 import "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 
-// Duplicated from common rather than imported, for as long as both packages
-// exist. TestImageNamesMatchCommon asserts they stay equal.
+// Duplicated from common while both exist; TestImageNamesMatchCommon pins them equal.
 const (
 	FluentdImageRepo      = "fluentd-full"
 	ConfigReloaderRepo    = "config-reloader"

--- a/e2e/internal/fixture/images.go
+++ b/e2e/internal/fixture/images.go
@@ -1,0 +1,34 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+
+// The locally built images the suites load into each cluster. These are
+// duplicated from common while both exist; images_test.go asserts they stay
+// equal, so the two cannot drift the way the syslog-ng reloader name did.
+const (
+	FluentdImageRepo      = "fluentd-full"
+	ConfigReloaderRepo    = "config-reloader"
+	SyslogNGReloaderRepo  = "syslog-ng-reloader"
+	FluentdDrainWatchRepo = "fluentd-drain-watch"
+	NodeExporterRepo      = "node-exporter"
+
+	localTag = "local"
+)
+
+func image(repo string) v1beta1.ImageSpec {
+	return v1beta1.ImageSpec{Repository: repo, Tag: localTag}
+}

--- a/e2e/internal/fixture/logging.go
+++ b/e2e/internal/fixture/logging.go
@@ -1,0 +1,128 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+// Defaults are the value most call sites already use, counted across the
+// suites rather than chosen. Anything that diverges passes an option; a
+// default must never absorb a divergence.
+const (
+	// DefaultWorkers is 2, used by four call sites against three using 1.
+	DefaultWorkers = 2
+)
+
+// LoggingOption modifies a Logging under construction.
+type LoggingOption func(*v1beta1.Logging)
+
+// Logging builds the Logging every suite starts from: recreate-on-immutable
+// enabled, control namespace set, and no agent or aggregator until asked.
+func Logging(namespace, name string, opts ...LoggingOption) *v1beta1.Logging {
+	l := &v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1beta1.LoggingSpec{
+			EnableRecreateWorkloadOnImmutableFieldChange: true,
+			ControlNamespace: namespace,
+		},
+	}
+	for _, o := range opts {
+		o(l)
+	}
+	return l
+}
+
+// WithFluentbit adds the agent spec the suites share: keepalive off, hot
+// reload and buffer volume on the local images.
+func WithFluentbit(opts ...func(*v1beta1.FluentbitSpec)) LoggingOption {
+	return func(l *v1beta1.Logging) {
+		s := &v1beta1.FluentbitSpec{
+			Network:           &v1beta1.FluentbitNetwork{Keepalive: new(false)},
+			ConfigHotReload:   &v1beta1.HotReload{Image: image(ConfigReloaderRepo)},
+			BufferVolumeImage: image(NodeExporterRepo),
+		}
+		for _, o := range opts {
+			o(s)
+		}
+		l.Spec.FluentbitSpec = s
+	}
+}
+
+// WithFluentd adds the aggregator spec the suites share.
+func WithFluentd(opts ...FluentdOption) LoggingOption {
+	return func(l *v1beta1.Logging) {
+		l.Spec.FluentdSpec = FluentdSpec(opts...)
+	}
+}
+
+// FluentdOption modifies a FluentdSpec under construction. It is exported so
+// the same options serve Logging.FluentdSpec and a detached FluentdConfig.
+type FluentdOption func(*v1beta1.FluentdSpec)
+
+// FluentdSpec builds the aggregator spec shared by the Logging-embedded and
+// detached forms.
+func FluentdSpec(opts ...FluentdOption) *v1beta1.FluentdSpec {
+	s := &v1beta1.FluentdSpec{
+		Image:               image(FluentdImageRepo),
+		ConfigReloaderImage: image(ConfigReloaderRepo),
+		BufferVolumeImage:   image(NodeExporterRepo),
+		Resources:           defaultResources(),
+		BufferVolumeMetrics: &v1beta1.Metrics{},
+		Workers:             DefaultWorkers,
+	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// Workers overrides the worker count. Three call sites use 1.
+func Workers(n int32) FluentdOption {
+	return func(s *v1beta1.FluentdSpec) { s.Workers = n }
+}
+
+// Drain enables buffer draining on downscale, with one replica.
+func Drain() FluentdOption {
+	return func(s *v1beta1.FluentdSpec) {
+		s.Scaling = &v1beta1.FluentdScaling{
+			Replicas: 1,
+			Drain: v1beta1.FluentdDrainConfig{
+				Enabled: true,
+				Image:   image(FluentdDrainWatchRepo),
+			},
+		}
+	}
+}
+
+// defaultResources is the limits/requests pair used by twelve of the CR call
+// sites. LoggingInfra and the syslog-ng overrides use different values and set
+// them explicitly.
+func defaultResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("200M"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("50M"),
+		},
+	}
+}

--- a/e2e/internal/fixture/logging.go
+++ b/e2e/internal/fixture/logging.go
@@ -35,12 +35,14 @@ type LoggingOption func(*v1beta1.Logging)
 
 // Logging builds the Logging every suite starts from: recreate-on-immutable
 // enabled, control namespace set, and no agent or aggregator until asked.
-func Logging(namespace, name string, opts ...LoggingOption) *v1beta1.Logging {
+// Logging is cluster-scoped, so controlNamespace sets Spec.ControlNamespace and
+// no ObjectMeta.Namespace.
+func Logging(controlNamespace, name string, opts ...LoggingOption) *v1beta1.Logging {
 	l := &v1beta1.Logging{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: v1beta1.LoggingSpec{
 			EnableRecreateWorkloadOnImmutableFieldChange: true,
-			ControlNamespace: namespace,
+			ControlNamespace: controlNamespace,
 		},
 	}
 	for _, o := range opts {

--- a/e2e/internal/fixture/logging.go
+++ b/e2e/internal/fixture/logging.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Kube logging authors
+// Copyright © 2026 Kube logging authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,21 +22,15 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
-// Defaults are the value most call sites already use, counted across the
-// suites rather than chosen. Anything that diverges passes an option; a
-// default must never absorb a divergence.
-const (
-	// DefaultWorkers is 2, used by four call sites against three using 1.
-	DefaultWorkers = 2
-)
+// DefaultWorkers is the worker count most suites use. Others pass Workers.
+const DefaultWorkers = 2
 
 // LoggingOption modifies a Logging under construction.
 type LoggingOption func(*v1beta1.Logging)
 
-// Logging builds the Logging every suite starts from: recreate-on-immutable
-// enabled, control namespace set, and no agent or aggregator until asked.
-// Logging is cluster-scoped, so controlNamespace sets Spec.ControlNamespace and
-// no ObjectMeta.Namespace.
+// Logging builds the Logging the suites start from, with no agent or aggregator
+// until asked for one. Logging is cluster-scoped, so controlNamespace sets only
+// Spec.ControlNamespace and no ObjectMeta.Namespace.
 func Logging(controlNamespace, name string, opts ...LoggingOption) *v1beta1.Logging {
 	l := &v1beta1.Logging{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -51,8 +45,7 @@ func Logging(controlNamespace, name string, opts ...LoggingOption) *v1beta1.Logg
 	return l
 }
 
-// WithFluentbit adds the agent spec the suites share: keepalive off, hot
-// reload and buffer volume on the local images.
+// WithFluentbit adds the agent spec the suites share.
 func WithFluentbit(opts ...func(*v1beta1.FluentbitSpec)) LoggingOption {
 	return func(l *v1beta1.Logging) {
 		s := &v1beta1.FluentbitSpec{
@@ -74,8 +67,8 @@ func WithFluentd(opts ...FluentdOption) LoggingOption {
 	}
 }
 
-// FluentdOption modifies a FluentdSpec under construction. It is exported so
-// the same options serve Logging.FluentdSpec and a detached FluentdConfig.
+// FluentdOption modifies a FluentdSpec under construction. It is exported so the
+// same options serve Logging.FluentdSpec and a detached FluentdConfig.
 type FluentdOption func(*v1beta1.FluentdSpec)
 
 // FluentdSpec builds the aggregator spec shared by the Logging-embedded and
@@ -95,12 +88,12 @@ func FluentdSpec(opts ...FluentdOption) *v1beta1.FluentdSpec {
 	return s
 }
 
-// Workers overrides the worker count. Three call sites use 1.
+// Workers overrides the worker count.
 func Workers(n int32) FluentdOption {
 	return func(s *v1beta1.FluentdSpec) { s.Workers = n }
 }
 
-// Drain enables buffer draining on downscale, with one replica.
+// Drain enables buffer draining on downscale.
 func Drain() FluentdOption {
 	return func(s *v1beta1.FluentdSpec) {
 		s.Scaling = &v1beta1.FluentdScaling{
@@ -113,9 +106,6 @@ func Drain() FluentdOption {
 	}
 }
 
-// defaultResources is the limits/requests pair used by twelve of the CR call
-// sites. LoggingInfra and the syslog-ng overrides use different values and set
-// them explicitly.
 func defaultResources() corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{

--- a/e2e/internal/fixture/logging.go
+++ b/e2e/internal/fixture/logging.go
@@ -22,15 +22,11 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
-// DefaultWorkers is the worker count most suites use. Others pass Workers.
 const DefaultWorkers = 2
 
-// LoggingOption modifies a Logging under construction.
 type LoggingOption func(*v1beta1.Logging)
 
-// Logging builds the Logging the suites start from, with no agent or aggregator
-// until asked for one. Logging is cluster-scoped, so controlNamespace sets only
-// Spec.ControlNamespace and no ObjectMeta.Namespace.
+// Logging is cluster-scoped: controlNamespace sets Spec.ControlNamespace only.
 func Logging(controlNamespace, name string, opts ...LoggingOption) *v1beta1.Logging {
 	l := &v1beta1.Logging{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -45,7 +41,6 @@ func Logging(controlNamespace, name string, opts ...LoggingOption) *v1beta1.Logg
 	return l
 }
 
-// WithFluentbit adds the agent spec the suites share.
 func WithFluentbit(opts ...func(*v1beta1.FluentbitSpec)) LoggingOption {
 	return func(l *v1beta1.Logging) {
 		s := &v1beta1.FluentbitSpec{
@@ -60,19 +55,15 @@ func WithFluentbit(opts ...func(*v1beta1.FluentbitSpec)) LoggingOption {
 	}
 }
 
-// WithFluentd adds the aggregator spec the suites share.
 func WithFluentd(opts ...FluentdOption) LoggingOption {
 	return func(l *v1beta1.Logging) {
 		l.Spec.FluentdSpec = FluentdSpec(opts...)
 	}
 }
 
-// FluentdOption modifies a FluentdSpec under construction. It is exported so the
-// same options serve Logging.FluentdSpec and a detached FluentdConfig.
+// Exported so the same options serve Logging.FluentdSpec and a detached FluentdConfig.
 type FluentdOption func(*v1beta1.FluentdSpec)
 
-// FluentdSpec builds the aggregator spec shared by the Logging-embedded and
-// detached forms.
 func FluentdSpec(opts ...FluentdOption) *v1beta1.FluentdSpec {
 	s := &v1beta1.FluentdSpec{
 		Image:               image(FluentdImageRepo),
@@ -88,12 +79,10 @@ func FluentdSpec(opts ...FluentdOption) *v1beta1.FluentdSpec {
 	return s
 }
 
-// Workers overrides the worker count.
 func Workers(n int32) FluentdOption {
 	return func(s *v1beta1.FluentdSpec) { s.Workers = n }
 }
 
-// Drain enables buffer draining on downscale.
 func Drain() FluentdOption {
 	return func(s *v1beta1.FluentdSpec) {
 		s.Scaling = &v1beta1.FluentdScaling{

--- a/e2e/internal/fixture/tenancy.go
+++ b/e2e/internal/fixture/tenancy.go
@@ -26,20 +26,15 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-// The two loggingRef values the multi-tenant suites route between.
 const (
 	InfraRef  = "infra"
 	TenantRef = "tenant"
 )
 
-// TenantReceiverURL is the cross-namespace form the tenant output posts to,
-// where the receiver lives in the infra namespace.
 func TenantReceiverURL(release, nsInfra, tag string) string {
 	return fmt.Sprintf("http://%s-test-receiver.%s:8080/%s", release, nsInfra, tag)
 }
 
-// LoggingInfra builds the infra-side ClusterOutput, ClusterFlow, FluentbitAgent
-// and Logging, in creation order. The caller creates them.
 func LoggingInfra(nsInfra, release, tag string, buffer *output.Buffer, producerLabels map[string]string) []client.Object {
 	out := &v1beta1.ClusterOutput{
 		ObjectMeta: metav1.ObjectMeta{Name: "http", Namespace: nsInfra},
@@ -87,8 +82,6 @@ func LoggingInfra(nsInfra, release, tag string, buffer *output.Buffer, producerL
 	return []client.Object{out, flow, agent, logging}
 }
 
-// LoggingTenant builds the tenant-side Output, Flow and Logging, in creation
-// order.
 func LoggingTenant(nsTenant, nsInfra, release, tag string, buffer *output.Buffer, producerLabels map[string]string) []client.Object {
 	out := &v1beta1.Output{
 		ObjectMeta: metav1.ObjectMeta{Name: "http", Namespace: nsTenant},
@@ -128,8 +121,6 @@ func LoggingTenant(nsTenant, nsInfra, release, tag string, buffer *output.Buffer
 	return []client.Object{out, flow, logging}
 }
 
-// LoggingRoute connects the infra collectors to every aggregator carrying a
-// tenant label.
 func LoggingRoute() *v1beta1.LoggingRoute {
 	return &v1beta1.LoggingRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "tenants"},
@@ -144,8 +135,7 @@ func LoggingRoute() *v1beta1.LoggingRoute {
 	}
 }
 
-// tenancyFluentdSpec is deliberately not FluentdSpec(): both tenancy
-// aggregators disable the PVC and request less than the single-tenant suites.
+// Not FluentdSpec(): tenancy disables the PVC and requests less.
 func tenancyFluentdSpec() *v1beta1.FluentdSpec {
 	return &v1beta1.FluentdSpec{
 		Image:               image(FluentdImageRepo),

--- a/e2e/internal/fixture/tenancy.go
+++ b/e2e/internal/fixture/tenancy.go
@@ -1,0 +1,163 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
+)
+
+// The two loggingRef values the multi-tenant suites route between.
+const (
+	InfraRef  = "infra"
+	TenantRef = "tenant"
+)
+
+// TenantReceiverURL is the cross-namespace form the tenant output posts to,
+// where the receiver lives in the infra namespace.
+func TenantReceiverURL(release, nsInfra, tag string) string {
+	return fmt.Sprintf("http://%s-test-receiver.%s:8080/%s", release, nsInfra, tag)
+}
+
+// LoggingInfra builds the infra-side objects: a ClusterOutput and ClusterFlow
+// carrying the infra loggingRef, a FluentbitAgent, and the aggregator Logging.
+// Returned in creation order; the caller creates them.
+func LoggingInfra(nsInfra, release, tag string, buffer *output.Buffer, producerLabels map[string]string) []client.Object {
+	out := &v1beta1.ClusterOutput{
+		ObjectMeta: metav1.ObjectMeta{Name: "http", Namespace: nsInfra},
+		Spec: v1beta1.ClusterOutputSpec{
+			OutputSpec: v1beta1.OutputSpec{
+				LoggingRef: InfraRef,
+				HTTPOutput: &output.HTTPOutputConfig{
+					Endpoint:    ReceiverURL(release, tag),
+					ContentType: "application/json",
+					Buffer:      buffer,
+				},
+			},
+		},
+	}
+
+	flow := &v1beta1.ClusterFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "flow", Namespace: nsInfra},
+		Spec: v1beta1.ClusterFlowSpec{
+			LoggingRef: InfraRef,
+			Match: []v1beta1.ClusterMatch{
+				{ClusterSelect: &v1beta1.ClusterSelect{Labels: producerLabels}},
+			},
+			GlobalOutputRefs: []string{out.Name},
+		},
+	}
+
+	agent := &v1beta1.FluentbitAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: InfraRef},
+		Spec: v1beta1.FluentbitSpec{
+			LoggingRef:        InfraRef,
+			ConfigHotReload:   &v1beta1.HotReload{Image: image(ConfigReloaderRepo)},
+			BufferVolumeImage: image(NodeExporterRepo),
+		},
+	}
+
+	logging := &v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: InfraRef, Labels: map[string]string{"tenant": InfraRef}},
+		Spec: v1beta1.LoggingSpec{
+			LoggingRef:       InfraRef,
+			ControlNamespace: nsInfra,
+			FluentdSpec:      tenancyFluentdSpec(),
+		},
+	}
+
+	return []client.Object{out, flow, agent, logging}
+}
+
+// LoggingTenant builds the tenant-side objects: a namespaced Output and Flow
+// carrying the tenant loggingRef, and the aggregator Logging watching the
+// tenant namespace. Returned in creation order.
+func LoggingTenant(nsTenant, nsInfra, release, tag string, buffer *output.Buffer, producerLabels map[string]string) []client.Object {
+	out := &v1beta1.Output{
+		ObjectMeta: metav1.ObjectMeta{Name: "http", Namespace: nsTenant},
+		Spec: v1beta1.OutputSpec{
+			LoggingRef: TenantRef,
+			HTTPOutput: &output.HTTPOutputConfig{
+				Endpoint:    TenantReceiverURL(release, nsInfra, tag),
+				ContentType: "application/json",
+				Buffer:      buffer,
+			},
+		},
+	}
+
+	flow := &v1beta1.Flow{
+		ObjectMeta: metav1.ObjectMeta{Name: "flow", Namespace: nsTenant},
+		Spec: v1beta1.FlowSpec{
+			LoggingRef: TenantRef,
+			Match: []v1beta1.Match{
+				{Select: &v1beta1.Select{Labels: producerLabels}},
+			},
+			LocalOutputRefs: []string{out.Name},
+		},
+	}
+
+	logging := &v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: TenantRef, Labels: map[string]string{"tenant": TenantRef}},
+		Spec: v1beta1.LoggingSpec{
+			LoggingRef:       TenantRef,
+			ControlNamespace: nsTenant,
+			WatchNamespaces:  []string{TenantRef},
+			FluentdSpec:      tenancyFluentdSpec(),
+		},
+	}
+
+	return []client.Object{out, flow, logging}
+}
+
+// LoggingRoute builds the route connecting the infra collectors to every
+// aggregator carrying a tenant label.
+func LoggingRoute() *v1beta1.LoggingRoute {
+	return &v1beta1.LoggingRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "tenants"},
+		Spec: v1beta1.LoggingRouteSpec{
+			Source: InfraRef,
+			Targets: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "tenant", Operator: metav1.LabelSelectorOpExists},
+				},
+			},
+		},
+	}
+}
+
+// tenancyFluentdSpec is deliberately not FluentdSpec(): both tenancy
+// aggregators disable the PVC and request 50m/50M, where the twelve
+// single-tenant call sites use the larger limits and requests pair.
+func tenancyFluentdSpec() *v1beta1.FluentdSpec {
+	return &v1beta1.FluentdSpec{
+		Image:               image(FluentdImageRepo),
+		ConfigReloaderImage: image(ConfigReloaderRepo),
+		BufferVolumeImage:   image(NodeExporterRepo),
+		DisablePvc:          true,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50M"),
+			},
+		},
+	}
+}

--- a/e2e/internal/fixture/tenancy.go
+++ b/e2e/internal/fixture/tenancy.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Kube logging authors
+// Copyright © 2026 Kube logging authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,9 +38,8 @@ func TenantReceiverURL(release, nsInfra, tag string) string {
 	return fmt.Sprintf("http://%s-test-receiver.%s:8080/%s", release, nsInfra, tag)
 }
 
-// LoggingInfra builds the infra-side objects: a ClusterOutput and ClusterFlow
-// carrying the infra loggingRef, a FluentbitAgent, and the aggregator Logging.
-// Returned in creation order; the caller creates them.
+// LoggingInfra builds the infra-side ClusterOutput, ClusterFlow, FluentbitAgent
+// and Logging, in creation order. The caller creates them.
 func LoggingInfra(nsInfra, release, tag string, buffer *output.Buffer, producerLabels map[string]string) []client.Object {
 	out := &v1beta1.ClusterOutput{
 		ObjectMeta: metav1.ObjectMeta{Name: "http", Namespace: nsInfra},
@@ -88,9 +87,8 @@ func LoggingInfra(nsInfra, release, tag string, buffer *output.Buffer, producerL
 	return []client.Object{out, flow, agent, logging}
 }
 
-// LoggingTenant builds the tenant-side objects: a namespaced Output and Flow
-// carrying the tenant loggingRef, and the aggregator Logging watching the
-// tenant namespace. Returned in creation order.
+// LoggingTenant builds the tenant-side Output, Flow and Logging, in creation
+// order.
 func LoggingTenant(nsTenant, nsInfra, release, tag string, buffer *output.Buffer, producerLabels map[string]string) []client.Object {
 	out := &v1beta1.Output{
 		ObjectMeta: metav1.ObjectMeta{Name: "http", Namespace: nsTenant},
@@ -115,10 +113,8 @@ func LoggingTenant(nsTenant, nsInfra, release, tag string, buffer *output.Buffer
 		},
 	}
 
-	// WatchNamespaces is a namespace list, not a loggingRef: it has to name the
+	// WatchNamespaces takes namespaces, not loggingRefs: it must name the
 	// namespace the Flow and Output above live in, or they are never picked up.
-	// The two only coincide today because the suites name that namespace
-	// "tenant", the same string as TenantRef.
 	logging := &v1beta1.Logging{
 		ObjectMeta: metav1.ObjectMeta{Name: TenantRef, Labels: map[string]string{"tenant": TenantRef}},
 		Spec: v1beta1.LoggingSpec{
@@ -132,8 +128,8 @@ func LoggingTenant(nsTenant, nsInfra, release, tag string, buffer *output.Buffer
 	return []client.Object{out, flow, logging}
 }
 
-// LoggingRoute builds the route connecting the infra collectors to every
-// aggregator carrying a tenant label.
+// LoggingRoute connects the infra collectors to every aggregator carrying a
+// tenant label.
 func LoggingRoute() *v1beta1.LoggingRoute {
 	return &v1beta1.LoggingRoute{
 		ObjectMeta: metav1.ObjectMeta{Name: "tenants"},
@@ -149,8 +145,7 @@ func LoggingRoute() *v1beta1.LoggingRoute {
 }
 
 // tenancyFluentdSpec is deliberately not FluentdSpec(): both tenancy
-// aggregators disable the PVC and request 50m/50M, where the twelve
-// single-tenant call sites use the larger limits and requests pair.
+// aggregators disable the PVC and request less than the single-tenant suites.
 func tenancyFluentdSpec() *v1beta1.FluentdSpec {
 	return &v1beta1.FluentdSpec{
 		Image:               image(FluentdImageRepo),

--- a/e2e/internal/fixture/tenancy.go
+++ b/e2e/internal/fixture/tenancy.go
@@ -115,12 +115,16 @@ func LoggingTenant(nsTenant, nsInfra, release, tag string, buffer *output.Buffer
 		},
 	}
 
+	// WatchNamespaces is a namespace list, not a loggingRef: it has to name the
+	// namespace the Flow and Output above live in, or they are never picked up.
+	// The two only coincide today because the suites name that namespace
+	// "tenant", the same string as TenantRef.
 	logging := &v1beta1.Logging{
 		ObjectMeta: metav1.ObjectMeta{Name: TenantRef, Labels: map[string]string{"tenant": TenantRef}},
 		Spec: v1beta1.LoggingSpec{
 			LoggingRef:       TenantRef,
 			ControlNamespace: nsTenant,
-			WatchNamespaces:  []string{TenantRef},
+			WatchNamespaces:  []string{nsTenant},
 			FluentdSpec:      tenancyFluentdSpec(),
 		},
 	}

--- a/e2e/internal/fixture/tenancy_test.go
+++ b/e2e/internal/fixture/tenancy_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Kube logging authors
+// Copyright © 2026 Kube logging authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,16 +74,12 @@ func TestLoggingTenantShape(t *testing.T) {
 	lg := objs[2].(*v1beta1.Logging)
 	require.Equal(t, TenantRef, lg.Spec.LoggingRef)
 	require.Equal(t, "tenant-ns", lg.Spec.ControlNamespace)
-	// The aggregator has to watch the namespace the Flow and Output were created
-	// in. "tenant-ns" differs from TenantRef on purpose: were the two equal, this
-	// assertion would pass against a hard-coded ref and prove nothing.
+	// "tenant-ns" differs from TenantRef on purpose: were the two equal, the
+	// assertion below would also pass against a hard-coded ref.
 	require.NotEqual(t, TenantRef, flow.Namespace)
 	require.Equal(t, []string{flow.Namespace}, lg.Spec.WatchNamespaces)
 }
 
-// Both tenancy aggregators diverge from the single-tenant default: PVC off and
-// requests-only 50m/50M. A default that absorbed this would silently give them
-// the larger 500m/200M pair and a PVC.
 func TestTenancyAggregatorDivergesFromTheDefault(t *testing.T) {
 	infra := LoggingInfra("i", "e2e", "t", Buffer("time"), nil)[3].(*v1beta1.Logging)
 	tenant := LoggingTenant("t", "i", "e2e", "t", Buffer("time"), nil)[2].(*v1beta1.Logging)
@@ -94,7 +90,7 @@ func TestTenancyAggregatorDivergesFromTheDefault(t *testing.T) {
 		require.Equal(t, resource.MustParse("50m"), fd.Resources.Requests[corev1.ResourceCPU])
 		require.Equal(t, resource.MustParse("50M"), fd.Resources.Requests[corev1.ResourceMemory])
 		require.Empty(t, fd.Resources.Limits, "the tenancy specs set no limits")
-		require.Zero(t, fd.Workers, "tenancy does not set Workers; the single-tenant default is 2")
+		require.Zero(t, fd.Workers, "tenancy does not set Workers")
 		require.Nil(t, fd.Scaling)
 	}
 

--- a/e2e/internal/fixture/tenancy_test.go
+++ b/e2e/internal/fixture/tenancy_test.go
@@ -74,7 +74,11 @@ func TestLoggingTenantShape(t *testing.T) {
 	lg := objs[2].(*v1beta1.Logging)
 	require.Equal(t, TenantRef, lg.Spec.LoggingRef)
 	require.Equal(t, "tenant-ns", lg.Spec.ControlNamespace)
-	require.Equal(t, []string{TenantRef}, lg.Spec.WatchNamespaces)
+	// The aggregator has to watch the namespace the Flow and Output were created
+	// in. "tenant-ns" differs from TenantRef on purpose: were the two equal, this
+	// assertion would pass against a hard-coded ref and prove nothing.
+	require.NotEqual(t, TenantRef, flow.Namespace)
+	require.Equal(t, []string{flow.Namespace}, lg.Spec.WatchNamespaces)
 }
 
 // Both tenancy aggregators diverge from the single-tenant default: PVC off and

--- a/e2e/internal/fixture/tenancy_test.go
+++ b/e2e/internal/fixture/tenancy_test.go
@@ -1,0 +1,109 @@
+// Copyright © 2025 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+func TestLoggingInfraShape(t *testing.T) {
+	buf := Buffer("time")
+	labels := map[string]string{"my-unique-label": "log-producer"}
+	objs := LoggingInfra("infra-ns", "e2e", "test.tag", buf, labels)
+
+	require.Len(t, objs, 4, "ClusterOutput, ClusterFlow, FluentbitAgent, Logging — in creation order")
+
+	out := objs[0].(*v1beta1.ClusterOutput)
+	require.Equal(t, "http", out.Name)
+	require.Equal(t, "infra-ns", out.Namespace)
+	require.Equal(t, InfraRef, out.Spec.LoggingRef)
+	require.Equal(t, "http://e2e-test-receiver:8080/test.tag", out.Spec.HTTPOutput.Endpoint)
+	require.Same(t, buf, out.Spec.HTTPOutput.Buffer)
+
+	flow := objs[1].(*v1beta1.ClusterFlow)
+	require.Equal(t, InfraRef, flow.Spec.LoggingRef)
+	require.Equal(t, labels, flow.Spec.Match[0].ClusterSelect.Labels)
+	require.Equal(t, []string{"http"}, flow.Spec.GlobalOutputRefs)
+
+	agent := objs[2].(*v1beta1.FluentbitAgent)
+	require.Equal(t, InfraRef, agent.Spec.LoggingRef)
+	require.Equal(t, "config-reloader", agent.Spec.ConfigHotReload.Image.Repository)
+
+	lg := objs[3].(*v1beta1.Logging)
+	require.Equal(t, InfraRef, lg.Spec.LoggingRef)
+	require.Equal(t, "infra-ns", lg.Spec.ControlNamespace)
+	require.Equal(t, map[string]string{"tenant": InfraRef}, lg.Labels)
+	require.Empty(t, lg.Spec.WatchNamespaces, "only the tenant side watches a namespace")
+}
+
+func TestLoggingTenantShape(t *testing.T) {
+	buf := Buffer("time")
+	labels := map[string]string{"my-unique-label": "log-producer"}
+	objs := LoggingTenant("tenant-ns", "infra-ns", "e2e", "test.tag", buf, labels)
+
+	require.Len(t, objs, 3, "Output, Flow, Logging — no agent on the tenant side")
+
+	out := objs[0].(*v1beta1.Output)
+	require.Equal(t, TenantRef, out.Spec.LoggingRef)
+	// Cross-namespace: the receiver lives in the infra namespace.
+	require.Equal(t, "http://e2e-test-receiver.infra-ns:8080/test.tag", out.Spec.HTTPOutput.Endpoint)
+
+	flow := objs[1].(*v1beta1.Flow)
+	require.Equal(t, TenantRef, flow.Spec.LoggingRef)
+	require.Equal(t, []string{"http"}, flow.Spec.LocalOutputRefs)
+
+	lg := objs[2].(*v1beta1.Logging)
+	require.Equal(t, TenantRef, lg.Spec.LoggingRef)
+	require.Equal(t, "tenant-ns", lg.Spec.ControlNamespace)
+	require.Equal(t, []string{TenantRef}, lg.Spec.WatchNamespaces)
+}
+
+// Both tenancy aggregators diverge from the single-tenant default: PVC off and
+// requests-only 50m/50M. A default that absorbed this would silently give them
+// the larger 500m/200M pair and a PVC.
+func TestTenancyAggregatorDivergesFromTheDefault(t *testing.T) {
+	infra := LoggingInfra("i", "e2e", "t", Buffer("time"), nil)[3].(*v1beta1.Logging)
+	tenant := LoggingTenant("t", "i", "e2e", "t", Buffer("time"), nil)[2].(*v1beta1.Logging)
+
+	for _, lg := range []*v1beta1.Logging{infra, tenant} {
+		fd := lg.Spec.FluentdSpec
+		require.True(t, fd.DisablePvc)
+		require.Equal(t, resource.MustParse("50m"), fd.Resources.Requests[corev1.ResourceCPU])
+		require.Equal(t, resource.MustParse("50M"), fd.Resources.Requests[corev1.ResourceMemory])
+		require.Empty(t, fd.Resources.Limits, "the tenancy specs set no limits")
+		require.Zero(t, fd.Workers, "tenancy does not set Workers; the single-tenant default is 2")
+		require.Nil(t, fd.Scaling)
+	}
+
+	// The single-tenant builder must still carry its own, different values.
+	def := FluentdSpec()
+	require.False(t, def.DisablePvc)
+	require.Equal(t, resource.MustParse("500m"), def.Resources.Limits[corev1.ResourceCPU])
+}
+
+func TestLoggingRoute(t *testing.T) {
+	r := LoggingRoute()
+	require.Equal(t, "tenants", r.Name)
+	require.Equal(t, InfraRef, r.Spec.Source)
+	require.Equal(t, metav1.LabelSelectorOpExists, r.Spec.Targets.MatchExpressions[0].Operator)
+	require.Equal(t, "tenant", r.Spec.Targets.MatchExpressions[0].Key)
+}

--- a/e2e/internal/fixture/tenancy_test.go
+++ b/e2e/internal/fixture/tenancy_test.go
@@ -64,7 +64,6 @@ func TestLoggingTenantShape(t *testing.T) {
 
 	out := objs[0].(*v1beta1.Output)
 	require.Equal(t, TenantRef, out.Spec.LoggingRef)
-	// Cross-namespace: the receiver lives in the infra namespace.
 	require.Equal(t, "http://e2e-test-receiver.infra-ns:8080/test.tag", out.Spec.HTTPOutput.Endpoint)
 
 	flow := objs[1].(*v1beta1.Flow)
@@ -74,8 +73,8 @@ func TestLoggingTenantShape(t *testing.T) {
 	lg := objs[2].(*v1beta1.Logging)
 	require.Equal(t, TenantRef, lg.Spec.LoggingRef)
 	require.Equal(t, "tenant-ns", lg.Spec.ControlNamespace)
-	// "tenant-ns" differs from TenantRef on purpose: were the two equal, the
-	// assertion below would also pass against a hard-coded ref.
+	// Differs from TenantRef on purpose: were they equal the assertion would also
+	// pass against a hard-coded ref.
 	require.NotEqual(t, TenantRef, flow.Namespace)
 	require.Equal(t, []string{flow.Namespace}, lg.Spec.WatchNamespaces)
 }
@@ -94,7 +93,6 @@ func TestTenancyAggregatorDivergesFromTheDefault(t *testing.T) {
 		require.Nil(t, fd.Scaling)
 	}
 
-	// The single-tenant builder must still carry its own, different values.
 	def := FluentdSpec()
 	require.False(t, def.DisablePvc)
 	require.Equal(t, resource.MustParse("500m"), def.Resources.Limits[corev1.ResourceCPU])


### PR DESCRIPTION
Adds `e2e/internal/fixture`, builders for the CR literals the suites repeat. Nothing imports it yet, so no existing behaviour changes.

- `Logging`, `FluentdSpec`, `Buffer`, `HTTPOutput` and `Flow`, with functional options.
- `LoggingInfra`, `LoggingTenant` and `LoggingRoute` ported from `common/helpers.go` as pure builders returning the objects in creation order, so the caller creates them and the package needs no client, context or `testing.T`.
- Each default is the value most call sites already use. Anything that diverges passes an option.
- Tenancy keeps its own aggregator spec: it disables the PVC and requests less than the single-tenant suites.
- The package does not import `common`. The image constants are duplicated while both exist and a test pins them equal, so they cannot drift the way the syslog-ng reloader name did.

13 tests, no cluster. `make check` passes.
