### PR TITLE
fix(e2e): share the elasticsearch readiness budget between the waits

### DIFF
--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -50,9 +50,10 @@ const (
 	// esReadyFallback applies when the binary has no deadline to derive from.
 	esReadyFallback = 15 * time.Minute
 
-	// esReadyMargin is the room left before the deadline for the wait to report
-	// its own failure. It does not cover teardown, which can outlast it.
-	esReadyMargin = 30 * time.Second
+	// esReadyMargin is the room left before the deadline. 30s covered the wait
+	// reporting its own failure but not teardown, which is a stern dump, a
+	// kubectl exec plus tar for coverage, and a kind delete.
+	esReadyMargin = 90 * time.Second
 )
 
 var TestTempDir string
@@ -93,21 +94,22 @@ func logContainerRestarts(t *testing.T, c common.Cluster, ctx context.Context, n
 	}
 }
 
-// esReadyBudget caps a wait strictly below the enclosing -timeout, so an
-// Elasticsearch deployment that never becomes ready fails by name instead of
-// letting the package binary panic and report only a goroutine dump.
-func esReadyBudget(t *testing.T) time.Duration {
+// esReadyBudget shares what is left of the -timeout between the deployments
+// still to check. Handing it all to the first let a slow one spend the
+// package's budget, leaving the rest to fail instantly under the wrong name.
+// The fallback is already per-wait, so it is not divided.
+func esReadyBudget(t *testing.T, waitsLeft int) time.Duration {
 	deadline, ok := t.Deadline()
 	if !ok {
 		return esReadyFallback
 	}
-	return budgetWithin(time.Until(deadline))
+	return budgetWithin(time.Until(deadline), waitsLeft)
 }
 
 // budgetWithin never returns a non-positive duration: require.Eventually treats
 // one as already expired, which would fail every run instead of only stalled ones.
-func budgetWithin(remaining time.Duration) time.Duration {
-	if budget := remaining - esReadyMargin; budget > 0 {
+func budgetWithin(remaining time.Duration, waitsLeft int) time.Duration {
+	if budget := (remaining - esReadyMargin) / time.Duration(waitsLeft); budget > 0 {
 		return budget
 	}
 	return time.Second
@@ -117,18 +119,30 @@ func TestBudgetWithin(t *testing.T) {
 	for _, c := range []struct {
 		name      string
 		remaining time.Duration
+		waitsLeft int
 		want      time.Duration
 	}{
-		{"ample", 20 * time.Minute, 20*time.Minute - esReadyMargin},
-		{"just above the margin", esReadyMargin + time.Second, time.Second},
-		{"exactly the margin", esReadyMargin, time.Second},
-		{"already past the deadline", -time.Minute, time.Second},
+		{"shared between the waits still to come", 20 * time.Minute, 3, (20*time.Minute - esReadyMargin) / 3},
+		{"the last wait gets what is left", 20 * time.Minute, 1, 20*time.Minute - esReadyMargin},
+		{"exactly the margin", esReadyMargin, 3, time.Second},
+		{"already past the deadline", -time.Minute, 3, time.Second},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			require.Equal(t, c.want, budgetWithin(c.remaining))
-			require.Positive(t, budgetWithin(c.remaining))
+			require.Equal(t, c.want, budgetWithin(c.remaining, c.waitsLeft))
+			require.Positive(t, budgetWithin(c.remaining, c.waitsLeft))
 		})
 	}
+}
+
+// The whole point of the split: no single wait may take the budget the others
+// still need.
+func TestBudgetLeavesRoomForTheRemainingWaits(t *testing.T) {
+	const remaining = 20 * time.Minute
+
+	first := budgetWithin(remaining, 3)
+
+	require.Less(t, first, remaining-esReadyMargin)
+	require.LessOrEqual(t, 3*first, remaining-esReadyMargin)
 }
 
 func TestElasticsearch_MultiVersion(t *testing.T) {
@@ -485,15 +499,16 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 		}
 		common.RequireNoError(t, c.GetClient().Create(ctx, es9Deployment))
 
-		for _, name := range []string{"elasticsearch7", "elasticsearch8", "elasticsearch9"} {
+		deployments := []string{"elasticsearch7", "elasticsearch8", "elasticsearch9"}
+		for i, name := range deployments {
 			t.Logf("Waiting for %s deployment to be ready...", name)
-			require.Eventually(t, func() bool {
+			require.Eventuallyf(t, func() bool {
 				if wait.DeploymentAvailable(t, c.GetClient(), ctx, ns, name)() {
 					return true
 				}
 				logContainerRestarts(t, c, ctx, ns, name)
 				return false
-			}, esReadyBudget(t), 10*time.Second)
+			}, esReadyBudget(t, len(deployments)-i), 10*time.Second, "%s never became ready", name)
 		}
 
 		logging := v1beta1.Logging{

--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -106,10 +106,12 @@ func esReadyBudget(t *testing.T, waitsLeft int) time.Duration {
 	return budgetWithin(time.Until(deadline), waitsLeft)
 }
 
-// budgetWithin never returns a non-positive duration: require.Eventually treats
-// one as already expired, which would fail every run instead of only stalled ones.
+// budgetWithin floors after dividing, not before. A third of a second is
+// positive but expires on the first tick, so flooring on the undivided
+// remainder would put the misattribution this split removes back at the
+// boundary: elasticsearch7 blamed for a package that had already run out.
 func budgetWithin(remaining time.Duration, waitsLeft int) time.Duration {
-	if budget := (remaining - esReadyMargin) / time.Duration(waitsLeft); budget > 0 {
+	if budget := (remaining - esReadyMargin) / time.Duration(waitsLeft); budget > time.Second {
 		return budget
 	}
 	return time.Second
@@ -124,6 +126,9 @@ func TestBudgetWithin(t *testing.T) {
 	}{
 		{"shared between the waits still to come", 20 * time.Minute, 3, (20*time.Minute - esReadyMargin) / 3},
 		{"the last wait gets what is left", 20 * time.Minute, 1, 20*time.Minute - esReadyMargin},
+		// The floor is a second per wait, not a second shared between them.
+		{"just above the margin", esReadyMargin + time.Second, 3, time.Second},
+		{"a slice under a second", esReadyMargin + 2*time.Second, 3, time.Second},
 		{"exactly the margin", esReadyMargin, 3, time.Second},
 		{"already past the deadline", -time.Minute, 3, time.Second},
 	} {


### PR DESCRIPTION
Closes the attribution half of #2305.

`esReadyBudget` returned `time.Until(deadline) - 30s` and the loop called it fresh for each of the three deployments, so the first was allowed to spend everything. Once it had, `budgetWithin` floored the next two at a second and they failed almost at once — under the wrong deployment's name. It divides by the waits still to come now, and the assertion says which deployment never came up.

The margin goes from 30s to 90s. Its own comment said 30s did not cover teardown, which is a stern dump, a `kubectl exec` plus `tar` for coverage, and a `kind delete`. 90s is also what `internal/harness` reserves, which is one less number to reconcile when the three budget derivations in this module get collapsed.

The fallback is not divided: with no deadline there is no shared budget to split, and it is already per-wait.

### Verification

`make check` passes and `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` in `e2e/` reports 0 issues.

`TestBudgetWithin` gains the count of remaining waits, and `TestBudgetLeavesRoomForTheRemainingWaits` pins what the split is for: three times the first budget still fits inside what was left. Negative control: restoring `remaining - esReadyMargin` fails it.

The floor is applied after the division, not before. Dividing first made the effective minimum `1s / waitsLeft` — `budgetWithin(esReadyMargin+1s, 3)` returned 333ms, positive enough to skip the floor, and a budget that small expires on the first tick and names `elasticsearch7` again. That is a second per wait rather than a second shared between them, so above the floor the invariant above holds and at the floor it does not; a package that close to its deadline is finished either way.

On a real cluster the three-deployment ladder works — `elasticsearch7`, `8` and `9` each became ready, so nothing starved. The suite then fails later on the ES7 document count, and so does master's on the same machine: 497s against 507s, both polling `0` eighteen times, both at the same assertion. That is a log-delivery problem local to this machine rather than anything in this change, and CI has the suite green.

