### PR TITLE
feat(e2e): add internal/harness and move fluentbit-multitenant onto it

### DIFF
--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -59,8 +59,8 @@ func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
 	env.WaitForRunning(
 		wait.Operator(release),
 		wait.Producer(producerLabels),
-		wait.Aggregator(nsInfra),
-		wait.Aggregator(nsTenant),
+		wait.FluentdAggregator(nsInfra),
+		wait.FluentdAggregator(nsTenant),
 	)
 	env.WaitForReceiverLogs(tagInfra, tagTenant)
 }

--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -15,13 +15,7 @@
 package fluentbit_multitenant
 
 import (
-	"strings"
 	"testing"
-	"time"
-
-	"github.com/cisco-open/operator-tools/pkg/types"
-	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kube-logging/logging-operator/e2e/internal/fixture"
 	"github.com/kube-logging/logging-operator/e2e/internal/harness"
@@ -48,12 +42,12 @@ func realTimeBuffer() *output.Buffer {
 }
 
 func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
-	env := harness.Start(t, harness.Config{
-		Cluster:          release,
-		Release:          release,
-		ControlNamespace: nsInfra,
-		Namespaces:       []string{nsTenant},
-	})
+	env := harness.New(t).
+		WithCluster(release).
+		WithRelease(release).
+		WithControlNamespace(nsInfra).
+		WithNamespaces(nsTenant).
+		Start()
 
 	buffer := realTimeBuffer()
 	env.Create(fixture.LoggingInfra(nsInfra, release, tagInfra, buffer, producerLabels)...)
@@ -62,32 +56,11 @@ func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
 
 	env.StartLogProducer(nsTenant, producerLabels)
 
-	aggregator := client.MatchingLabels{types.NameLabel: "fluentd", types.ComponentLabel: "fluentd"}
-	running := []struct {
-		what string
-		cond func() bool
-	}{
-		{"the operator", wait.AnyPodShouldBeRunning(t, env.Client, client.MatchingLabels{types.NameLabel: release})},
-		{"the producer", wait.AnyPodShouldBeRunning(t, env.Client, client.MatchingLabels(producerLabels))},
-		{"the infra aggregator", wait.AnyPodShouldBeRunning(t, env.Client, aggregator, client.InNamespace(nsInfra))},
-		{"the tenant aggregator", wait.AnyPodShouldBeRunning(t, env.Client, aggregator, client.InNamespace(nsTenant))},
-	}
-
-	require.Eventually(t, func() bool {
-		for _, step := range running {
-			if !step.cond() {
-				t.Logf("waiting for %s", step.what)
-				return false
-			}
-		}
-
-		logs, err := env.ReceiverLogs(30)
-		if err != nil {
-			t.Logf("failed to get log consumer logs: %v", err)
-			return false
-		}
-		t.Logf("log consumer logs: %s", logs)
-
-		return strings.Contains(logs, tagTenant) && strings.Contains(logs, tagInfra)
-	}, 5*time.Minute, 3*time.Second)
+	env.WaitForRunning(
+		wait.Operator(release),
+		wait.Producer(producerLabels),
+		wait.Aggregator(nsInfra),
+		wait.Aggregator(nsTenant),
+	)
+	env.WaitForReceiverLogs(tagInfra, tagTenant)
 }

--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -15,162 +15,79 @@
 package fluentbit_multitenant
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cisco-open/operator-tools/pkg/types"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/fixture"
+	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-var TestTempDir string
-
-func init() {
-	var ok bool
-	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
-	if !ok {
-		TestTempDir = "../.."
-	}
-	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
-	if err != nil {
-		panic(err)
-	}
-}
-
-var (
-	tags           = "time"
-	realTimeBuffer = &output.Buffer{
-		Tags:        &tags,
-		Timekey:     "1s",
-		TimekeyWait: "0s",
-	}
+const (
+	release   = "fluentbit-multitenant"
+	nsInfra   = "infra"
+	nsTenant  = "tenant"
+	tagInfra  = "tag_infra"
+	tagTenant = "tag_tenant"
 )
 
-var producerLabels = map[string]string{
-	"my-unique-label": "log-producer",
+var producerLabels = map[string]string{"my-unique-label": "log-producer"}
+
+// This is the one suite whose buffer leaves Type unset, so it is written out
+// rather than taken from fixture.Buffer, whose "file" default would switch the
+// outputs from memory buffering.
+func realTimeBuffer() *output.Buffer {
+	tags := "time"
+	return &output.Buffer{Tags: &tags, Timekey: "1s", TimekeyWait: "0s"}
 }
 
 func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
-	common.Initialize(t)
-	nsInfra := "infra"
-	nsTenant := "tenant"
-	tagInfra := "tag_infra"
-	tagTenant := "tag_tenant"
-
-	release := "fluentbit-multitenant"
-	common.WithCluster(release, t, func(t *testing.T, c common.Cluster) {
-		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
-			options.Namespace = nsInfra
-			options.NameOverride = release
-		}))
-
-		ctx := context.Background()
-
-		common.RequireNoError(t, c.GetClient().Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: nsTenant,
-			},
-		}))
-
-		common.LoggingInfra(ctx, t, c.GetClient(), nsInfra, release, tagInfra, realTimeBuffer, producerLabels)
-		common.LoggingTenant(ctx, t, c.GetClient(), nsTenant, nsInfra, release, tagTenant, realTimeBuffer, producerLabels)
-		common.LoggingRoute(ctx, t, c.GetClient())
-
-		aggregatorLabels := map[string]string{
-			types.NameLabel:      "fluentd",
-			types.ComponentLabel: "fluentd",
-		}
-		operatorLabels := map[string]string{
-			types.NameLabel: release,
-		}
-
-		// start log producer in the tenant namespace
-		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
-			options.Namespace = nsTenant
-			options.Labels = producerLabels
-		}))
-
-		require.Eventually(t, func() bool {
-			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
-				t.Log("waiting for the operator")
-				return false
-			}
-			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
-				t.Log("waiting for the producer")
-				return false
-			}
-			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsInfra)); !aggregatorRunning() {
-				t.Log("waiting for the infra aggregator")
-				return false
-			}
-			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsTenant)); !aggregatorRunning() {
-				t.Log("waiting for the tenant aggregator")
-				return false
-			}
-
-			cmd := common.CmdEnv(exec.Command("kubectl",
-				"logs",
-				"-n", nsInfra,
-				"--tail", "30",
-				"-l", fmt.Sprintf("%s=%s-test-receiver", types.NameLabel, release)), c)
-			rawOut, err := cmd.Output()
-			if err != nil {
-				t.Logf("failed to get log consumer logs: %v", err)
-				return false
-			}
-			t.Logf("log consumer logs: %s", rawOut)
-			return strings.Contains(string(rawOut), tagTenant) && strings.Contains(string(rawOut), tagInfra)
-		}, 5*time.Minute, 3*time.Second)
-	}, func(t *testing.T, c common.Cluster) error {
-		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
-		t.Logf("Printing cluster logs to %s", path)
-		err := c.PrintLogs(common.PrintLogConfig{
-			Namespaces: []string{nsInfra, nsTenant, "default"},
-			FilePath:   path,
-			Limit:      100 * 1000,
-		})
-		if err != nil {
-			return err
-		}
-
-		loggingOperatorName := "logging-operator-" + release
-		t.Logf("Collecting coverage files from logging-operator: %s/%s", nsInfra, loggingOperatorName)
-		err = c.CollectTestCoverageFiles(nsInfra, loggingOperatorName)
-		if err != nil {
-			t.Logf("Failed collecting coverage files: %s", err)
-		}
-
-		return nil
-	}, func(o *cluster.Options) {
-		if o.Scheme == nil {
-			o.Scheme = runtime.NewScheme()
-		}
-		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
+	env := harness.Start(t, harness.Config{
+		Cluster:          release,
+		Release:          release,
+		ControlNamespace: nsInfra,
+		Namespaces:       []string{nsTenant},
 	})
+
+	buffer := realTimeBuffer()
+	env.Create(fixture.LoggingInfra(nsInfra, release, tagInfra, buffer, producerLabels)...)
+	env.Create(fixture.LoggingTenant(nsTenant, nsInfra, release, tagTenant, buffer, producerLabels)...)
+	env.Create(fixture.LoggingRoute())
+
+	env.StartLogProducer(nsTenant, producerLabels)
+
+	aggregator := client.MatchingLabels{types.NameLabel: "fluentd", types.ComponentLabel: "fluentd"}
+	running := []struct {
+		what string
+		cond func() bool
+	}{
+		{"the operator", wait.AnyPodShouldBeRunning(t, env.Client, client.MatchingLabels{types.NameLabel: release})},
+		{"the producer", wait.AnyPodShouldBeRunning(t, env.Client, client.MatchingLabels(producerLabels))},
+		{"the infra aggregator", wait.AnyPodShouldBeRunning(t, env.Client, aggregator, client.InNamespace(nsInfra))},
+		{"the tenant aggregator", wait.AnyPodShouldBeRunning(t, env.Client, aggregator, client.InNamespace(nsTenant))},
+	}
+
+	require.Eventually(t, func() bool {
+		for _, step := range running {
+			if !step.cond() {
+				t.Logf("waiting for %s", step.what)
+				return false
+			}
+		}
+
+		logs, err := env.ReceiverLogs(30)
+		if err != nil {
+			t.Logf("failed to get log consumer logs: %v", err)
+			return false
+		}
+		t.Logf("log consumer logs: %s", logs)
+
+		return strings.Contains(logs, tagTenant) && strings.Contains(logs, tagInfra)
+	}, 5*time.Minute, 3*time.Second)
 }

--- a/e2e/internal/fixture/equivalence_test.go
+++ b/e2e/internal/fixture/equivalence_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fixture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kube-logging/logging-operator/e2e/common"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
+)
+
+// recorder keeps whatever is handed to Create. The embedded nil Client is
+// never reached: the helpers under test only create.
+type recorder struct {
+	client.Client
+	created []client.Object
+}
+
+func (r *recorder) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+	r.created = append(r.created, obj)
+	return nil
+}
+
+// The builders have to keep producing what common creates today, object for
+// object and in the same order, or a suite that moves onto them stops testing
+// what it used to. Nothing else pins that: the shape tests above assert the
+// fields this package chose, not that the choice matches the live path.
+func TestBuildersMatchCommon(t *testing.T) {
+	const (
+		nsInfra  = "infra"
+		nsTenant = "tenant"
+		release  = "fluentbit-multitenant"
+	)
+	labels := map[string]string{"my-unique-label": "log-producer"}
+	buffer := func() *output.Buffer {
+		tags := "time"
+		return &output.Buffer{Tags: &tags, Timekey: "1s", TimekeyWait: "0s"}
+	}
+
+	t.Run("infra", func(t *testing.T) {
+		rec := &recorder{}
+		common.LoggingInfra(context.Background(), t, rec, nsInfra, release, "tag_infra", buffer(), labels)
+
+		require.Equal(t, rec.created, LoggingInfra(nsInfra, release, "tag_infra", buffer(), labels))
+	})
+
+	t.Run("tenant", func(t *testing.T) {
+		rec := &recorder{}
+		common.LoggingTenant(context.Background(), t, rec, nsTenant, nsInfra, release, "tag_tenant", buffer(), labels)
+
+		require.Equal(t, rec.created, LoggingTenant(nsTenant, nsInfra, release, "tag_tenant", buffer(), labels))
+	})
+
+	t.Run("route", func(t *testing.T) {
+		rec := &recorder{}
+		common.LoggingRoute(context.Background(), t, rec)
+
+		require.Equal(t, rec.created, []client.Object{LoggingRoute()})
+	})
+}

--- a/e2e/internal/fixture/equivalence_test.go
+++ b/e2e/internal/fixture/equivalence_test.go
@@ -39,8 +39,11 @@ func (r *recorder) Create(_ context.Context, obj client.Object, _ ...client.Crea
 
 // The builders have to keep producing what common creates today, object for
 // object and in the same order, or a suite that moves onto them stops testing
-// what it used to. Nothing else pins that: the shape tests above assert the
-// fields this package chose, not that the choice matches the live path.
+// what it used to. Nothing else pins that: the shape tests assert the fields
+// this package chose, not that the choice matches the live path.
+//
+// Scaffolding, not a fixture: it makes common the oracle, so common cannot be
+// deleted while it stands. It goes with the last suite that still uses common.
 func TestBuildersMatchCommon(t *testing.T) {
 	const (
 		nsInfra  = "infra"

--- a/e2e/internal/harness/harness.go
+++ b/e2e/internal/harness/harness.go
@@ -125,21 +125,14 @@ func Start(t *testing.T, cfg Config) *Env {
 		ControlNamespace: cfg.ControlNamespace,
 	}
 
-	// t.Cleanup is LIFO and the order below is load-bearing, so these are
-	// registered back to front: artifacts, kubeconfig, cancel, delete.
-	t.Cleanup(func() { assert.NoError(t, common.DeleteTestCluster(cfg.Cluster)) })
-	t.Cleanup(func() {
-		cancel()
-		// Checked here, not in the goroutine: FailNow is undefined off the test one.
-		select {
-		case err := <-startErr:
-			assert.NoError(t, err, "starting the cluster")
-		case <-time.After(clusterStopTimeout):
-			assert.Fail(t, "cluster.Start did not return after cancellation")
-		}
-	})
-	t.Cleanup(func() { assert.NoError(t, c.Cleanup()) })
-	t.Cleanup(func() { env.collectArtifacts(cfg) })
+	registerTeardown(t.Cleanup,
+		func(step string, v any) { assert.Fail(t, fmt.Sprintf("teardown step %q panicked: %v", step, v)) },
+		teardownSteps(
+			func() { env.collectArtifacts(cfg) },
+			func() { assert.NoError(t, c.Cleanup()) },
+			func() { stopCluster(t, cancel, startErr) },
+			func() { assert.NoError(t, common.DeleteTestCluster(cfg.Cluster)) },
+		))
 
 	setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(o *setup.LoggingOperatorOptions) {
 		o.Namespace = cfg.ControlNamespace
@@ -200,6 +193,50 @@ func (e *Env) collectArtifacts(cfg Config) {
 	if err := e.Cluster.CollectTestCoverageFiles(e.ControlNamespace, operator); err != nil {
 		// Logged, never fatal: the run's coverage is not the suite's verdict.
 		e.T.Logf("Failed collecting coverage files: %s", err)
+	}
+}
+
+type teardownStep struct {
+	name string
+	run  func()
+}
+
+// teardownSteps lists them in the order they have to run. This order is what
+// kept clusters from leaking before it moved here, so it is one list rather
+// than four Cleanup calls in reverse.
+func teardownSteps(artifacts, kubeconfig, stop, deleteCluster func()) []teardownStep {
+	return []teardownStep{
+		{"artifacts", artifacts},
+		{"kubeconfig", kubeconfig},
+		{"stop", stop},
+		{"delete", deleteCluster},
+	}
+}
+
+// registerTeardown hands the steps over back to front, because Cleanup is LIFO,
+// and isolates each one: Go abandons the remaining cleanups at the first panic,
+// which would strand the cluster.
+func registerTeardown(cleanup func(func()), onPanic func(step string, v any), steps []teardownStep) {
+	for _, step := range slices.Backward(steps) {
+		cleanup(func() {
+			defer func() {
+				if v := recover(); v != nil {
+					onPanic(step.name, v)
+				}
+			}()
+			step.run()
+		})
+	}
+}
+
+func stopCluster(t *testing.T, cancel context.CancelFunc, startErr <-chan error) {
+	cancel()
+	// Checked here, not in the goroutine: FailNow is undefined off the test one.
+	select {
+	case err := <-startErr:
+		assert.NoError(t, err, "starting the cluster")
+	case <-time.After(clusterStopTimeout):
+		assert.Fail(t, "cluster.Start did not return after cancellation")
 	}
 }
 

--- a/e2e/internal/harness/harness.go
+++ b/e2e/internal/harness/harness.go
@@ -1,0 +1,244 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/cisco-open/operator-tools/pkg/types"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+
+	"github.com/kube-logging/logging-operator/e2e/common"
+	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+// clusterStopTimeout bounds the wait for cluster.Start to return after the
+// context is canceled, so a runnable that will not stop is named rather than
+// running the binary out of its -timeout.
+const clusterStopTimeout = time.Minute
+
+// clusterLogLimit is the tail length used for the archived cluster dump.
+const clusterLogLimit = 100 * 1000
+
+// defaultSchemeBuilders covers every type the suites register today except the
+// prometheus-operator ones, which only logging_metrics_monitoring needs.
+var defaultSchemeBuilders = []func(*runtime.Scheme) error{
+	v1beta1.AddToScheme,
+	apiextensionsv1.AddToScheme,
+	appsv1.AddToScheme,
+	batchv1.AddToScheme,
+	corev1.AddToScheme,
+	rbacv1.AddToScheme,
+}
+
+type Config struct {
+	// Cluster is the kind cluster name. Named rather than derived from
+	// t.Name(): kind accepts only [a-z0-9.-] and none of the test names match.
+	Cluster string
+
+	// Release is the helm release, and the operator's nameOverride with it.
+	Release string
+
+	// ControlNamespace is where the operator and the test receiver run.
+	ControlNamespace string
+
+	// Namespaces are created before the test body. They are dumped at teardown
+	// alongside ControlNamespace and default.
+	Namespaces []string
+
+	// OperatorArgs are appended to the operator's container arguments.
+	OperatorArgs []string
+
+	// ExtraSchemeBuilders are registered on top of the shared set, for the one
+	// suite that needs the prometheus-operator types.
+	ExtraSchemeBuilders []func(*runtime.Scheme) error
+}
+
+type Env struct {
+	T   *testing.T
+	Ctx context.Context
+
+	Client  client.Client
+	Cluster common.Cluster
+
+	Release          string
+	ControlNamespace string
+}
+
+// Start brings up the cluster, installs the operator and registers teardown.
+// It marks the test parallel, so it has to be the first call in the test.
+func Start(t *testing.T, cfg Config) *Env {
+	common.Initialize(t)
+
+	scheme, err := buildScheme(cfg.ExtraSchemeBuilders)
+	common.RequireNoError(t, err)
+
+	c, err := common.GetTestCluster(cfg.Cluster, func(o *cluster.Options) { o.Scheme = scheme })
+	if err != nil {
+		// The kind cluster is up before the client can fail, and teardown is
+		// not registered yet.
+		assert.NoError(t, common.DeleteTestCluster(cfg.Cluster))
+	}
+	common.RequireNoError(t, err)
+
+	// Not t.Context(): that is canceled before the first Cleanup runs, which
+	// would stop the cache before the log dump reads through it.
+	ctx, cancel := context.WithCancel(context.Background())
+	startErr := make(chan error, 1)
+	go func() { startErr <- c.Start(ctx) }()
+
+	env := &Env{
+		T:                t,
+		Ctx:              ctx,
+		Client:           c.GetClient(),
+		Cluster:          c,
+		Release:          cfg.Release,
+		ControlNamespace: cfg.ControlNamespace,
+	}
+
+	// t.Cleanup is LIFO and the order below is load-bearing, so these are
+	// registered back to front: artifacts, kubeconfig, cancel, delete.
+	t.Cleanup(func() { assert.NoError(t, common.DeleteTestCluster(cfg.Cluster)) })
+	t.Cleanup(func() {
+		cancel()
+		// Checked here, not in the goroutine: FailNow is undefined off the test one.
+		select {
+		case err := <-startErr:
+			assert.NoError(t, err, "starting the cluster")
+		case <-time.After(clusterStopTimeout):
+			assert.Fail(t, "cluster.Start did not return after cancellation")
+		}
+	})
+	t.Cleanup(func() { assert.NoError(t, c.Cleanup()) })
+	t.Cleanup(func() { env.collectArtifacts(cfg) })
+
+	setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(o *setup.LoggingOperatorOptions) {
+		o.Namespace = cfg.ControlNamespace
+		o.NameOverride = cfg.Release
+		o.Args = cfg.OperatorArgs
+	}))
+
+	for _, ns := range cfg.Namespaces {
+		env.Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	}
+
+	return env
+}
+
+func (e *Env) Create(objects ...client.Object) {
+	e.T.Helper()
+	for _, object := range objects {
+		common.RequireNoError(e.T, e.Client.Create(e.Ctx, object))
+	}
+}
+
+// StartLogProducer runs on the test goroutine: the create errors reach it
+// through RequireNoError, which needs FailNow to be defined.
+func (e *Env) StartLogProducer(namespace string, labels map[string]string) {
+	e.T.Helper()
+	setup.LogProducer(e.T, e.Client, setup.LogProducerOptionFunc(func(o *setup.LogProducerOptions) {
+		o.Namespace = namespace
+		o.Labels = labels
+	}))
+}
+
+// ReceiverLogs returns the tail of the chart's test receiver, which is where a
+// suite looks to see that its logs arrived.
+func (e *Env) ReceiverLogs(tail int) (string, error) {
+	out, err := common.CmdEnv(exec.Command("kubectl",
+		"logs",
+		"-n", e.ControlNamespace,
+		"--tail", fmt.Sprint(tail),
+		"-l", fmt.Sprintf("%s=%s-test-receiver", types.NameLabel, e.Release)), e.Cluster).Output()
+	return string(out), err
+}
+
+func (e *Env) collectArtifacts(cfg Config) {
+	path, err := artifactPath(e.T.Name())
+	if err != nil {
+		e.T.Logf("Skipping cluster logs: %s", err)
+	} else {
+		e.T.Logf("Printing cluster logs to %s", path)
+		assert.NoError(e.T, e.Cluster.PrintLogs(common.PrintLogConfig{
+			Namespaces: dumpNamespaces(cfg),
+			FilePath:   path,
+			Limit:      clusterLogLimit,
+		}))
+	}
+
+	operator := "logging-operator-" + e.Release
+	e.T.Logf("Collecting coverage files from logging-operator: %s/%s", e.ControlNamespace, operator)
+	if err := e.Cluster.CollectTestCoverageFiles(e.ControlNamespace, operator); err != nil {
+		// Logged, never fatal: the run's coverage is not the suite's verdict.
+		e.T.Logf("Failed collecting coverage files: %s", err)
+	}
+}
+
+func buildScheme(extra []func(*runtime.Scheme) error) (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	for _, add := range slices.Concat(defaultSchemeBuilders, extra) {
+		if err := add(scheme); err != nil {
+			return nil, err
+		}
+	}
+	return scheme, nil
+}
+
+// dumpNamespaces is ControlNamespace, the configured ones and default, without
+// repeats, so a suite that names one of them does not dump it twice.
+func dumpNamespaces(cfg Config) []string {
+	out := make([]string, 0, len(cfg.Namespaces)+2)
+	seen := map[string]bool{}
+	// Concat, not append: appending to cfg.Namespaces could write into the
+	// caller's backing array.
+	for _, ns := range slices.Concat([]string{cfg.ControlNamespace}, cfg.Namespaces, []string{"default"}) {
+		if ns != "" && !seen[ns] {
+			seen[ns] = true
+			out = append(out, ns)
+		}
+	}
+	return out
+}
+
+// artifactPath is build/_test under PROJECT_DIR, the directory every suite
+// used to build for itself in an init().
+func artifactPath(name string) (string, error) {
+	root, ok := os.LookupEnv("PROJECT_DIR")
+	if !ok {
+		root = "../.."
+	}
+	dir := filepath.Join(root, "build/_test")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("cluster-%s.log", name)), nil
+}

--- a/e2e/internal/harness/harness.go
+++ b/e2e/internal/harness/harness.go
@@ -46,27 +46,23 @@ import (
 )
 
 const (
-	// clusterStopTimeout bounds the wait for cluster.Start to return after the
-	// context is canceled, so a runnable that will not stop is named rather
-	// than running the binary out of its -timeout.
+	// Names a runnable that will not stop, rather than letting it run the
+	// binary out of its -timeout.
 	clusterStopTimeout = time.Minute
 
 	clusterLogLimit = 100 * 1000
-
-	// receiverLogTail is the tail length the suites read from the test receiver.
 	receiverLogTail = 30
 
 	// waitBudget and waitInterval are what the suites spend by hand today.
 	waitBudget   = 5 * time.Minute
 	waitInterval = 3 * time.Second
 
-	// teardownMargin is held back from the budget so a wait that runs to the
-	// end still leaves time to dump logs and delete the cluster.
+	// Leaves a wait that runs to the end time to tear down.
 	teardownMargin = 90 * time.Second
 )
 
-// defaultSchemeBuilders covers every type the suites register today except the
-// prometheus-operator ones, which only logging_metrics_monitoring needs.
+// Everything the suites register except the prometheus-operator types, which
+// only logging_metrics_monitoring needs.
 var defaultSchemeBuilders = []func(*runtime.Scheme) error{
 	v1beta1.AddToScheme,
 	apiextensionsv1.AddToScheme,
@@ -94,27 +90,24 @@ func New(t *testing.T) *Builder {
 	return &Builder{t: t}
 }
 
-// WithCluster names the kind cluster. Named rather than derived from t.Name():
-// kind accepts only [a-z0-9.-] and none of the test names match.
+// WithCluster is named rather than derived from t.Name(): kind accepts only
+// [a-z0-9.-] and none of the test names match.
 func (b *Builder) WithCluster(name string) *Builder {
 	b.cfg.cluster = name
 	return b
 }
 
-// WithRelease names the helm release, and the operator's nameOverride with it.
 func (b *Builder) WithRelease(name string) *Builder {
 	b.cfg.release = name
 	return b
 }
 
-// WithControlNamespace sets where the operator and the test receiver run.
 func (b *Builder) WithControlNamespace(namespace string) *Builder {
 	b.cfg.controlNamespace = namespace
 	return b
 }
 
-// WithNamespaces are created before the test body and dumped at teardown
-// alongside the control namespace and default.
+// WithNamespaces are also dumped at teardown.
 func (b *Builder) WithNamespaces(namespaces ...string) *Builder {
 	b.cfg.namespaces = append(b.cfg.namespaces, namespaces...)
 	return b
@@ -125,7 +118,6 @@ func (b *Builder) WithOperatorArgs(args ...string) *Builder {
 	return b
 }
 
-// WithScheme registers types on top of the shared set.
 func (b *Builder) WithScheme(add ...func(*runtime.Scheme) error) *Builder {
 	b.cfg.schemeBuilders = append(b.cfg.schemeBuilders, add...)
 	return b
@@ -144,8 +136,7 @@ type Env struct {
 	dumpNamespaces []string
 }
 
-// Start brings up the cluster, installs the operator and registers teardown.
-// It marks the test parallel, so it has to be the first call in the test.
+// Start marks the test parallel, so it has to be the first call in the test.
 func (b *Builder) Start() *Env {
 	t := b.t
 	common.Initialize(t)
@@ -204,8 +195,7 @@ func (e *Env) Create(objects ...client.Object) {
 	}
 }
 
-// StartLogProducer runs on the test goroutine: the create errors reach it
-// through RequireNoError, which needs FailNow to be defined.
+// StartLogProducer runs on the test goroutine, where FailNow is defined.
 func (e *Env) StartLogProducer(namespace string, labels map[string]string) {
 	e.T.Helper()
 	setup.LogProducer(e.T, e.Client, setup.LogProducerOptionFunc(func(o *setup.LogProducerOptions) {
@@ -214,8 +204,6 @@ func (e *Env) StartLogProducer(namespace string, labels map[string]string) {
 	}))
 }
 
-// WaitForRunning blocks until every condition holds, and names the one that
-// did not if it runs out of budget.
 func (e *Env) WaitForRunning(conditions ...wait.Condition) {
 	e.T.Helper()
 
@@ -235,9 +223,8 @@ func (e *Env) WaitForRunning(conditions ...wait.Condition) {
 	}, e.waitBudget(), waitInterval, "still waiting for %s", &outstanding)
 }
 
-// WaitForReceiverLogs blocks until the test receiver has logged every tag, and
-// names the one still missing if it runs out of budget. The tail itself is not
-// echoed each poll: the archived cluster dump already has the receiver's log.
+// WaitForReceiverLogs does not echo the tail each poll: the archived cluster
+// dump already carries the receiver's log.
 func (e *Env) WaitForReceiverLogs(tags ...string) {
 	e.T.Helper()
 
@@ -258,8 +245,6 @@ func (e *Env) WaitForReceiverLogs(tags ...string) {
 	}, e.waitBudget(), waitInterval, "the test receiver never logged %s", &outstanding)
 }
 
-// ReceiverLogs returns the tail of the chart's test receiver, which is where a
-// suite looks to see that its logs arrived.
 func (e *Env) ReceiverLogs(tail int) (string, error) {
 	out, err := common.CmdEnv(exec.Command("kubectl",
 		"logs",
@@ -269,8 +254,8 @@ func (e *Env) ReceiverLogs(tail int) (string, error) {
 	return string(out), err
 }
 
-// waitBudget is what the suites spend today, held under what is left of the
-// binary's deadline so one wait cannot take the package's whole budget with it.
+// waitBudget holds a wait under what is left of the binary's deadline, so one
+// cannot take the package's whole budget with it.
 func (e *Env) waitBudget() time.Duration {
 	deadline, ok := e.T.Deadline()
 	if !ok {
@@ -308,7 +293,6 @@ type step struct {
 
 type teardown []step
 
-// cleanupT is the part of testing.T register needs.
 type cleanupT interface {
 	Cleanup(func())
 	Errorf(format string, args ...any)
@@ -356,7 +340,7 @@ func (e *Env) collectArtifacts() {
 	operator := "logging-operator-" + e.Release
 	e.T.Logf("Collecting coverage files from logging-operator: %s/%s", e.ControlNamespace, operator)
 	if err := e.Cluster.CollectTestCoverageFiles(e.ControlNamespace, operator); err != nil {
-		// Logged, never fatal: the run's coverage is not the suite's verdict.
+		// Logged, never fatal: coverage is not the suite's verdict.
 		e.T.Logf("Failed collecting coverage files: %s", err)
 	}
 }
@@ -371,11 +355,11 @@ func buildScheme(extra []func(*runtime.Scheme) error) (*runtime.Scheme, error) {
 	return scheme, nil
 }
 
-// dumpNamespaces is the control namespace, the configured ones and default,
-// without repeats, so a suite that names one does not dump it twice.
 func dumpNamespaces(cfg config) []string {
 	out := make([]string, 0, len(cfg.namespaces)+2)
 	seen := map[string]bool{}
+	// Concat, not append: appending to cfg.namespaces could write into the
+	// caller's backing array.
 	for _, ns := range slices.Concat([]string{cfg.controlNamespace}, cfg.namespaces, []string{"default"}) {
 		if ns != "" && !seen[ns] {
 			seen[ns] = true
@@ -385,8 +369,6 @@ func dumpNamespaces(cfg config) []string {
 	return out
 }
 
-// artifactPath is build/_test under PROJECT_DIR, the directory every suite
-// used to build for itself in an init().
 func artifactPath(name string) (string, error) {
 	root, ok := os.LookupEnv("PROJECT_DIR")
 	if !ok {

--- a/e2e/internal/harness/harness.go
+++ b/e2e/internal/harness/harness.go
@@ -177,14 +177,12 @@ func (b *Builder) Start() *Env {
 		dumpNamespaces:   dumpNamespaces(b.cfg),
 	}
 
-	registerTeardown(t.Cleanup,
-		func(step string, v any) { assert.Fail(t, fmt.Sprintf("teardown step %q panicked: %v", step, v)) },
-		teardownSteps(
-			env.collectArtifacts,
-			func() { assert.NoError(t, c.Cleanup()) },
-			func() { stopCluster(t, cancel, startErr) },
-			func() { assert.NoError(t, common.DeleteTestCluster(b.cfg.cluster)) },
-		))
+	teardown{
+		{"artifacts", env.collectArtifacts},
+		{"kubeconfig", func() { assert.NoError(t, c.Cleanup()) }},
+		{"stop", func() { stopCluster(t, cancel, startErr) }},
+		{"delete", func() { assert.NoError(t, common.DeleteTestCluster(b.cfg.cluster)) }},
+	}.register(t)
 
 	setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(o *setup.LoggingOperatorOptions) {
 		o.Namespace = b.cfg.controlNamespace
@@ -303,35 +301,30 @@ func (p *pending) String() string {
 	return p.name
 }
 
-type teardownStep struct {
+type step struct {
 	name string
 	run  func()
 }
 
-// teardownSteps lists them in the order they have to run. This order is what
-// kept clusters from leaking before it moved here, so it is one list rather
-// than four Cleanup calls in reverse.
-func teardownSteps(artifacts, kubeconfig, stop, deleteCluster func()) []teardownStep {
-	return []teardownStep{
-		{"artifacts", artifacts},
-		{"kubeconfig", kubeconfig},
-		{"stop", stop},
-		{"delete", deleteCluster},
-	}
+type teardown []step
+
+// cleanupT is the part of testing.T register needs.
+type cleanupT interface {
+	Cleanup(func())
+	Errorf(format string, args ...any)
 }
 
-// registerTeardown hands the steps over back to front, because Cleanup is LIFO,
-// and isolates each one: Go abandons the remaining cleanups at the first panic,
-// which would strand the cluster.
-func registerTeardown(cleanup func(func()), onPanic func(step string, v any), steps []teardownStep) {
-	for _, step := range slices.Backward(steps) {
-		cleanup(func() {
+// register goes back to front because Cleanup is LIFO, and isolates each step:
+// Go abandons the rest at the first panic, which would strand the cluster.
+func (td teardown) register(t cleanupT) {
+	for _, s := range slices.Backward(td) {
+		t.Cleanup(func() {
 			defer func() {
 				if v := recover(); v != nil {
-					onPanic(step.name, v)
+					assert.Fail(t, fmt.Sprintf("teardown step %q panicked: %v", s.name, v))
 				}
 			}()
-			step.run()
+			s.run()
 		})
 	}
 }

--- a/e2e/internal/harness/harness.go
+++ b/e2e/internal/harness/harness.go
@@ -21,11 +21,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/cisco-open/operator-tools/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,16 +41,29 @@ import (
 
 	"github.com/kube-logging/logging-operator/e2e/common"
 	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
-// clusterStopTimeout bounds the wait for cluster.Start to return after the
-// context is canceled, so a runnable that will not stop is named rather than
-// running the binary out of its -timeout.
-const clusterStopTimeout = time.Minute
+const (
+	// clusterStopTimeout bounds the wait for cluster.Start to return after the
+	// context is canceled, so a runnable that will not stop is named rather
+	// than running the binary out of its -timeout.
+	clusterStopTimeout = time.Minute
 
-// clusterLogLimit is the tail length used for the archived cluster dump.
-const clusterLogLimit = 100 * 1000
+	clusterLogLimit = 100 * 1000
+
+	// receiverLogTail is the tail length the suites read from the test receiver.
+	receiverLogTail = 30
+
+	// waitBudget and waitInterval are what the suites spend by hand today.
+	waitBudget   = 5 * time.Minute
+	waitInterval = 3 * time.Second
+
+	// teardownMargin is held back from the budget so a wait that runs to the
+	// end still leaves time to dump logs and delete the cluster.
+	teardownMargin = 90 * time.Second
+)
 
 // defaultSchemeBuilders covers every type the suites register today except the
 // prometheus-operator ones, which only logging_metrics_monitoring needs.
@@ -60,27 +76,59 @@ var defaultSchemeBuilders = []func(*runtime.Scheme) error{
 	rbacv1.AddToScheme,
 }
 
-type Config struct {
-	// Cluster is the kind cluster name. Named rather than derived from
-	// t.Name(): kind accepts only [a-z0-9.-] and none of the test names match.
-	Cluster string
+type config struct {
+	cluster          string
+	release          string
+	controlNamespace string
+	namespaces       []string
+	operatorArgs     []string
+	schemeBuilders   []func(*runtime.Scheme) error
+}
 
-	// Release is the helm release, and the operator's nameOverride with it.
-	Release string
+type Builder struct {
+	t   *testing.T
+	cfg config
+}
 
-	// ControlNamespace is where the operator and the test receiver run.
-	ControlNamespace string
+func New(t *testing.T) *Builder {
+	return &Builder{t: t}
+}
 
-	// Namespaces are created before the test body. They are dumped at teardown
-	// alongside ControlNamespace and default.
-	Namespaces []string
+// WithCluster names the kind cluster. Named rather than derived from t.Name():
+// kind accepts only [a-z0-9.-] and none of the test names match.
+func (b *Builder) WithCluster(name string) *Builder {
+	b.cfg.cluster = name
+	return b
+}
 
-	// OperatorArgs are appended to the operator's container arguments.
-	OperatorArgs []string
+// WithRelease names the helm release, and the operator's nameOverride with it.
+func (b *Builder) WithRelease(name string) *Builder {
+	b.cfg.release = name
+	return b
+}
 
-	// ExtraSchemeBuilders are registered on top of the shared set, for the one
-	// suite that needs the prometheus-operator types.
-	ExtraSchemeBuilders []func(*runtime.Scheme) error
+// WithControlNamespace sets where the operator and the test receiver run.
+func (b *Builder) WithControlNamespace(namespace string) *Builder {
+	b.cfg.controlNamespace = namespace
+	return b
+}
+
+// WithNamespaces are created before the test body and dumped at teardown
+// alongside the control namespace and default.
+func (b *Builder) WithNamespaces(namespaces ...string) *Builder {
+	b.cfg.namespaces = append(b.cfg.namespaces, namespaces...)
+	return b
+}
+
+func (b *Builder) WithOperatorArgs(args ...string) *Builder {
+	b.cfg.operatorArgs = append(b.cfg.operatorArgs, args...)
+	return b
+}
+
+// WithScheme registers types on top of the shared set.
+func (b *Builder) WithScheme(add ...func(*runtime.Scheme) error) *Builder {
+	b.cfg.schemeBuilders = append(b.cfg.schemeBuilders, add...)
+	return b
 }
 
 type Env struct {
@@ -92,21 +140,24 @@ type Env struct {
 
 	Release          string
 	ControlNamespace string
+
+	dumpNamespaces []string
 }
 
 // Start brings up the cluster, installs the operator and registers teardown.
 // It marks the test parallel, so it has to be the first call in the test.
-func Start(t *testing.T, cfg Config) *Env {
+func (b *Builder) Start() *Env {
+	t := b.t
 	common.Initialize(t)
 
-	scheme, err := buildScheme(cfg.ExtraSchemeBuilders)
+	scheme, err := buildScheme(b.cfg.schemeBuilders)
 	common.RequireNoError(t, err)
 
-	c, err := common.GetTestCluster(cfg.Cluster, func(o *cluster.Options) { o.Scheme = scheme })
+	c, err := common.GetTestCluster(b.cfg.cluster, func(o *cluster.Options) { o.Scheme = scheme })
 	if err != nil {
 		// The kind cluster is up before the client can fail, and teardown is
 		// not registered yet.
-		assert.NoError(t, common.DeleteTestCluster(cfg.Cluster))
+		assert.NoError(t, common.DeleteTestCluster(b.cfg.cluster))
 	}
 	common.RequireNoError(t, err)
 
@@ -121,26 +172,27 @@ func Start(t *testing.T, cfg Config) *Env {
 		Ctx:              ctx,
 		Client:           c.GetClient(),
 		Cluster:          c,
-		Release:          cfg.Release,
-		ControlNamespace: cfg.ControlNamespace,
+		Release:          b.cfg.release,
+		ControlNamespace: b.cfg.controlNamespace,
+		dumpNamespaces:   dumpNamespaces(b.cfg),
 	}
 
 	registerTeardown(t.Cleanup,
 		func(step string, v any) { assert.Fail(t, fmt.Sprintf("teardown step %q panicked: %v", step, v)) },
 		teardownSteps(
-			func() { env.collectArtifacts(cfg) },
+			env.collectArtifacts,
 			func() { assert.NoError(t, c.Cleanup()) },
 			func() { stopCluster(t, cancel, startErr) },
-			func() { assert.NoError(t, common.DeleteTestCluster(cfg.Cluster)) },
+			func() { assert.NoError(t, common.DeleteTestCluster(b.cfg.cluster)) },
 		))
 
 	setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(o *setup.LoggingOperatorOptions) {
-		o.Namespace = cfg.ControlNamespace
-		o.NameOverride = cfg.Release
-		o.Args = cfg.OperatorArgs
+		o.Namespace = b.cfg.controlNamespace
+		o.NameOverride = b.cfg.release
+		o.Args = b.cfg.operatorArgs
 	}))
 
-	for _, ns := range cfg.Namespaces {
+	for _, ns := range b.cfg.namespaces {
 		env.Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 	}
 
@@ -164,6 +216,50 @@ func (e *Env) StartLogProducer(namespace string, labels map[string]string) {
 	}))
 }
 
+// WaitForRunning blocks until every condition holds, and names the one that
+// did not if it runs out of budget.
+func (e *Env) WaitForRunning(conditions ...wait.Condition) {
+	e.T.Helper()
+
+	var outstanding pending
+	require.Eventuallyf(e.T, func() bool {
+		for _, condition := range conditions {
+			met, err := condition.Met(e.Ctx, e.Client)
+			if err != nil {
+				e.T.Logf("checking %s: %v", condition.Name, err)
+			}
+			if !met {
+				outstanding.set(condition.Name)
+				return false
+			}
+		}
+		return true
+	}, e.waitBudget(), waitInterval, "still waiting for %s", &outstanding)
+}
+
+// WaitForReceiverLogs blocks until the test receiver has logged every tag, and
+// names the one still missing if it runs out of budget. The tail itself is not
+// echoed each poll: the archived cluster dump already has the receiver's log.
+func (e *Env) WaitForReceiverLogs(tags ...string) {
+	e.T.Helper()
+
+	var outstanding pending
+	require.Eventuallyf(e.T, func() bool {
+		logs, err := e.ReceiverLogs(receiverLogTail)
+		if err != nil {
+			e.T.Logf("reading the test receiver: %v", err)
+			return false
+		}
+		for _, tag := range tags {
+			if !strings.Contains(logs, tag) {
+				outstanding.set(tag)
+				return false
+			}
+		}
+		return true
+	}, e.waitBudget(), waitInterval, "the test receiver never logged %s", &outstanding)
+}
+
 // ReceiverLogs returns the tail of the chart's test receiver, which is where a
 // suite looks to see that its logs arrived.
 func (e *Env) ReceiverLogs(tail int) (string, error) {
@@ -175,25 +271,36 @@ func (e *Env) ReceiverLogs(tail int) (string, error) {
 	return string(out), err
 }
 
-func (e *Env) collectArtifacts(cfg Config) {
-	path, err := artifactPath(e.T.Name())
-	if err != nil {
-		e.T.Logf("Skipping cluster logs: %s", err)
-	} else {
-		e.T.Logf("Printing cluster logs to %s", path)
-		assert.NoError(e.T, e.Cluster.PrintLogs(common.PrintLogConfig{
-			Namespaces: dumpNamespaces(cfg),
-			FilePath:   path,
-			Limit:      clusterLogLimit,
-		}))
+// waitBudget is what the suites spend today, held under what is left of the
+// binary's deadline so one wait cannot take the package's whole budget with it.
+func (e *Env) waitBudget() time.Duration {
+	deadline, ok := e.T.Deadline()
+	if !ok {
+		return waitBudget
 	}
+	return min(waitBudget, max(time.Until(deadline)-teardownMargin, time.Second))
+}
 
-	operator := "logging-operator-" + e.Release
-	e.T.Logf("Collecting coverage files from logging-operator: %s/%s", e.ControlNamespace, operator)
-	if err := e.Cluster.CollectTestCoverageFiles(e.ControlNamespace, operator); err != nil {
-		// Logged, never fatal: the run's coverage is not the suite's verdict.
-		e.T.Logf("Failed collecting coverage files: %s", err)
+// pending is written by the condition, which testify runs on its own goroutine,
+// and read when the assertion message is formatted on the test's.
+type pending struct {
+	mu   sync.Mutex
+	name string
+}
+
+func (p *pending) set(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.name = name
+}
+
+func (p *pending) String() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.name == "" {
+		return "the first condition to be checked"
 	}
+	return p.name
 }
 
 type teardownStep struct {
@@ -240,6 +347,27 @@ func stopCluster(t *testing.T, cancel context.CancelFunc, startErr <-chan error)
 	}
 }
 
+func (e *Env) collectArtifacts() {
+	path, err := artifactPath(e.T.Name())
+	if err != nil {
+		e.T.Logf("Skipping cluster logs: %s", err)
+	} else {
+		e.T.Logf("Printing cluster logs to %s", path)
+		assert.NoError(e.T, e.Cluster.PrintLogs(common.PrintLogConfig{
+			Namespaces: e.dumpNamespaces,
+			FilePath:   path,
+			Limit:      clusterLogLimit,
+		}))
+	}
+
+	operator := "logging-operator-" + e.Release
+	e.T.Logf("Collecting coverage files from logging-operator: %s/%s", e.ControlNamespace, operator)
+	if err := e.Cluster.CollectTestCoverageFiles(e.ControlNamespace, operator); err != nil {
+		// Logged, never fatal: the run's coverage is not the suite's verdict.
+		e.T.Logf("Failed collecting coverage files: %s", err)
+	}
+}
+
 func buildScheme(extra []func(*runtime.Scheme) error) (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 	for _, add := range slices.Concat(defaultSchemeBuilders, extra) {
@@ -250,14 +378,12 @@ func buildScheme(extra []func(*runtime.Scheme) error) (*runtime.Scheme, error) {
 	return scheme, nil
 }
 
-// dumpNamespaces is ControlNamespace, the configured ones and default, without
-// repeats, so a suite that names one of them does not dump it twice.
-func dumpNamespaces(cfg Config) []string {
-	out := make([]string, 0, len(cfg.Namespaces)+2)
+// dumpNamespaces is the control namespace, the configured ones and default,
+// without repeats, so a suite that names one does not dump it twice.
+func dumpNamespaces(cfg config) []string {
+	out := make([]string, 0, len(cfg.namespaces)+2)
 	seen := map[string]bool{}
-	// Concat, not append: appending to cfg.Namespaces could write into the
-	// caller's backing array.
-	for _, ns := range slices.Concat([]string{cfg.ControlNamespace}, cfg.Namespaces, []string{"default"}) {
+	for _, ns := range slices.Concat([]string{cfg.controlNamespace}, cfg.namespaces, []string{"default"}) {
 		if ns != "" && !seen[ns] {
 			seen[ns] = true
 			out = append(out, ns)

--- a/e2e/internal/harness/harness_test.go
+++ b/e2e/internal/harness/harness_test.go
@@ -16,6 +16,7 @@ package harness
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -32,59 +33,53 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
-// cleanupRecorder stands in for testing.T's Cleanup, so the order the steps end
-// up running in can be asserted without a cluster.
-type cleanupRecorder struct {
-	registered []func()
+// Registered in a subtest so the order comes from testing's own LIFO rather
+// than a stand-in for it.
+func TestTeardownRunsInDeclaredOrder(t *testing.T) {
+	var ran []string
+	record := func(name string) step { return step{name, func() { ran = append(ran, name) }} }
+
+	t.Run("teardown", func(t *testing.T) {
+		teardown{record("artifacts"), record("kubeconfig"), record("stop"), record("delete")}.register(t)
+	})
+
+	assert.Equal(t, []string{"artifacts", "kubeconfig", "stop", "delete"}, ran)
 }
 
-func (c *cleanupRecorder) Cleanup(fn func()) {
-	c.registered = append(c.registered, fn)
+// A real subtest cannot be used here: register reports the panic, which would
+// fail the subtest and this test with it.
+type reportingT struct {
+	cleanups []func()
+	reported []string
 }
 
-// run does what testing does at the end of a test: LIFO.
-func (c *cleanupRecorder) run() {
-	for _, fn := range slices.Backward(c.registered) {
+func (r *reportingT) Cleanup(fn func()) { r.cleanups = append(r.cleanups, fn) }
+func (r *reportingT) Errorf(format string, args ...any) {
+	r.reported = append(r.reported, fmt.Sprintf(format, args...))
+}
+
+func (r *reportingT) runCleanups() {
+	for _, fn := range slices.Backward(r.cleanups) {
 		fn()
 	}
 }
 
-// The order here is what kept clusters from leaking: the log dump needs the
-// cache and the kubeconfig, both of which the later steps take away.
-func TestTeardownRunsInDeclaredOrder(t *testing.T) {
-	var ran []string
-	record := func(name string) func() { return func() { ran = append(ran, name) } }
-
-	recorder := &cleanupRecorder{}
-	registerTeardown(recorder.Cleanup, failOnPanic(t), teardownSteps(
-		record("artifacts"), record("kubeconfig"), record("stop"), record("delete"),
-	))
-	recorder.run()
-
-	assert.Equal(t, []string{"artifacts", "kubeconfig", "stop", "delete"}, ran)
-}
-
 // Go abandons the remaining cleanups at the first panic, so without the recover
-// in registerTeardown a panicking log dump would leave the cluster running.
+// a panicking log dump would leave the cluster running.
 func TestTeardownDeletesTheClusterAfterAnEarlierPanic(t *testing.T) {
-	var ran, panicked []string
-	record := func(name string) func() { return func() { ran = append(ran, name) } }
+	var ran []string
+	record := func(name string) step { return step{name, func() { ran = append(ran, name) }} }
 
-	recorder := &cleanupRecorder{}
-	registerTeardown(recorder.Cleanup,
-		func(step string, _ any) { panicked = append(panicked, step) },
-		teardownSteps(
-			func() { ran = append(ran, "artifacts"); panic("boom") },
-			record("kubeconfig"), record("stop"), record("delete"),
-		))
-	recorder.run()
+	recorder := &reportingT{}
+	teardown{
+		{"artifacts", func() { ran = append(ran, "artifacts"); panic("boom") }},
+		record("kubeconfig"), record("stop"), record("delete"),
+	}.register(recorder)
+	recorder.runCleanups()
 
 	assert.Equal(t, []string{"artifacts", "kubeconfig", "stop", "delete"}, ran)
-	assert.Equal(t, []string{"artifacts"}, panicked, "the panic is reported, not swallowed")
-}
-
-func failOnPanic(t *testing.T) func(string, any) {
-	return func(step string, v any) { assert.Fail(t, "unexpected panic", "%s: %v", step, v) }
+	assert.Len(t, recorder.reported, 1, "the panic is reported, not swallowed")
+	assert.Contains(t, recorder.reported[0], `"artifacts" panicked`)
 }
 
 func TestBuildScheme(t *testing.T) {
@@ -133,8 +128,6 @@ func TestDumpNamespaces(t *testing.T) {
 			config: config{controlNamespace: "infra", namespaces: []string{"tenant"}},
 			want:   []string{"infra", "tenant", "default"},
 		},
-		// A suite that runs in default, or names it explicitly, would otherwise
-		// have stern dump it twice.
 		"repeats are dropped": {
 			config: config{controlNamespace: "default", namespaces: []string{"tenant", "tenant"}},
 			want:   []string{"default", "tenant"},
@@ -152,12 +145,8 @@ func TestDumpNamespaces(t *testing.T) {
 	}
 }
 
-// The cap is what the suites spend by hand today; the deadline is what stops
-// one wait taking the whole package budget with it.
 func TestWaitBudgetStaysUnderTheCapAndTheDeadline(t *testing.T) {
-	env := &Env{T: t}
-
-	budget := env.waitBudget()
+	budget := (&Env{T: t}).waitBudget()
 
 	assert.Positive(t, budget)
 	assert.LessOrEqual(t, budget, waitBudget)
@@ -174,7 +163,6 @@ func TestArtifactPath(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, filepath.Join(root, "build/_test", "cluster-TestSomething.log"), path)
-	// The directory each suite used to build in its own init().
 	info, err := os.Stat(filepath.Dir(path))
 	require.NoError(t, err)
 	assert.True(t, info.IsDir())

--- a/e2e/internal/harness/harness_test.go
+++ b/e2e/internal/harness/harness_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
@@ -106,7 +107,6 @@ func TestBuildScheme(t *testing.T) {
 		assert.True(t, scheme.Recognizes(mustGVK(t, scheme, &v1beta1.Logging{})), "the shared set stays")
 	})
 
-	// Concat, not append: a caller's slice must not gain the extras.
 	t.Run("the default set is not mutated by extras", func(t *testing.T) {
 		before := len(defaultSchemeBuilders)
 		_, err := buildScheme([]func(*runtime.Scheme) error{monitoringv1.AddToScheme})
@@ -126,21 +126,21 @@ func TestBuildScheme(t *testing.T) {
 
 func TestDumpNamespaces(t *testing.T) {
 	testCases := map[string]struct {
-		config Config
+		config config
 		want   []string
 	}{
 		"control namespace first, default last": {
-			config: Config{ControlNamespace: "infra", Namespaces: []string{"tenant"}},
+			config: config{controlNamespace: "infra", namespaces: []string{"tenant"}},
 			want:   []string{"infra", "tenant", "default"},
 		},
 		// A suite that runs in default, or names it explicitly, would otherwise
 		// have stern dump it twice.
 		"repeats are dropped": {
-			config: Config{ControlNamespace: "default", Namespaces: []string{"tenant", "tenant"}},
+			config: config{controlNamespace: "default", namespaces: []string{"tenant", "tenant"}},
 			want:   []string{"default", "tenant"},
 		},
 		"an unset control namespace is skipped": {
-			config: Config{Namespaces: []string{"tenant"}},
+			config: config{namespaces: []string{"tenant"}},
 			want:   []string{"tenant", "default"},
 		},
 	}
@@ -149,6 +149,20 @@ func TestDumpNamespaces(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, testCase.want, dumpNamespaces(testCase.config))
 		})
+	}
+}
+
+// The cap is what the suites spend by hand today; the deadline is what stops
+// one wait taking the whole package budget with it.
+func TestWaitBudgetStaysUnderTheCapAndTheDeadline(t *testing.T) {
+	env := &Env{T: t}
+
+	budget := env.waitBudget()
+
+	assert.Positive(t, budget)
+	assert.LessOrEqual(t, budget, waitBudget)
+	if deadline, ok := t.Deadline(); ok {
+		assert.Less(t, budget, time.Until(deadline), "a wait must not outlive the binary")
 	}
 }
 

--- a/e2e/internal/harness/harness_test.go
+++ b/e2e/internal/harness/harness_test.go
@@ -1,0 +1,119 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harness
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+func TestBuildScheme(t *testing.T) {
+	t.Run("the default set covers what the suites register", func(t *testing.T) {
+		scheme, err := buildScheme(nil)
+		require.NoError(t, err)
+
+		for _, obj := range []runtime.Object{
+			&v1beta1.Logging{}, &v1beta1.ClusterFlow{}, &corev1.Pod{},
+		} {
+			assert.True(t, scheme.Recognizes(mustGVK(t, scheme, obj)), "%T", obj)
+		}
+	})
+
+	t.Run("extras are added on top of the default", func(t *testing.T) {
+		scheme, err := buildScheme([]func(*runtime.Scheme) error{monitoringv1.AddToScheme})
+		require.NoError(t, err)
+
+		assert.True(t, scheme.Recognizes(mustGVK(t, scheme, &monitoringv1.ServiceMonitor{})))
+		assert.True(t, scheme.Recognizes(mustGVK(t, scheme, &v1beta1.Logging{})), "the shared set stays")
+	})
+
+	// Concat, not append: a caller's slice must not gain the extras.
+	t.Run("the default set is not mutated by extras", func(t *testing.T) {
+		before := len(defaultSchemeBuilders)
+		_, err := buildScheme([]func(*runtime.Scheme) error{monitoringv1.AddToScheme})
+		require.NoError(t, err)
+
+		assert.Len(t, defaultSchemeBuilders, before)
+	})
+
+	t.Run("a failing builder is reported", func(t *testing.T) {
+		want := errors.New("boom")
+		_, err := buildScheme([]func(*runtime.Scheme) error{
+			func(*runtime.Scheme) error { return want },
+		})
+		assert.ErrorIs(t, err, want)
+	})
+}
+
+func TestDumpNamespaces(t *testing.T) {
+	testCases := map[string]struct {
+		config Config
+		want   []string
+	}{
+		"control namespace first, default last": {
+			config: Config{ControlNamespace: "infra", Namespaces: []string{"tenant"}},
+			want:   []string{"infra", "tenant", "default"},
+		},
+		// A suite that runs in default, or names it explicitly, would otherwise
+		// have stern dump it twice.
+		"repeats are dropped": {
+			config: Config{ControlNamespace: "default", Namespaces: []string{"tenant", "tenant"}},
+			want:   []string{"default", "tenant"},
+		},
+		"an unset control namespace is skipped": {
+			config: Config{Namespaces: []string{"tenant"}},
+			want:   []string{"tenant", "default"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, dumpNamespaces(testCase.config))
+		})
+	}
+}
+
+func TestArtifactPath(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PROJECT_DIR", root)
+
+	path, err := artifactPath("TestSomething")
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(root, "build/_test", "cluster-TestSomething.log"), path)
+	// The directory each suite used to build in its own init().
+	info, err := os.Stat(filepath.Dir(path))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func mustGVK(t *testing.T, scheme *runtime.Scheme, obj runtime.Object) schema.GroupVersionKind {
+	t.Helper()
+	gvks, _, err := scheme.ObjectKinds(obj)
+	require.NoError(t, err)
+	require.NotEmpty(t, gvks)
+	return gvks[0]
+}

--- a/e2e/internal/harness/harness_test.go
+++ b/e2e/internal/harness/harness_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -29,6 +30,61 @@ import (
 
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
+
+// cleanupRecorder stands in for testing.T's Cleanup, so the order the steps end
+// up running in can be asserted without a cluster.
+type cleanupRecorder struct {
+	registered []func()
+}
+
+func (c *cleanupRecorder) Cleanup(fn func()) {
+	c.registered = append(c.registered, fn)
+}
+
+// run does what testing does at the end of a test: LIFO.
+func (c *cleanupRecorder) run() {
+	for _, fn := range slices.Backward(c.registered) {
+		fn()
+	}
+}
+
+// The order here is what kept clusters from leaking: the log dump needs the
+// cache and the kubeconfig, both of which the later steps take away.
+func TestTeardownRunsInDeclaredOrder(t *testing.T) {
+	var ran []string
+	record := func(name string) func() { return func() { ran = append(ran, name) } }
+
+	recorder := &cleanupRecorder{}
+	registerTeardown(recorder.Cleanup, failOnPanic(t), teardownSteps(
+		record("artifacts"), record("kubeconfig"), record("stop"), record("delete"),
+	))
+	recorder.run()
+
+	assert.Equal(t, []string{"artifacts", "kubeconfig", "stop", "delete"}, ran)
+}
+
+// Go abandons the remaining cleanups at the first panic, so without the recover
+// in registerTeardown a panicking log dump would leave the cluster running.
+func TestTeardownDeletesTheClusterAfterAnEarlierPanic(t *testing.T) {
+	var ran, panicked []string
+	record := func(name string) func() { return func() { ran = append(ran, name) } }
+
+	recorder := &cleanupRecorder{}
+	registerTeardown(recorder.Cleanup,
+		func(step string, _ any) { panicked = append(panicked, step) },
+		teardownSteps(
+			func() { ran = append(ran, "artifacts"); panic("boom") },
+			record("kubeconfig"), record("stop"), record("delete"),
+		))
+	recorder.run()
+
+	assert.Equal(t, []string{"artifacts", "kubeconfig", "stop", "delete"}, ran)
+	assert.Equal(t, []string{"artifacts"}, panicked, "the panic is reported, not swallowed")
+}
+
+func failOnPanic(t *testing.T) func(string, any) {
+	return func(step string, v any) { assert.Fail(t, "unexpected panic", "%s: %v", step, v) }
+}
 
 func TestBuildScheme(t *testing.T) {
 	t.Run("the default set covers what the suites register", func(t *testing.T) {

--- a/e2e/internal/wait/condition.go
+++ b/e2e/internal/wait/condition.go
@@ -22,14 +22,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Condition is a named thing to wait for. It carries no testing.T and no
-// client, so a suite can name one without assembling it: whoever evaluates it
-// supplies both. Name is what a failed wait reports.
+// Condition carries no testing.T and no client, so a suite can name one without
+// assembling it and whoever evaluates it supplies both.
 type Condition struct {
 	Name string
 	Met  func(context.Context, client.Reader) (bool, error)
 }
 
+// PodRunning is the escape hatch; the constructors below carry their own name
+// and selector so a call site passes only what varies.
 func PodRunning(name string, opts ...client.ListOption) Condition {
 	return Condition{
 		Name: name,
@@ -49,17 +50,23 @@ func PodRunning(name string, opts ...client.ListOption) Condition {
 }
 
 func Operator(release string) Condition {
-	return PodRunning("the operator", client.MatchingLabels{types.NameLabel: release})
+	return PodRunning("operator", client.MatchingLabels{types.NameLabel: release})
 }
 
 func Producer(labels map[string]string) Condition {
-	return PodRunning("the producer", client.MatchingLabels(labels))
+	return PodRunning("producer", client.MatchingLabels(labels))
 }
 
-// Aggregator matches the fluentd statefulset's pods in one namespace, which is
-// what a multi-tenant suite waits on per tenant.
-func Aggregator(namespace string) Condition {
-	return PodRunning("the aggregator in "+namespace,
-		client.MatchingLabels{types.NameLabel: "fluentd", types.ComponentLabel: "fluentd"},
+func FluentdAggregator(namespace string) Condition {
+	return aggregator("fluentd", namespace)
+}
+
+func SyslogNGAggregator(namespace string) Condition {
+	return aggregator("syslog-ng", namespace)
+}
+
+func aggregator(kind, namespace string) Condition {
+	return PodRunning(kind+" aggregator in "+namespace,
+		client.MatchingLabels{types.NameLabel: kind, types.ComponentLabel: kind},
 		client.InNamespace(namespace))
 }

--- a/e2e/internal/wait/condition.go
+++ b/e2e/internal/wait/condition.go
@@ -1,0 +1,65 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+
+	"github.com/cisco-open/operator-tools/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Condition is a named thing to wait for. It carries no testing.T and no
+// client, so a suite can name one without assembling it: whoever evaluates it
+// supplies both. Name is what a failed wait reports.
+type Condition struct {
+	Name string
+	Met  func(context.Context, client.Reader) (bool, error)
+}
+
+func PodRunning(name string, opts ...client.ListOption) Condition {
+	return Condition{
+		Name: name,
+		Met: func(ctx context.Context, cl client.Reader) (bool, error) {
+			var pods corev1.PodList
+			if err := cl.List(ctx, &pods, opts...); err != nil {
+				return false, err
+			}
+			for _, pod := range pods.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+	}
+}
+
+func Operator(release string) Condition {
+	return PodRunning("the operator", client.MatchingLabels{types.NameLabel: release})
+}
+
+func Producer(labels map[string]string) Condition {
+	return PodRunning("the producer", client.MatchingLabels(labels))
+}
+
+// Aggregator matches the fluentd statefulset's pods in one namespace, which is
+// what a multi-tenant suite waits on per tenant.
+func Aggregator(namespace string) Condition {
+	return PodRunning("the aggregator in "+namespace,
+		client.MatchingLabels{types.NameLabel: "fluentd", types.ComponentLabel: "fluentd"},
+		client.InNamespace(namespace))
+}


### PR DESCRIPTION
`internal/fixture` landed in #2299 and nothing has imported it since — 655 lines carried by the module with no consumer. This adds the lifecycle package the suites were meant to sit on, and moves one suite onto both. `fluentbit-multitenant`, 176 lines to 66.

```go
env := harness.New(t).
    WithCluster(release).
    WithRelease(release).
    WithControlNamespace(nsInfra).
    WithNamespaces(nsTenant).
    Start()

env.Create(fixture.LoggingInfra(nsInfra, release, tagInfra, buffer, producerLabels)...)
env.StartLogProducer(nsTenant, producerLabels)

env.WaitForRunning(
    wait.Operator(release),
    wait.Producer(producerLabels),
    wait.Aggregator(nsInfra),
    wait.Aggregator(nsTenant),
)
env.WaitForReceiverLogs(tagInfra, tagTenant)
```

`Start` marks the test parallel, builds the scheme, brings up the cluster, installs the operator, creates the extra namespaces and registers teardown. What that retires per suite, still present in the other twelve: an `init()` building `build/_test` (12 files), the `beforeCleanup` closure that dumps logs and collects coverage (12), the scheme closure (102 `AddToScheme` lines in total), `context.Background()` (19) and `common.Initialize` (16).

Net lines are up here — the harness and its tests against 110 removed from one suite. It only pays from the second suite on, which is why one moves rather than thirteen.

### Waiting

`wait.Condition` carries no `testing.T` and no client, so a condition is a value a suite names rather than one it assembles; the harness supplies both. The budget comes from the harness — `min(5m, remaining − 90s)` — so the numbers the suites spend today do not move, but a wait cannot take the package's whole budget with it. On timeout the assertion names what was outstanding: `still waiting for the aggregator in tenant`, rather than `Condition never satisfied`.

The receiver tail is no longer echoed on every poll. It was 24 identical banners in a local run, and the archived cluster dump already carries it.

### Teardown

Writing the test for the ordering turned up a second problem. Go abandons the remaining cleanups at the first panic, so a log dump that panicked would have left the kind cluster running for the rest of the job. The order is one list now, registered from it, and each step recovers so an early failure still reaches the delete.

Both are covered without a cluster. Registering forward reverses the observed order; removing the recover lets the panic through before the delete runs.

### Scope

Only `internal/harness`, so it imports `common` and `common/setup` for now. Giving `common/cluster.go` and `common/setup` their own packages is a move with no behaviour in it, and doing it now would leave two implementations live while twelve suites still use the old one. That layering inverts when `common/` goes.

### Semantic drift

`fluentbit-multitenant` is the only suite whose buffer leaves `Type` unset; the other twelve set `"file"`, and so does `fixture.Buffer`. Taking the fixture default would have switched both outputs from memory to file buffering — the suite would still pass, for a different reason. The literal stays in the suite. Worth deciding separately whether `"file"` was meant all along.

Nothing pinned that `fixture` produces what `common` does: the tests added with it assert the shape that package chose, not that the choice matches the live path. `TestBuildersMatchCommon` records what `common.LoggingInfra`, `LoggingTenant` and `LoggingRoute` hand to `Create` and requires the builders to equal it, object for object and in order. It passes as written, so this migration changes no object.

That test is scaffolding, not a fixture: it makes `common` the oracle, so `common` cannot be deleted while it stands. The condition for removing it — the last suite that still uses `common` — is written next to it.

### Verification

`make check` passes, `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` in `e2e/` reports 0 issues, and all seven commits build, vet and test on their own. The migrated suite passes against a real cluster: `make test-e2e-nodeps E2E_TEST=fluentbit-multitenant`, 67.6s, with `tag_infra` and `tag_tenant` both reaching the receiver.

Negative controls: moving the tenancy fluentd memory request from 50M to 100M fails `TestBuildersMatchCommon` on both infra and tenant; dropping the namespace de-duplication fails `repeats are dropped`; the two teardown ones above. Harness unit tests are pure Go, no stub binaries.
