### PR TITLE
refactor(e2e): move three more suites onto the harness

### DIFF
--- a/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
+++ b/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
@@ -15,192 +15,67 @@
 package fluentbit_hotreload
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
-	operatortypes "github.com/cisco-open/operator-tools/pkg/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/fixture"
+	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
-	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-var TestTempDir string
-
-func init() {
-	var ok bool
-	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
-	if !ok {
-		TestTempDir = "../.."
-	}
-	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
-	if err != nil {
-		panic(err)
-	}
-}
-
-var (
-	tags           = "time"
-	realTimeBuffer = &output.Buffer{
-		Tags:        &tags,
-		Timekey:     "1s",
-		TimekeyWait: "0s",
-	}
+const (
+	release   = "fluentbit-hotreload"
+	nsInfra   = "infra"
+	nsTenant  = "tenant"
+	tagInfra  = "tag_infra"
+	tagTenant = "tag_tenant"
 )
 
-var producerLabels = map[string]string{
-	"my-unique-label": "log-producer",
+var producerLabels = map[string]string{"my-unique-label": "log-producer"}
+
+// Type is left unset here as it is in fluentbit-multitenant; fixture.Buffer's
+// "file" default would switch the outputs from memory buffering.
+func realTimeBuffer() *output.Buffer {
+	tags := "time"
+	return &output.Buffer{Tags: &tags, Timekey: "1s", TimekeyWait: "0s"}
 }
 
 func TestFluentbitHotReload(t *testing.T) {
-	common.Initialize(t)
-	nsInfra := "infra"
-	nsTenant := "tenant"
-	tagInfra := "tag_infra"
-	tagTenant := "tag_tenant"
+	env := harness.New(t).
+		WithCluster(release).
+		WithRelease(release).
+		WithControlNamespace(nsInfra).
+		WithNamespaces(nsTenant).
+		Start()
 
-	release := "fluentbit-hotreload"
-	common.WithCluster(release, t, func(t *testing.T, c common.Cluster) {
-		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
-			options.Namespace = nsInfra
-			options.NameOverride = release
-		}))
+	buffer := realTimeBuffer()
+	env.Create(fixture.LoggingInfra(nsInfra, release, tagInfra, buffer, producerLabels)...)
+	env.Create(fixture.LoggingTenant(nsTenant, nsInfra, release, tagTenant, buffer, producerLabels)...)
 
-		ctx := context.Background()
+	env.StartLogProducer(nsTenant, producerLabels)
 
-		common.RequireNoError(t, c.GetClient().Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: nsTenant,
-			},
-		}))
+	env.WaitForRunning(
+		wait.Operator(release),
+		wait.Producer(producerLabels),
+		wait.FluentdAggregator(nsInfra),
+		wait.FluentdAggregator(nsTenant),
+	)
 
-		common.LoggingInfra(ctx, t, c.GetClient(), nsInfra, release, tagInfra, realTimeBuffer, producerLabels)
-		common.LoggingTenant(ctx, t, c.GetClient(), nsTenant, nsInfra, release, tagTenant, realTimeBuffer, producerLabels)
+	// No route yet, so the tenant's logs have nowhere to go.
+	env.Receiver.MustReceive(tagInfra)
+	env.Receiver.MustNotReceive(tagTenant)
 
-		aggregatorLabels := map[string]string{
-			operatortypes.NameLabel:      "fluentd",
-			operatortypes.ComponentLabel: "fluentd",
-		}
-		operatorLabels := map[string]string{
-			operatortypes.NameLabel: release,
-		}
+	env.Create(fixture.LoggingRoute())
+	env.Receiver.MustReceive(tagTenant)
 
-		// start log producer in the tenant namespace
-		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
-			options.Namespace = nsTenant
-			options.Labels = producerLabels
-		}))
-
-		require.Eventually(t, func() bool {
-			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
-				t.Log("waiting for the operator")
-				return false
-			}
-			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
-				t.Log("waiting for the producer")
-				return false
-			}
-			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsInfra)); !aggregatorRunning() {
-				t.Log("waiting for the infra aggregator")
-				return false
-			}
-			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsTenant)); !aggregatorRunning() {
-				t.Log("waiting for the tenant aggregator")
-				return false
-			}
-			return true
-		}, 5*time.Minute, 3*time.Second)
-
-		require.Eventually(t, func() bool {
-			cmd := common.CmdEnv(exec.Command("kubectl",
-				"logs",
-				"-n", nsInfra,
-				"--tail", "100",
-				"-l", fmt.Sprintf("%s=%s-test-receiver", operatortypes.NameLabel, release)), c)
-			rawOut, err := cmd.Output()
-			if err != nil {
-				t.Logf("failed to get log consumer logs: %v", err)
-				return false
-			}
-			t.Logf("log consumer logs should contain no tenant, only infra logs: %s", rawOut)
-			return !strings.Contains(string(rawOut), tagTenant) && strings.Contains(string(rawOut), tagInfra)
-		}, 5*time.Minute, 3*time.Second)
-
-		common.LoggingRoute(ctx, t, c.GetClient())
-
-		require.Eventually(t, func() bool {
-			cmd := common.CmdEnv(exec.Command("kubectl",
-				"logs",
-				"-n", nsInfra,
-				"--tail", "30",
-				"-l", fmt.Sprintf("%s=%s-test-receiver", operatortypes.NameLabel, release)), c)
-			rawOut, err := cmd.Output()
-			if err != nil {
-				t.Logf("failed to get log consumer logs: %v", err)
-				return false
-			}
-			t.Logf("log consumer logs should contain tenant logs: %s", rawOut)
-			return strings.Contains(string(rawOut), tagTenant)
-		}, 5*time.Minute, 3*time.Second)
-
-		ds := &appsv1.DaemonSet{}
-		err := c.GetClient().Get(ctx, types.NamespacedName{
-			Namespace: nsInfra,
-			Name:      "infra-fluentbit",
-		}, ds)
-		assert.NoError(t, err)
-
-		assert.Equal(t, int64(1), ds.Generation, "generation should not be incremented for a reloadable agent")
-	}, func(t *testing.T, c common.Cluster) error {
-		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
-		t.Logf("Printing cluster logs to %s", path)
-		err := c.PrintLogs(common.PrintLogConfig{
-			Namespaces: []string{nsInfra, nsTenant, "default"},
-			FilePath:   path,
-			Limit:      100 * 1000,
-		})
-		if err != nil {
-			return err
-		}
-
-		loggingOperatorName := "logging-operator-" + release
-		t.Logf("Collecting coverage files from logging-operator: %s/%s", nsInfra, loggingOperatorName)
-		err = c.CollectTestCoverageFiles(nsInfra, loggingOperatorName)
-		if err != nil {
-			t.Logf("Failed collecting coverage files: %s", err)
-		}
-
-		return nil
-	}, func(o *cluster.Options) {
-		if o.Scheme == nil {
-			o.Scheme = runtime.NewScheme()
-		}
-		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
-	})
+	ds := &appsv1.DaemonSet{}
+	assert.NoError(t, env.Client.Get(env.Ctx, types.NamespacedName{
+		Namespace: nsInfra,
+		Name:      "infra-fluentbit",
+	}, ds))
+	assert.Equal(t, int64(1), ds.Generation, "generation should not be incremented for a reloadable agent")
 }

--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -62,5 +62,5 @@ func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
 		wait.FluentdAggregator(nsInfra),
 		wait.FluentdAggregator(nsTenant),
 	)
-	env.WaitForReceiverLogs(tagInfra, tagTenant)
+	env.Receiver.MustReceive(tagInfra, tagTenant)
 }

--- a/e2e/internal/harness/harness.go
+++ b/e2e/internal/harness/harness.go
@@ -51,7 +51,10 @@ const (
 	clusterStopTimeout = time.Minute
 
 	clusterLogLimit = 100 * 1000
-	receiverLogTail = 30
+
+	// Generous on purpose: more lines makes a tag easier to find and its
+	// absence harder to claim.
+	receiverLogTail = 100
 
 	// waitBudget and waitInterval are what the suites spend by hand today.
 	waitBudget   = 5 * time.Minute
@@ -132,6 +135,7 @@ type Env struct {
 
 	Release          string
 	ControlNamespace string
+	Receiver         Receiver
 
 	dumpNamespaces []string
 }
@@ -167,6 +171,7 @@ func (b *Builder) Start() *Env {
 		ControlNamespace: b.cfg.controlNamespace,
 		dumpNamespaces:   dumpNamespaces(b.cfg),
 	}
+	env.Receiver = Receiver{env: env}
 
 	teardown{
 		{"artifacts", env.collectArtifacts},
@@ -223,16 +228,22 @@ func (e *Env) WaitForRunning(conditions ...wait.Condition) {
 	}, e.waitBudget(), waitInterval, "still waiting for %s", &outstanding)
 }
 
-// WaitForReceiverLogs does not echo the tail each poll: the archived cluster
-// dump already carries the receiver's log.
-func (e *Env) WaitForReceiverLogs(tags ...string) {
-	e.T.Helper()
+// Receiver is the test receiver the chart installs, where a suite looks to see
+// which logs arrived.
+type Receiver struct {
+	env *Env
+}
+
+// MustReceive does not echo the tail each poll: the archived cluster dump
+// already carries the receiver's log.
+func (r Receiver) MustReceive(tags ...string) {
+	r.env.T.Helper()
 
 	var outstanding pending
-	require.Eventuallyf(e.T, func() bool {
-		logs, err := e.ReceiverLogs(receiverLogTail)
+	require.Eventuallyf(r.env.T, func() bool {
+		logs, err := r.Logs()
 		if err != nil {
-			e.T.Logf("reading the test receiver: %v", err)
+			r.env.T.Logf("reading the test receiver: %v", err)
 			return false
 		}
 		for _, tag := range tags {
@@ -242,15 +253,27 @@ func (e *Env) WaitForReceiverLogs(tags ...string) {
 			}
 		}
 		return true
-	}, e.waitBudget(), waitInterval, "the test receiver never logged %s", &outstanding)
+	}, r.env.waitBudget(), waitInterval, "the test receiver never logged %s", &outstanding)
 }
 
-func (e *Env) ReceiverLogs(tail int) (string, error) {
+// MustNotReceive is a point-in-time check, since an absence cannot be waited
+// for. It belongs after whatever wait establishes that the pipeline is running.
+func (r Receiver) MustNotReceive(tags ...string) {
+	r.env.T.Helper()
+
+	logs, err := r.Logs()
+	require.NoError(r.env.T, err)
+	for _, tag := range tags {
+		assert.NotContains(r.env.T, logs, tag)
+	}
+}
+
+func (r Receiver) Logs() (string, error) {
 	out, err := common.CmdEnv(exec.Command("kubectl",
 		"logs",
-		"-n", e.ControlNamespace,
-		"--tail", fmt.Sprint(tail),
-		"-l", fmt.Sprintf("%s=%s-test-receiver", types.NameLabel, e.Release)), e.Cluster).Output()
+		"-n", r.env.ControlNamespace,
+		"--tail", fmt.Sprint(receiverLogTail),
+		"-l", fmt.Sprintf("%s=%s-test-receiver", types.NameLabel, r.env.Release)), r.env.Cluster).Output()
 	return string(out), err
 }
 

--- a/e2e/internal/wait/condition.go
+++ b/e2e/internal/wait/condition.go
@@ -49,6 +49,20 @@ func PodRunning(name string, opts ...client.ListOption) Condition {
 	}
 }
 
+func Pod(namespace, name string) Condition {
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+	return Condition{
+		Name: "pod " + namespace + "/" + name,
+		Met: func(ctx context.Context, cl client.Reader) (bool, error) {
+			var pod corev1.Pod
+			if err := cl.Get(ctx, key, &pod); err != nil {
+				return false, client.IgnoreNotFound(err)
+			}
+			return pod.Status.Phase == corev1.PodRunning, nil
+		},
+	}
+}
+
 func Operator(release string) Condition {
 	return PodRunning("operator", client.MatchingLabels{types.NameLabel: release})
 }

--- a/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
+++ b/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
@@ -15,31 +15,16 @@
 package syslong_ng_aggregator
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/cisco-open/operator-tools/pkg/typeoverride"
-	"github.com/cisco-open/operator-tools/pkg/types"
-	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/resources/syslogng"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
@@ -47,223 +32,145 @@ import (
 	syslogngoutput "github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/output"
 )
 
-var TestTempDir string
+const (
+	ns      = "test"
+	release = "e2e"
+	testTag = "test.tag"
+)
 
-func init() {
-	var ok bool
-	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
-	if !ok {
-		TestTempDir = "../.."
-	}
-	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
-	if err != nil {
-		panic(err)
-	}
-}
+var producerLabels = map[string]string{"my-unique-label": "log-producer"}
 
 func TestSyslogNGIsRunningAndForwardingLogs(t *testing.T) {
-	common.Initialize(t)
-	ns := "test"
-	releaseNameOverride := "e2e"
-	common.WithCluster("syslog-ng-forwarding", t, func(t *testing.T, c common.Cluster) {
-		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
-			options.Namespace = ns
-			options.NameOverride = releaseNameOverride
-		}))
+	env := harness.New(t).
+		WithCluster("syslog-ng-forwarding").
+		WithRelease(release).
+		WithControlNamespace(ns).
+		Start()
 
-		ctx := context.Background()
-
-		logging := v1beta1.Logging{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "syslog-ng-aggregator-test",
-				Namespace: ns,
-			},
-			Spec: v1beta1.LoggingSpec{
-				EnableRecreateWorkloadOnImmutableFieldChange: true,
-				ControlNamespace: ns,
-				FluentbitSpec: &v1beta1.FluentbitSpec{
-					Network: &v1beta1.FluentbitNetwork{
-						Keepalive: new(false),
-					},
-					ConfigHotReload: &v1beta1.HotReload{
-						Image: v1beta1.ImageSpec{
-							Repository: common.ConfigReloaderRepo,
-							Tag:        common.ConfigReloaderTag,
-						},
-					},
-					BufferVolumeImage: v1beta1.ImageSpec{
-						Repository: common.NodeExporterRepo,
-						Tag:        common.NodeExporterTag,
+	logging := &v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "syslog-ng-aggregator-test",
+			Namespace: ns,
+		},
+		Spec: v1beta1.LoggingSpec{
+			EnableRecreateWorkloadOnImmutableFieldChange: true,
+			ControlNamespace: ns,
+			FluentbitSpec: &v1beta1.FluentbitSpec{
+				Network: &v1beta1.FluentbitNetwork{
+					Keepalive: new(false),
+				},
+				ConfigHotReload: &v1beta1.HotReload{
+					Image: v1beta1.ImageSpec{
+						Repository: common.ConfigReloaderRepo,
+						Tag:        common.ConfigReloaderTag,
 					},
 				},
-				SyslogNGSpec: &v1beta1.SyslogNGSpec{
-					ConfigReloadImage: &v1beta1.BasicImageSpec{
-						Repository: common.SyslogNGReloaderRepo,
-						Tag:        common.SyslogNGReloaderTag,
-					},
-					BufferVolumeMetricsImage: &v1beta1.BasicImageSpec{
-						Repository: common.NodeExporterRepo,
-						Tag:        common.NodeExporterTag,
-					},
-					StatefulSetOverrides: &typeoverride.StatefulSet{
-						Spec: typeoverride.StatefulSetSpec{
-							Template: typeoverride.PodTemplateSpec{
-								Spec: typeoverride.PodSpec{
-									Containers: []corev1.Container{
-										{
-											Name: syslogng.ContainerName,
-											Resources: corev1.ResourceRequirements{
-												Limits: corev1.ResourceList{
-													corev1.ResourceCPU:    resource.MustParse("100m"),
-													corev1.ResourceMemory: resource.MustParse("100M"),
-												},
-												Requests: corev1.ResourceList{
-													corev1.ResourceCPU:    resource.MustParse("25m"),
-													corev1.ResourceMemory: resource.MustParse("10M"),
-												},
+				BufferVolumeImage: v1beta1.ImageSpec{
+					Repository: common.NodeExporterRepo,
+					Tag:        common.NodeExporterTag,
+				},
+			},
+			SyslogNGSpec: &v1beta1.SyslogNGSpec{
+				ConfigReloadImage: &v1beta1.BasicImageSpec{
+					Repository: common.SyslogNGReloaderRepo,
+					Tag:        common.SyslogNGReloaderTag,
+				},
+				BufferVolumeMetricsImage: &v1beta1.BasicImageSpec{
+					Repository: common.NodeExporterRepo,
+					Tag:        common.NodeExporterTag,
+				},
+				StatefulSetOverrides: &typeoverride.StatefulSet{
+					Spec: typeoverride.StatefulSetSpec{
+						Template: typeoverride.PodTemplateSpec{
+							Spec: typeoverride.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: syslogng.ContainerName,
+										Resources: corev1.ResourceRequirements{
+											Limits: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("100m"),
+												corev1.ResourceMemory: resource.MustParse("100M"),
 											},
-											VolumeMounts: []corev1.VolumeMount{
-												{
-													Name:      "buffers",
-													MountPath: "/buffers",
-												},
+											Requests: corev1.ResourceList{
+												corev1.ResourceCPU:    resource.MustParse("25m"),
+												corev1.ResourceMemory: resource.MustParse("10M"),
+											},
+										},
+										VolumeMounts: []corev1.VolumeMount{
+											{
+												Name:      "buffers",
+												MountPath: "/buffers",
 											},
 										},
 									},
-									Volumes: []corev1.Volume{
-										{
-											Name: "buffers",
-											VolumeSource: corev1.VolumeSource{
-												EmptyDir: &corev1.EmptyDirVolumeSource{},
-											},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: "buffers",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
 										},
 									},
 								},
 							},
 						},
 					},
-					BufferVolumeMetrics: &v1beta1.BufferMetrics{
-						Metrics: v1beta1.Metrics{
-							Interval: "1s",
-						},
-						MountName: "buffers",
+				},
+				BufferVolumeMetrics: &v1beta1.BufferMetrics{
+					Metrics: v1beta1.Metrics{
+						Interval: "1s",
 					},
+					MountName: "buffers",
 				},
 			},
-		}
-		testTag := "test.tag"
+		},
+	}
 
-		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
-		output := v1beta1.SyslogNGOutput{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-output",
-				Namespace: ns,
-			},
-			Spec: v1beta1.SyslogNGOutputSpec{
-				HTTP: &syslogngoutput.HTTPOutput{
-					URL: fmt.Sprintf("http://%s-test-receiver:8080/%s", releaseNameOverride, testTag),
-					Headers: []string{
-						"Content-type: application/json",
-					},
-					Method: "POST",
-					DiskBuffer: &syslogngoutput.DiskBuffer{
-						DiskBufSize: 100 * 1024 * 1024,
-						Reliable:    true,
-						Dir:         syslogng.BufferPath,
-					},
+	output := &v1beta1.SyslogNGOutput{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-output",
+			Namespace: ns,
+		},
+		Spec: v1beta1.SyslogNGOutputSpec{
+			HTTP: &syslogngoutput.HTTPOutput{
+				URL: fmt.Sprintf("http://%s-test-receiver:8080/%s", release, testTag),
+				Headers: []string{
+					"Content-type: application/json",
+				},
+				Method: "POST",
+				DiskBuffer: &syslogngoutput.DiskBuffer{
+					DiskBufSize: 100 * 1024 * 1024,
+					Reliable:    true,
+					Dir:         syslogng.BufferPath,
 				},
 			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &output))
-		flow := v1beta1.SyslogNGFlow{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-flow",
-				Namespace: ns,
-			},
-			Spec: v1beta1.SyslogNGFlowSpec{
-				Match: &v1beta1.SyslogNGMatch{
-					Regexp: &filter.RegexpMatchExpr{
-						Pattern: "log-producer",
-						Value:   "json.kubernetes.labels.my-unique-label",
-						Type:    "string",
-					},
+		},
+	}
+
+	flow := &v1beta1.SyslogNGFlow{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-flow",
+			Namespace: ns,
+		},
+		Spec: v1beta1.SyslogNGFlowSpec{
+			Match: &v1beta1.SyslogNGMatch{
+				Regexp: &filter.RegexpMatchExpr{
+					Pattern: "log-producer",
+					Value:   "json.kubernetes.labels.my-unique-label",
+					Type:    "string",
 				},
-				LocalOutputRefs: []string{output.Name},
 			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &flow))
+			LocalOutputRefs: []string{output.Name},
+		},
+	}
 
-		aggergatorLabels := map[string]string{
-			types.NameLabel:      "syslog-ng",
-			types.ComponentLabel: "syslog-ng",
-		}
-		operatorLabels := map[string]string{
-			types.NameLabel: releaseNameOverride,
-		}
-		producerLabels := map[string]string{
-			"my-unique-label": "log-producer",
-		}
-		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
-			options.Namespace = ns
-			options.Labels = producerLabels
-		}))
+	env.Create(logging, output, flow)
+	env.StartLogProducer(ns, producerLabels)
 
-		require.Eventually(t, func() bool {
-			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
-				t.Log("waiting for the operator")
-				return false
-			}
-			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
-				t.Log("waiting for the producer")
-				return false
-			}
-			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggergatorLabels)); !aggregatorRunning() {
-				t.Log("waiting for the aggregator")
-				return false
-			}
-
-			cmd := common.CmdEnv(exec.Command("kubectl",
-				"logs",
-				"-n", ns,
-				"-l", fmt.Sprintf("%s=%s-test-receiver", types.NameLabel, releaseNameOverride)), c)
-			rawOut, err := cmd.Output()
-			if err != nil {
-				t.Logf("failed to get log consumer logs: %+v %s", err, rawOut)
-				return false
-			}
-			t.Logf("log consumer logs: %s", rawOut)
-			return strings.Contains(string(rawOut), testTag)
-		}, 5*time.Minute, 2*time.Second)
-	}, func(t *testing.T, c common.Cluster) error {
-		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
-		t.Logf("Printing cluster logs to %s", path)
-		err := c.PrintLogs(common.PrintLogConfig{
-			Namespaces: []string{ns, "default"},
-			FilePath:   path,
-			Limit:      100 * 1000,
-		})
-		if err != nil {
-			return err
-		}
-
-		loggingOperatorName := "logging-operator-" + releaseNameOverride
-		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
-		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
-		if err != nil {
-			t.Logf("Failed collecting coverage files: %s", err)
-		}
-
-		return nil
-	}, func(o *cluster.Options) {
-		if o.Scheme == nil {
-			o.Scheme = runtime.NewScheme()
-		}
-		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
-	})
+	env.WaitForRunning(
+		wait.Operator(release),
+		wait.Producer(producerLabels),
+		wait.SyslogNGAggregator(ns),
+	)
+	env.Receiver.MustReceive(testTag)
 }

--- a/e2e/watch-selector/watch_selector_test.go
+++ b/e2e/watch-selector/watch_selector_test.go
@@ -15,197 +15,130 @@
 package watch_selector
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/e2e-framework/third_party/helm"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
+	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
-var TestTempDir string
+const (
+	ns      = "test"
+	release = "e2e"
 
-func init() {
-	var ok bool
-	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
-	if !ok {
-		TestTempDir = "../.."
-	}
-	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
-	if err != nil {
-		panic(err)
-	}
-}
+	// unmanagedNS is created by the fluent chart, not by the harness.
+	unmanagedNS = "fluentd"
+)
 
 func TestWatchSelectors(t *testing.T) {
-	common.Initialize(t)
-	ns := "test"
-	releaseNameOverride := "e2e"
-	common.WithCluster("watch-selector", t, func(t *testing.T, c common.Cluster) {
-		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
-			options.Namespace = ns
-			options.NameOverride = releaseNameOverride
-			options.Args = []string{"-enable-leader-election=true", "-watch-labeled-children=true", "-watch-labeled-secrets=true"}
-		}))
+	env := harness.New(t).
+		WithCluster("watch-selector").
+		WithRelease(release).
+		WithControlNamespace(ns).
+		WithOperatorArgs("-enable-leader-election=true", "-watch-labeled-children=true", "-watch-labeled-secrets=true").
+		Start()
 
-		ctx := context.Background()
-
-		// Managed logging resource which creates a fluentd pod with a secret named: watch-selector-test-fluentd
-		logging := v1beta1.Logging{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "watch-selector-test",
-				Namespace: ns,
-			},
-			Spec: v1beta1.LoggingSpec{
-				ControlNamespace: ns,
-				FluentbitSpec: &v1beta1.FluentbitSpec{
-					ConfigHotReload: &v1beta1.HotReload{
-						Image: v1beta1.ImageSpec{
-							Repository: common.ConfigReloaderRepo,
-							Tag:        common.ConfigReloaderTag,
-						},
-					},
-					BufferVolumeImage: v1beta1.ImageSpec{
-						Repository: common.NodeExporterRepo,
-						Tag:        common.NodeExporterTag,
-					},
-				},
-				FluentdSpec: &v1beta1.FluentdSpec{
+	logging := &v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "watch-selector-test",
+			Namespace: ns,
+		},
+		Spec: v1beta1.LoggingSpec{
+			ControlNamespace: ns,
+			FluentbitSpec: &v1beta1.FluentbitSpec{
+				ConfigHotReload: &v1beta1.HotReload{
 					Image: v1beta1.ImageSpec{
-						Repository: common.FluentdImageRepo,
-						Tag:        common.FluentdImageTag,
-					},
-					ConfigReloaderImage: v1beta1.ImageSpec{
 						Repository: common.ConfigReloaderRepo,
 						Tag:        common.ConfigReloaderTag,
 					},
-					BufferVolumeImage: v1beta1.ImageSpec{
-						Repository: common.NodeExporterRepo,
-						Tag:        common.NodeExporterTag,
-					},
+				},
+				BufferVolumeImage: v1beta1.ImageSpec{
+					Repository: common.NodeExporterRepo,
+					Tag:        common.NodeExporterTag,
 				},
 			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
-
-		// Unmanaged resources
-		common.RequireNoError(t, installFluentdSts(c))
-
-		unmanagedSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "unmanaged-fluentd-secret",
-				Namespace: ns,
-				Labels: map[string]string{
-					"app": "fluentd",
+			FluentdSpec: &v1beta1.FluentdSpec{
+				Image: v1beta1.ImageSpec{
+					Repository: common.FluentdImageRepo,
+					Tag:        common.FluentdImageTag,
+				},
+				ConfigReloaderImage: v1beta1.ImageSpec{
+					Repository: common.ConfigReloaderRepo,
+					Tag:        common.ConfigReloaderTag,
+				},
+				BufferVolumeImage: v1beta1.ImageSpec{
+					Repository: common.NodeExporterRepo,
+					Tag:        common.NodeExporterTag,
 				},
 			},
-			Data: map[string][]byte{
-				"key": []byte("value"),
+		},
+	}
+	env.Create(logging)
+
+	require.NoError(t, installFluentdSts(env))
+
+	unmanagedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unmanaged-fluentd-secret",
+			Namespace: ns,
+			Labels: map[string]string{
+				"app": "fluentd",
 			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, unmanagedSecret))
+		},
+		Data: map[string][]byte{
+			"key": []byte("value"),
+		},
+	}
+	env.Create(unmanagedSecret)
 
-		require.Eventually(t, func() bool {
-			if isManagedFluentdPodRunning := wait.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: ns, Name: logging.Name + "-fluentd-0"}); !isManagedFluentdPodRunning() {
-				t.Logf("managed fluentd pod is not running")
-				return false
-			}
+	env.WaitForRunning(
+		wait.Pod(ns, logging.Name+"-fluentd-0"),
+		wait.Pod(unmanagedNS, "fluentd-0"),
+	)
 
-			if isUnmanagedFluentdPodRunning := wait.PodShouldBeRunning(t, c.GetClient(), client.ObjectKey{Namespace: "fluentd", Name: "fluentd-0"}); !isUnmanagedFluentdPodRunning() {
-				t.Logf("unmanaged fluentd pod is not running")
-				return false
-			}
+	deployedLogging := &v1beta1.Logging{}
+	require.NoError(t, env.Client.Get(env.Ctx, client.ObjectKeyFromObject(logging), deployedLogging))
 
-			return true
-		}, 5*time.Minute, 3*time.Second)
+	// The managed resources have to be owned by the logging resource.
+	managedSts := &appsv1.StatefulSet{}
+	require.NoError(t, env.Client.Get(env.Ctx, client.ObjectKey{Namespace: ns, Name: deployedLogging.Name + "-fluentd"}, managedSts))
+	requireOwnedBy(t, deployedLogging, metav1.GetControllerOf(managedSts))
 
-		deployedLogging := &v1beta1.Logging{}
-		common.RequireNoError(t, c.GetClient().Get(ctx, client.ObjectKeyFromObject(&logging), deployedLogging))
+	managedSecret := &corev1.Secret{}
+	require.NoError(t, env.Client.Get(env.Ctx, client.ObjectKey{Namespace: ns, Name: deployedLogging.Name + "-fluentd"}, managedSecret))
+	requireOwnedBy(t, deployedLogging, metav1.GetControllerOf(managedSecret))
 
-		// Check if the managed resources are actually controlled by the logging resource
-		managedSts := &appsv1.StatefulSet{}
-		common.RequireNoError(t, c.GetClient().Get(ctx, client.ObjectKey{Namespace: ns, Name: deployedLogging.Name + "-fluentd"}, managedSts))
-		stsOwnerRefMeta := metav1.GetControllerOf(managedSts)
-		require.NotNil(t, stsOwnerRefMeta)
+	// The unmanaged ones have to be left alone.
+	unmanagedSts := &appsv1.StatefulSet{}
+	require.NoError(t, env.Client.Get(env.Ctx, client.ObjectKey{Namespace: unmanagedNS, Name: "fluentd"}, unmanagedSts))
+	require.Nil(t, metav1.GetControllerOf(unmanagedSts))
 
-		require.Equal(t, deployedLogging.APIVersion, stsOwnerRefMeta.APIVersion)
-		require.Equal(t, deployedLogging.Kind, stsOwnerRefMeta.Kind)
-		require.Equal(t, deployedLogging.Name, stsOwnerRefMeta.Name)
-		require.True(t, *stsOwnerRefMeta.Controller)
-
-		managedSecret := &corev1.Secret{}
-		common.RequireNoError(t, c.GetClient().Get(ctx, client.ObjectKey{Namespace: ns, Name: deployedLogging.Name + "-fluentd"}, managedSecret))
-		secretOwnerRefMeta := metav1.GetControllerOf(managedSecret)
-		require.NotNil(t, secretOwnerRefMeta)
-
-		require.Equal(t, deployedLogging.APIVersion, secretOwnerRefMeta.APIVersion)
-		require.Equal(t, deployedLogging.Kind, secretOwnerRefMeta.Kind)
-		require.Equal(t, deployedLogging.Name, secretOwnerRefMeta.Name)
-		require.True(t, *secretOwnerRefMeta.Controller)
-
-		// Check if the unmanaged resources are actually not controlled by the operator
-		unmanagedSts := &appsv1.StatefulSet{}
-		common.RequireNoError(t, c.GetClient().Get(ctx, client.ObjectKey{Namespace: "fluentd", Name: "fluentd"}, unmanagedSts))
-		secretOwnerRefMeta = metav1.GetControllerOf(unmanagedSts)
-		require.Nil(t, secretOwnerRefMeta)
-
-		secret := &corev1.Secret{}
-		common.RequireNoError(t, c.GetClient().Get(ctx, client.ObjectKeyFromObject(unmanagedSecret), secret))
-		secretOwnerRefMeta = metav1.GetControllerOf(secret)
-		require.Nil(t, secretOwnerRefMeta)
-	}, func(t *testing.T, c common.Cluster) error {
-		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
-		t.Logf("Printing cluster logs to %s", path)
-		err := c.PrintLogs(common.PrintLogConfig{
-			Namespaces: []string{ns, "default"},
-			FilePath:   path,
-			Limit:      100 * 1000,
-		})
-		if err != nil {
-			return err
-		}
-
-		loggingOperatorName := "logging-operator-" + releaseNameOverride
-		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
-		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
-		if err != nil {
-			t.Logf("Failed collecting coverage files: %s", err)
-		}
-
-		return nil
-	}, func(o *cluster.Options) {
-		if o.Scheme == nil {
-			o.Scheme = runtime.NewScheme()
-		}
-		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
-	})
+	secret := &corev1.Secret{}
+	require.NoError(t, env.Client.Get(env.Ctx, client.ObjectKeyFromObject(unmanagedSecret), secret))
+	require.Nil(t, metav1.GetControllerOf(secret))
 }
 
-func installFluentdSts(c common.Cluster) error {
-	manager := helm.New(c.KubeConfigFilePath())
+func requireOwnedBy(t *testing.T, owner *v1beta1.Logging, ref *metav1.OwnerReference) {
+	t.Helper()
+
+	require.NotNil(t, ref)
+	require.Equal(t, owner.APIVersion, ref.APIVersion)
+	require.Equal(t, owner.Kind, ref.Kind)
+	require.Equal(t, owner.Name, ref.Name)
+	require.True(t, *ref.Controller)
+}
+
+func installFluentdSts(env *harness.Env) error {
+	manager := helm.New(env.Cluster.KubeConfigFilePath())
 
 	if err := manager.RunRepo(helm.WithArgs("add", "fluent", "https://fluent.github.io/helm-charts")); err != nil {
 		return fmt.Errorf("failed to add fluent repo: %v", err)
@@ -215,7 +148,7 @@ func installFluentdSts(c common.Cluster) error {
 		helm.WithName("fluentd"),
 		helm.WithChart("fluent/fluentd"),
 		helm.WithArgs("--create-namespace"),
-		helm.WithNamespace("fluentd"),
+		helm.WithNamespace(unmanagedNS),
 		helm.WithArgs("--set", "kind=StatefulSet"),
 		helm.WithWait(),
 	); err != nil {


### PR DESCRIPTION
Three more suites onto the harness, and the three things they needed that it did not have.

| suite | lines |
| --- | --- |
| `fluentbit-hotreload` | 206 → 81 |
| `watch-selector` | 226 → 159 |
| `syslog-ng-aggregator` | 269 → 176 |

Each addition lands with a caller. `wait.SyslogNGAggregator` had none until now, and `wait.PodRunning` still has none by design — it is the escape hatch the named constructors fall back on.

- **`wait.Pod(namespace, name)`.** `watch-selector` waits on two pods by name rather than by selector.
- **`Env.Receiver`.** `MustReceive` and `MustNotReceive`, replacing `WaitForReceiverLogs`. The tail moves inside the type: one value of 100, which is stricter than the 30 an absence check would otherwise get and no weaker for presence, since more lines only make a tag easier to find.
- **`WithOperatorArgs`** already existed and gets its first use in `watch-selector`.

### What was left alone on purpose

`watch-selector` keeps its `Logging` literal. `fixture.WithFluentbit()` would add `Network.Keepalive` and `WithFluentd()` would add `Resources`, `BufferVolumeMetrics` and `Workers: 2`, none of which that suite has today. `syslog-ng-aggregator` keeps its `SyslogNGSpec` for the same reason: the statefulset overrides and buffer volumes have no builder, and one caller does not justify inventing one.

`fluentbit-hotreload`'s combined predicate is split, `MustReceive(tagInfra)` then `MustNotReceive(tagTenant)`. Worked through the three orderings — infra first, tenant first, tenant never — the two agree in every case; the split fails immediately rather than after five minutes, and says which half broke.

Two divergences are changed rather than preserved, so they are stated rather than silent: `syslog-ng-aggregator` polled at 2s and now polls at the shared 3s, and its aggregator check was cluster-wide and is now scoped to the one namespace it uses. Neither can change a verdict. The `syslong_ng_aggregator` package typo is untouched; renaming belongs with the rest of the naming work.

### Verification

`make check` passes, `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` in `e2e/` reports 0 issues, and every commit builds, vets and tests on its own.

Against real clusters: `syslog-ng-aggregator` 112s and `watch-selector` 64s both pass.

`fluentbit-hotreload` does **not** pass locally, and neither does the version on master. Same failure, same place, 4s apart: the tenant pipeline delivers nothing on this machine — 601 receiver deliveries all `tag_infra`, zero `tag_tenant`, against 605/0 for the unmigrated suite. So the migration is not the difference, but the local run is a before/after control rather than a pass. CI is the verdict for that one, where the suite has been green on six consecutive runs.
