### PR TITLE
perf(e2e): load the operator images in one kind invocation

### DIFF
--- a/e2e/common/setup/loggingoperator.go
+++ b/e2e/common/setup/loggingoperator.go
@@ -114,15 +114,19 @@ func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOpti
 	}
 
 	var loggingOperatorImage e2eImage
+	images := make([]string, 0, len(defaultImages))
 	for _, image := range defaultImages {
 		if image.lookupEnv == "LOGGING_OPERATOR_IMAGE" {
 			loggingOperatorImage = image
 		}
 
-		err := c.LoadImages(processImage(t, image))
-		if err != nil {
-			t.Fatalf("kind load image: %s", err)
-		}
+		images = append(images, processImage(t, image))
+	}
+
+	// One invocation, so docker save writes shared layers once instead of once
+	// per image.
+	if err := c.LoadImages(images...); err != nil {
+		t.Fatalf("kind load images: %s", err)
 	}
 
 	_, err = installer.Run(chartReq, map[string]interface{}{

--- a/e2e/internal/kind/commands_test.go
+++ b/e2e/internal/kind/commands_test.go
@@ -235,6 +235,14 @@ func TestInvocations(t *testing.T) {
 			timeout: time.Minute,
 			want:    nil,
 		},
+		// One call for every image, so docker save writes shared layers once.
+		"several images load in a single call": {
+			invoke: func(k *Kind) error {
+				return k.LoadDockerImage([]string{"a:local", "b:local", "c:local"}, LoadDockerImageOptions{Name: "c"})
+			},
+			timeout: time.Minute,
+			want:    []string{"load docker-image --name c a:local b:local c:local"},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
`LoggingOperator` looped over the six images calling `LoadImages` once each, so every cluster ran six `kind load docker-image` invocations — 102 across a full run where 17 would do. `LoadImages` was already variadic and `LoadDockerImage` already appends every image to one command, so only the caller changed.

`docker save` writes a shared layer once per invocation rather than once per image. Measured on three layer-sharing images locally: 88,659,456 bytes as three separate tars against 59,109,376 batched, 33% less. The six e2e images are not built locally, so their real overlap is unmeasured.

This reduces I/O volume without serialising anything, so it does not contradict the measurement in #2287 that concurrent loads beat serial ones. It is one contributor to that flake, not the whole fix — the concurrency cap is still open there.

`TestInvocations` now pins that several images produce a single command line. The caller side has no unit test: `LoggingOperator` needs a live cluster, so only a real e2e run exercises it.
