### PR TITLE
Make enabledIPv6 work without breaking single-stack clusters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,8 @@ v1alpha1 is the legacy API; conversion functions exist to v1beta1 (which is the 
 
 **Immutable fields**: `controlNamespace`, `FluentbitAgentNamespace`, and `AllowClusterResourcesFromAllNamespaces` are CRD-enforced immutable on `Logging` resources (via `XValidation`). Changing them requires deleting and recreating the resource.
 
+**Server-allocated Service fields**: `clusterIP`, `clusterIPs` and `ipFamilies` are assigned by the API server, so reconcilers pin them to the live object in a `beforeUpdateHook` (`v1beta1.PreserveAllocatedIPFamilies`) instead of asserting a desired value. Changing an existing Service's primary IP family is rejected as *invalid* rather than *immutable*, so `MatchImmutableErrorMessages` does not match it and the recreate fallback never fires — the reconcile fails permanently. Naming an IP family the cluster has no range for is rejected the same way, on create.
+
 ## Testing
 
 - Unit/integration tests use `envtest` (embedded Kubernetes API server + etcd); no cluster needed

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_fluentbitagents.yaml
@@ -794,6 +794,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -1740,6 +1742,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -782,6 +782,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -1887,6 +1889,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -782,6 +782,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -3420,6 +3422,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
@@ -1663,6 +1663,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -2609,6 +2611,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -4416,6 +4420,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -7054,6 +7060,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -9581,6 +9589,8 @@ spec:
                 properties:
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -13788,6 +13798,8 @@ spec:
                     type: integer
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_loggings.yaml
@@ -1663,6 +1663,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -2609,6 +2611,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -4416,6 +4420,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -5521,6 +5527,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -8048,6 +8056,8 @@ spec:
                 properties:
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -12255,6 +12265,8 @@ spec:
                     type: integer
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:

--- a/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngconfigs.yaml
+++ b/charts/logging-operator/charts/logging-operator-crds/templates/logging.banzaicloud.io_syslogngconfigs.yaml
@@ -33,6 +33,8 @@ spec:
             properties:
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -4240,6 +4242,8 @@ spec:
                 type: integer
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_fluentbitagents.yaml
@@ -791,6 +791,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -1737,6 +1739,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -779,6 +779,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -1884,6 +1886,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -779,6 +779,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -3417,6 +3419,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1660,6 +1660,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -2606,6 +2608,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -4413,6 +4417,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -7051,6 +7057,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -9578,6 +9586,8 @@ spec:
                 properties:
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -13785,6 +13795,8 @@ spec:
                     type: integer
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_loggings.yaml
@@ -1660,6 +1660,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -2606,6 +2608,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -4413,6 +4417,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -5518,6 +5524,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -8045,6 +8053,8 @@ spec:
                 properties:
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -12252,6 +12262,8 @@ spec:
                     type: integer
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:

--- a/charts/logging-operator/crds/logging.banzaicloud.io_syslogngconfigs.yaml
+++ b/charts/logging-operator/crds/logging.banzaicloud.io_syslogngconfigs.yaml
@@ -30,6 +30,8 @@ spec:
             properties:
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -4237,6 +4239,8 @@ spec:
                 type: integer
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_fluentbitagents.yaml
@@ -791,6 +791,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -1737,6 +1739,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/config/crd/bases/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -779,6 +779,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -1884,6 +1886,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/config/crd/bases/logging.banzaicloud.io_fluentdconfigs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_fluentdconfigs.yaml
@@ -779,6 +779,8 @@ spec:
                 type: object
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -3417,6 +3419,8 @@ spec:
                 type: string
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -1660,6 +1660,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -2606,6 +2608,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -4413,6 +4417,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -7051,6 +7057,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -9578,6 +9586,8 @@ spec:
                 properties:
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -13785,6 +13795,8 @@ spec:
                     type: integer
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:

--- a/config/crd/bases/logging.banzaicloud.io_loggings.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_loggings.yaml
@@ -1660,6 +1660,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -2606,6 +2608,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -4413,6 +4417,8 @@ spec:
                     type: object
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -5518,6 +5524,8 @@ spec:
                     type: string
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -8045,6 +8053,8 @@ spec:
                 properties:
                   bufferVolumeMetrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:
@@ -12252,6 +12262,8 @@ spec:
                     type: integer
                   metrics:
                     properties:
+                      bind:
+                        type: string
                       enabled:
                         type: boolean
                       interval:

--- a/config/crd/bases/logging.banzaicloud.io_syslogngconfigs.yaml
+++ b/config/crd/bases/logging.banzaicloud.io_syslogngconfigs.yaml
@@ -30,6 +30,8 @@ spec:
             properties:
               bufferVolumeMetrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:
@@ -4237,6 +4239,8 @@ spec:
                 type: integer
               metrics:
                 properties:
+                  bind:
+                    type: string
                   enabled:
                     type: boolean
                   interval:

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/resources"
 	"github.com/kube-logging/logging-operator/pkg/resources/fluentbit"
 	"github.com/kube-logging/logging-operator/pkg/resources/fluentd"
+	"github.com/kube-logging/logging-operator/pkg/resources/ipfamily"
 	"github.com/kube-logging/logging-operator/pkg/resources/loggingdataprovider"
 	"github.com/kube-logging/logging-operator/pkg/resources/model"
 	"github.com/kube-logging/logging-operator/pkg/resources/syslogng"
@@ -74,6 +75,7 @@ func NewLoggingReconciler(client client.Client, eventRecorder events.EventRecord
 		Client:        client,
 		EventRecorder: eventRecorder,
 		Log:           log,
+		ipFamilies:    ipfamily.NewDetector(client, log.WithName("ipfamily")),
 	}
 }
 
@@ -82,6 +84,15 @@ type LoggingReconciler struct {
 	client.Client
 	EventRecorder events.EventRecorder
 	Log           logr.Logger
+	ipFamilies    *ipfamily.Detector
+}
+
+// clusterSupportsIPv6 probes lazily, so a cluster that never enables IPv6 never pays for it.
+func (r *LoggingReconciler) clusterSupportsIPv6(ctx context.Context, logging *loggingv1beta1.Logging, enabledIPv6 bool) bool {
+	if !enabledIPv6 {
+		return false
+	}
+	return r.ipFamilies.SupportsIPv6(ctx, logging.Spec.ControlNamespace)
 }
 
 // +kubebuilder:rbac:groups=logging.banzaicloud.io,resources=loggings;fluentbitagents;flows;clusterflows;outputs;clusteroutputs;fluentdconfigs;syslogngconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -227,7 +238,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				log.Info("flow configuration", "config", fluentdConfig)
 			}
 
-			reconcilers = append(reconcilers, fluentd.New(r.Client, r.Log, &logging, fluentdSpec, fluentdExternal, &fluentdConfig, secretList, reconcilerOpts).Reconcile)
+			reconcilers = append(reconcilers, fluentd.New(r.Client, r.Log, &logging, fluentdSpec, fluentdExternal, &fluentdConfig, secretList, reconcilerOpts, r.clusterSupportsIPv6(ctx, &logging, fluentdSpec.EnabledIPv6)).Reconcile)
 		}
 		loggingDataProvider = fluentd.NewDataProvider(r.Client, &logging, fluentdSpec, fluentdExternal)
 	}
@@ -246,7 +257,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				log.Info("flow configuration", "config", syslogNGConfig)
 			}
 
-			reconcilers = append(reconcilers, syslogng.New(r.Client, r.Log, &logging, syslogNGSpec, syslogNGExternal, syslogNGConfig, secretList, reconcilerOpts).Reconcile)
+			reconcilers = append(reconcilers, syslogng.New(r.Client, r.Log, &logging, syslogNGSpec, syslogNGExternal, syslogNGConfig, secretList, reconcilerOpts, r.clusterSupportsIPv6(ctx, &logging, syslogNGSpec.EnabledIPv6)).Reconcile)
 		}
 		loggingDataProvider = syslogng.NewDataProvider(r.Client, &logging, syslogNGExternal)
 	}
@@ -268,6 +279,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				loggingDataProvider,
 				nameProvider,
 				loggingResourceRepo,
+				r.clusterSupportsIPv6(ctx, &logging, logging.Spec.FluentbitSpec.EnabledIPv6),
 			).Reconcile)
 		}
 	default:
@@ -285,6 +297,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				loggingDataProvider,
 				fluentbit.NewStandaloneFluentbitNameProvider(&f),
 				loggingResourceRepo,
+				r.clusterSupportsIPv6(ctx, &logging, f.Spec.EnabledIPv6),
 			).Reconcile)
 		}
 	}

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -246,7 +246,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	syslogNGExternal, syslogNGSpec := loggingResources.GetSyslogNGSpec()
 	if syslogNGSpec != nil {
 		logging.AggregatorLevelConfigCheck(syslogNGSPec.ConfigCheck)
-		syslogNGConfig, secretList, err := r.clusterConfigurationSyslogNG(loggingResources)
+		syslogNGConfig, secretList, err := r.clusterConfigurationSyslogNG(ctx, loggingResources)
 		if err != nil {
 			// TODO: move config generation into Syslog-NG reconciler
 			reconcilers = append(reconcilers, func(ctx context.Context) (*reconcile.Result, error) {
@@ -461,7 +461,7 @@ func (r *LoggingReconciler) clusterConfigurationFluentd(resources model.LoggingR
 	return output.String(), &slf.Secrets, nil
 }
 
-func (r *LoggingReconciler) clusterConfigurationSyslogNG(resources model.LoggingResources) (string, *secret.MountSecrets, error) {
+func (r *LoggingReconciler) clusterConfigurationSyslogNG(ctx context.Context, resources model.LoggingResources) (string, *secret.MountSecrets, error) {
 	if cfg := resources.Logging.Spec.FlowConfigOverride; cfg != "" {
 		return cfg, nil, nil
 	}
@@ -482,6 +482,7 @@ func (r *LoggingReconciler) clusterConfigurationSyslogNG(resources model.Logging
 		Flows:                resources.SyslogNG.Flows,
 		SecretLoaderFactory:  &slf,
 		SourcePort:           syslogng.ServicePort,
+		ClusterHasIPv6:       len(r.clusterIPFamilies(ctx, &resources.Logging, syslogngSpec.EnabledIPv6)) > 0,
 		SyslogNGSpec:         syslogngSpec,
 		SkipInvalidResources: resources.Logging.Spec.SkipInvalidResources,
 		Logger:               r.Log,

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -88,9 +88,9 @@ type LoggingReconciler struct {
 }
 
 // clusterIPFamilies probes lazily, so a cluster that never enables IPv6 never pays for it.
-func (r *LoggingReconciler) clusterIPFamilies(ctx context.Context, logging *loggingv1beta1.Logging, enabledIPv6 bool) []corev1.IPFamily {
+func (r *LoggingReconciler) clusterIPFamilies(ctx context.Context, logging *loggingv1beta1.Logging, enabledIPv6 bool) ([]corev1.IPFamily, error) {
 	if !enabledIPv6 {
-		return nil
+		return nil, nil
 	}
 	return r.ipFamilies.Families(ctx, logging.Spec.ControlNamespace)
 }
@@ -238,7 +238,11 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				log.Info("flow configuration", "config", fluentdConfig)
 			}
 
-			reconcilers = append(reconcilers, fluentd.New(r.Client, r.Log, &logging, fluentdSpec, fluentdExternal, &fluentdConfig, secretList, reconcilerOpts, r.clusterIPFamilies(ctx, &logging, fluentdSpec.EnabledIPv6)).Reconcile)
+			families, err := r.clusterIPFamilies(ctx, &logging, fluentdSpec.EnabledIPv6)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			reconcilers = append(reconcilers, fluentd.New(r.Client, r.Log, &logging, fluentdSpec, fluentdExternal, &fluentdConfig, secretList, reconcilerOpts, families).Reconcile)
 		}
 		loggingDataProvider = fluentd.NewDataProvider(r.Client, &logging, fluentdSpec, fluentdExternal)
 	}
@@ -257,7 +261,11 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				log.Info("flow configuration", "config", syslogNGConfig)
 			}
 
-			reconcilers = append(reconcilers, syslogng.New(r.Client, r.Log, &logging, syslogNGSpec, syslogNGExternal, syslogNGConfig, secretList, reconcilerOpts, r.clusterIPFamilies(ctx, &logging, syslogNGSpec.EnabledIPv6)).Reconcile)
+			families, err := r.clusterIPFamilies(ctx, &logging, syslogNGSpec.EnabledIPv6)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			reconcilers = append(reconcilers, syslogng.New(r.Client, r.Log, &logging, syslogNGSpec, syslogNGExternal, syslogNGConfig, secretList, reconcilerOpts, families).Reconcile)
 		}
 		loggingDataProvider = syslogng.NewDataProvider(r.Client, &logging, syslogNGExternal)
 	}
@@ -269,6 +277,10 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			fluentbitWarning.Do(func() {
 				log.Info("WARNING fluentbit definition inside the Logging resource is deprecated and will be removed in the next major release")
 			})
+			legacyFamilies, err := r.clusterIPFamilies(ctx, &logging, logging.Spec.FluentbitSpec.EnabledIPv6)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 			nameProvider := fluentbit.NewLegacyFluentbitNameProvider(&logging)
 			reconcilers = append(reconcilers, fluentbit.New(
 				r.Client,
@@ -279,7 +291,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				loggingDataProvider,
 				nameProvider,
 				loggingResourceRepo,
-				r.clusterIPFamilies(ctx, &logging, logging.Spec.FluentbitSpec.EnabledIPv6),
+				legacyFamilies,
 			).Reconcile)
 		}
 	default:
@@ -288,6 +300,10 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		l := log.WithName("fluentbit")
 		for _, f := range loggingResources.Fluentbits {
+			agentFamilies, err := r.clusterIPFamilies(ctx, &logging, f.Spec.EnabledIPv6)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 			reconcilers = append(reconcilers, fluentbit.New(
 				r.Client,
 				l.WithValues("fluentbitagent", f.Name),
@@ -297,7 +313,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				loggingDataProvider,
 				fluentbit.NewStandaloneFluentbitNameProvider(&f),
 				loggingResourceRepo,
-				r.clusterIPFamilies(ctx, &logging, f.Spec.EnabledIPv6),
+				agentFamilies,
 			).Reconcile)
 		}
 	}
@@ -473,6 +489,10 @@ func (r *LoggingReconciler) clusterConfigurationSyslogNG(ctx context.Context, re
 	}
 
 	_, syslogngSpec := resources.GetSyslogNGSpec()
+	syslogNGFamilies, err := r.clusterIPFamilies(ctx, &resources.Logging, syslogngSpec.EnabledIPv6)
+	if err != nil {
+		return "", nil, err
+	}
 	in := syslogngconfig.Input{
 		Name:                 resources.Logging.Name,
 		Namespace:            resources.Logging.Namespace,
@@ -482,7 +502,7 @@ func (r *LoggingReconciler) clusterConfigurationSyslogNG(ctx context.Context, re
 		Flows:                resources.SyslogNG.Flows,
 		SecretLoaderFactory:  &slf,
 		SourcePort:           syslogng.ServicePort,
-		ClusterHasIPv6:       len(r.clusterIPFamilies(ctx, &resources.Logging, syslogngSpec.EnabledIPv6)) > 0,
+		ClusterHasIPv6:       len(syslogNGFamilies) > 0,
 		SyslogNGSpec:         syslogngSpec,
 		SkipInvalidResources: resources.Logging.Spec.SkipInvalidResources,
 		Logger:               r.Log,

--- a/controllers/logging/logging_controller.go
+++ b/controllers/logging/logging_controller.go
@@ -87,12 +87,12 @@ type LoggingReconciler struct {
 	ipFamilies    *ipfamily.Detector
 }
 
-// clusterSupportsIPv6 probes lazily, so a cluster that never enables IPv6 never pays for it.
-func (r *LoggingReconciler) clusterSupportsIPv6(ctx context.Context, logging *loggingv1beta1.Logging, enabledIPv6 bool) bool {
+// clusterIPFamilies probes lazily, so a cluster that never enables IPv6 never pays for it.
+func (r *LoggingReconciler) clusterIPFamilies(ctx context.Context, logging *loggingv1beta1.Logging, enabledIPv6 bool) []corev1.IPFamily {
 	if !enabledIPv6 {
-		return false
+		return nil
 	}
-	return r.ipFamilies.SupportsIPv6(ctx, logging.Spec.ControlNamespace)
+	return r.ipFamilies.Families(ctx, logging.Spec.ControlNamespace)
 }
 
 // +kubebuilder:rbac:groups=logging.banzaicloud.io,resources=loggings;fluentbitagents;flows;clusterflows;outputs;clusteroutputs;fluentdconfigs;syslogngconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -238,7 +238,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				log.Info("flow configuration", "config", fluentdConfig)
 			}
 
-			reconcilers = append(reconcilers, fluentd.New(r.Client, r.Log, &logging, fluentdSpec, fluentdExternal, &fluentdConfig, secretList, reconcilerOpts, r.clusterSupportsIPv6(ctx, &logging, fluentdSpec.EnabledIPv6)).Reconcile)
+			reconcilers = append(reconcilers, fluentd.New(r.Client, r.Log, &logging, fluentdSpec, fluentdExternal, &fluentdConfig, secretList, reconcilerOpts, r.clusterIPFamilies(ctx, &logging, fluentdSpec.EnabledIPv6)).Reconcile)
 		}
 		loggingDataProvider = fluentd.NewDataProvider(r.Client, &logging, fluentdSpec, fluentdExternal)
 	}
@@ -257,7 +257,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				log.Info("flow configuration", "config", syslogNGConfig)
 			}
 
-			reconcilers = append(reconcilers, syslogng.New(r.Client, r.Log, &logging, syslogNGSpec, syslogNGExternal, syslogNGConfig, secretList, reconcilerOpts, r.clusterSupportsIPv6(ctx, &logging, syslogNGSpec.EnabledIPv6)).Reconcile)
+			reconcilers = append(reconcilers, syslogng.New(r.Client, r.Log, &logging, syslogNGSpec, syslogNGExternal, syslogNGConfig, secretList, reconcilerOpts, r.clusterIPFamilies(ctx, &logging, syslogNGSpec.EnabledIPv6)).Reconcile)
 		}
 		loggingDataProvider = syslogng.NewDataProvider(r.Client, &logging, syslogNGExternal)
 	}
@@ -279,7 +279,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				loggingDataProvider,
 				nameProvider,
 				loggingResourceRepo,
-				r.clusterSupportsIPv6(ctx, &logging, logging.Spec.FluentbitSpec.EnabledIPv6),
+				r.clusterIPFamilies(ctx, &logging, logging.Spec.FluentbitSpec.EnabledIPv6),
 			).Reconcile)
 		}
 	default:
@@ -297,7 +297,7 @@ func (r *LoggingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				loggingDataProvider,
 				fluentbit.NewStandaloneFluentbitNameProvider(&f),
 				loggingResourceRepo,
-				r.clusterSupportsIPv6(ctx, &logging, f.Spec.EnabledIPv6),
+				r.clusterIPFamilies(ctx, &logging, f.Spec.EnabledIPv6),
 			).Reconcile)
 		}
 	}

--- a/docs/configuration/crds/v1beta1/common_types.md
+++ b/docs/configuration/crds/v1beta1/common_types.md
@@ -38,7 +38,7 @@ Metrics defines the service monitor endpoints
 
 ### bind (string, optional) {#metrics-bind}
 
-Bind is the address the metrics endpoint listens on. Defaults to 0.0.0.0, or to [::] when enabledIPv6 is set. 
+Bind is the address the metrics endpoint listens on. Defaults to 0.0.0.0, or to [::] when enabledIPv6 is set. The syslog-ng metrics exporter has no listen address option, so it ignores this field. 
 
 
 ### enabled (*bool, optional) {#metrics-enabled}

--- a/docs/configuration/crds/v1beta1/common_types.md
+++ b/docs/configuration/crds/v1beta1/common_types.md
@@ -36,6 +36,11 @@ ImageSpec struct hold information about image specification
 
 Metrics defines the service monitor endpoints
 
+### bind (string, optional) {#metrics-bind}
+
+Bind is the address the metrics endpoint listens on. Defaults to 0.0.0.0, or to [::] when enabledIPv6 is set. 
+
+
 ### enabled (*bool, optional) {#metrics-enabled}
 
 Enabled controls whether the metrics endpoint should be exposed. Defaults to false. When false, the metrics HTTP server will not be started and no metrics port will be exposed. 

--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -46,7 +46,7 @@ var fluentBitConfigTemplate = `
     {{- if .Monitor.EnabledIPv6 }}
     HTTP_Listen  [::]
     {{- else }}
-    Listen 0.0.0.0
+    HTTP_Listen  0.0.0.0
     {{- end }}
     HTTP_Port    {{ .Monitor.Port }}
     {{- end }}

--- a/pkg/resources/fluentbit/config.go
+++ b/pkg/resources/fluentbit/config.go
@@ -43,11 +43,7 @@ var fluentBitConfigTemplate = `
     Coro_Stack_Size    {{ .CoroStackSize }}
     {{- if .Monitor.Enabled }}
     HTTP_Server  On
-    {{- if .Monitor.EnabledIPv6 }}
-    HTTP_Listen  [::]
-    {{- else }}
-    HTTP_Listen  0.0.0.0
-    {{- end }}
+    HTTP_Listen  {{ .Monitor.Bind }}
     HTTP_Port    {{ .Monitor.Port }}
     {{- end }}
     {{- range $key, $value := .BufferStorage }}

--- a/pkg/resources/fluentbit/configsecret.go
+++ b/pkg/resources/fluentbit/configsecret.go
@@ -63,6 +63,7 @@ type fluentBitConfig struct {
 		Enabled     bool
 		Port        int32
 		EnabledIPv6 bool
+		Bind        string
 		Path        string
 	}
 	Flush                    int32
@@ -245,6 +246,7 @@ func (r *Reconciler) configSecret() (runtime.Object, reconciler.DesiredState, er
 		input.Monitor.Enabled = true
 		input.Monitor.Port = r.fluentbitSpec.Metrics.Port
 		input.Monitor.EnabledIPv6 = r.fluentbitSpec.EnabledIPv6
+		input.Monitor.Bind = r.fluentbitSpec.Metrics.BindAddress(r.fluentbitSpec.EnabledIPv6)
 		input.Monitor.Path = r.fluentbitSpec.Metrics.Path
 	}
 

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -314,7 +314,8 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 		if r.fluentbitSpec.BufferVolumeMetrics.Port != 0 {
 			port = r.fluentbitSpec.BufferVolumeMetrics.Port
 		}
-		portParam := fmt.Sprintf("--web.listen-address=:%d", port)
+		// An unset bind keeps the wildcard address, which listens on both families.
+		portParam := fmt.Sprintf("--web.listen-address=%s:%d", r.fluentbitSpec.BufferVolumeMetrics.Bind, port)
 		args := []string{portParam}
 		if len(r.fluentbitSpec.BufferVolumeArgs) != 0 {
 			args = append(args, r.fluentbitSpec.BufferVolumeArgs...)

--- a/pkg/resources/fluentbit/fluentbit.go
+++ b/pkg/resources/fluentbit/fluentbit.go
@@ -95,6 +95,7 @@ type Reconciler struct {
 	loggingDataProvider  loggingdataprovider.LoggingDataProvider
 	nameProvider         NameProvider
 	loggingResourcesRepo *model.LoggingResourceRepository
+	clusterHasIPv6       bool
 }
 
 // NewReconciler creates a new FluentbitAgent reconciler
@@ -106,6 +107,7 @@ func New(client client.Client,
 	loggingDataProvider loggingdataprovider.LoggingDataProvider,
 	nameProvider NameProvider,
 	loggingResourcesRepo *model.LoggingResourceRepository,
+	clusterHasIPv6 bool,
 ) *Reconciler {
 	return &Reconciler{
 		Logging:              logging,
@@ -115,6 +117,7 @@ func New(client client.Client,
 		loggingDataProvider:  loggingDataProvider,
 		nameProvider:         nameProvider,
 		loggingResourcesRepo: loggingResourcesRepo,
+		clusterHasIPv6:       clusterHasIPv6,
 	}
 }
 

--- a/pkg/resources/fluentbit/fluentbit.go
+++ b/pkg/resources/fluentbit/fluentbit.go
@@ -95,7 +95,7 @@ type Reconciler struct {
 	loggingDataProvider  loggingdataprovider.LoggingDataProvider
 	nameProvider         NameProvider
 	loggingResourcesRepo *model.LoggingResourceRepository
-	clusterHasIPv6       bool
+	clusterFamilies      []corev1.IPFamily
 }
 
 // NewReconciler creates a new FluentbitAgent reconciler
@@ -107,7 +107,7 @@ func New(client client.Client,
 	loggingDataProvider loggingdataprovider.LoggingDataProvider,
 	nameProvider NameProvider,
 	loggingResourcesRepo *model.LoggingResourceRepository,
-	clusterHasIPv6 bool,
+	clusterFamilies []corev1.IPFamily,
 ) *Reconciler {
 	return &Reconciler{
 		Logging:              logging,
@@ -117,7 +117,7 @@ func New(client client.Client,
 		loggingDataProvider:  loggingDataProvider,
 		nameProvider:         nameProvider,
 		loggingResourcesRepo: loggingResourcesRepo,
-		clusterHasIPv6:       clusterHasIPv6,
+		clusterFamilies:      clusterFamilies,
 	}
 }
 

--- a/pkg/resources/fluentbit/service.go
+++ b/pkg/resources/fluentbit/service.go
@@ -61,7 +61,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 		}
 
 		if r.fluentbitSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -168,7 +168,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 		}
 
 		if r.fluentbitSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 		}
 
 		return desired, reconciler.StatePresent, nil

--- a/pkg/resources/fluentbit/service.go
+++ b/pkg/resources/fluentbit/service.go
@@ -61,7 +61,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 		}
 
 		if r.fluentbitSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -168,7 +168,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 		}
 
 		if r.fluentbitSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 		}
 
 		return desired, reconciler.StatePresent, nil

--- a/pkg/resources/fluentbit/service_test.go
+++ b/pkg/resources/fluentbit/service_test.go
@@ -28,17 +28,17 @@ import (
 func TestMetricsServicesIPFamilies(t *testing.T) {
 	metricsEnabled := true
 	tests := []struct {
-		name           string
-		enabledIPv6    bool
-		clusterHasIPv6 bool
-		expected       []corev1.IPFamily
+		name            string
+		enabledIPv6     bool
+		clusterFamilies []corev1.IPFamily
+		expected        []corev1.IPFamily
 	}{
 		{name: "ipv6 not requested"},
 		{
-			name:           "requested on a cluster that has IPv6",
-			enabledIPv6:    true,
-			clusterHasIPv6: true,
-			expected:       []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+			name:            "requested on a cluster that has IPv6",
+			enabledIPv6:     true,
+			clusterFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+			expected:        []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
 		},
 		{
 			// Naming IPv6 here would be rejected at create, and a create rejection has no recovery path.
@@ -63,8 +63,8 @@ func TestMetricsServicesIPFamilies(t *testing.T) {
 						Port:    9200,
 					},
 				},
-				nameProvider:   NewLegacyFluentbitNameProvider(logging),
-				clusterHasIPv6: test.clusterHasIPv6,
+				nameProvider:    NewLegacyFluentbitNameProvider(logging),
+				clusterFamilies: test.clusterFamilies,
 			}
 
 			metricsService, _, err := r.serviceMetrics()

--- a/pkg/resources/fluentbit/service_test.go
+++ b/pkg/resources/fluentbit/service_test.go
@@ -28,11 +28,23 @@ import (
 func TestMetricsServicesIPFamilies(t *testing.T) {
 	metricsEnabled := true
 	tests := []struct {
-		name        string
-		enabledIPv6 bool
+		name           string
+		enabledIPv6    bool
+		clusterHasIPv6 bool
+		expected       []corev1.IPFamily
 	}{
-		{name: "single-stack"},
-		{name: "dual-stack", enabledIPv6: true},
+		{name: "ipv6 not requested"},
+		{
+			name:           "requested on a cluster that has IPv6",
+			enabledIPv6:    true,
+			clusterHasIPv6: true,
+			expected:       []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		},
+		{
+			// Naming IPv6 here would be rejected at create, and a create rejection has no recovery path.
+			name:        "requested on a cluster without an IPv6 range",
+			enabledIPv6: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -51,7 +63,8 @@ func TestMetricsServicesIPFamilies(t *testing.T) {
 						Port:    9200,
 					},
 				},
-				nameProvider: NewLegacyFluentbitNameProvider(logging),
+				nameProvider:   NewLegacyFluentbitNameProvider(logging),
+				clusterHasIPv6: test.clusterHasIPv6,
 			}
 
 			metricsService, _, err := r.serviceMetrics()
@@ -59,13 +72,13 @@ func TestMetricsServicesIPFamilies(t *testing.T) {
 			bufferMetricsService, _, err := r.serviceBufferMetrics()
 			require.NoError(t, err)
 
-			assertIPFamilies(t, metricsService, test.enabledIPv6)
-			assertIPFamilies(t, bufferMetricsService, test.enabledIPv6)
+			assertIPFamilies(t, metricsService, test.enabledIPv6, test.expected)
+			assertIPFamilies(t, bufferMetricsService, test.enabledIPv6, test.expected)
 		})
 	}
 }
 
-func assertIPFamilies(t *testing.T, object runtime.Object, enabledIPv6 bool) {
+func assertIPFamilies(t *testing.T, object runtime.Object, enabledIPv6 bool, expected []corev1.IPFamily) {
 	t.Helper()
 
 	service, ok := object.(*corev1.Service)
@@ -79,5 +92,5 @@ func assertIPFamilies(t *testing.T, object runtime.Object, enabledIPv6 bool) {
 
 	require.NotNil(t, service.Spec.IPFamilyPolicy)
 	require.Equal(t, corev1.IPFamilyPolicyPreferDualStack, *service.Spec.IPFamilyPolicy)
-	require.Equal(t, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, service.Spec.IPFamilies)
+	require.Equal(t, expected, service.Spec.IPFamilies)
 }

--- a/pkg/resources/fluentd/appconfigmap_test.go
+++ b/pkg/resources/fluentd/appconfigmap_test.go
@@ -47,7 +47,7 @@ func newCheckPodReconciler(t *testing.T, fluentdSpec *v1beta1.FluentdSpec, c cli
 
 	config := "<system>\n</system>\n"
 
-	return New(c, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{})
+	return New(c, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{}, false)
 }
 
 // newFakeClient returns a client backed by an empty in-memory store for the

--- a/pkg/resources/fluentd/appconfigmap_test.go
+++ b/pkg/resources/fluentd/appconfigmap_test.go
@@ -47,7 +47,7 @@ func newCheckPodReconciler(t *testing.T, fluentdSpec *v1beta1.FluentdSpec, c cli
 
 	config := "<system>\n</system>\n"
 
-	return New(c, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{}, false)
+	return New(c, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{}, nil)
 }
 
 // newFakeClient returns a client backed by an empty in-memory store for the

--- a/pkg/resources/fluentd/appconfigmap_test.go
+++ b/pkg/resources/fluentd/appconfigmap_test.go
@@ -40,7 +40,7 @@ func newCheckPodReconciler(t *testing.T, fluentdSpec *v1beta1.FluentdSpec) *Reco
 
 	config := "<system>\n</system>\n"
 
-	return New(nil, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{})
+	return New(nil, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{}, false)
 }
 
 func TestNewCheckPodDNSSettings(t *testing.T) {

--- a/pkg/resources/fluentd/appconfigmap_test.go
+++ b/pkg/resources/fluentd/appconfigmap_test.go
@@ -40,7 +40,7 @@ func newCheckPodReconciler(t *testing.T, fluentdSpec *v1beta1.FluentdSpec) *Reco
 
 	config := "<system>\n</system>\n"
 
-	return New(nil, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{}, false)
+	return New(nil, log.Log, logging, logging.Spec.FluentdSpec, nil, &config, nil, reconciler.ReconcilerOpts{}, nil)
 }
 
 func TestNewCheckPodDNSSettings(t *testing.T) {

--- a/pkg/resources/fluentd/config.go
+++ b/pkg/resources/fluentd/config.go
@@ -61,10 +61,8 @@ var fluentdInputTemplate = `
     @type prometheus
     {{- if .Monitor.EnabledIPv6 }}
     @id in_prometheus6
-    bind "[::]"
-    {{- else }}
-    bind "0.0.0.0"
     {{- end }}
+    bind "{{ .Monitor.Bind }}"
     port {{ .Monitor.Port }}
     {{- if .Monitor.Path }}
     metrics_path {{ .Monitor.Path }}

--- a/pkg/resources/fluentd/configsecret.go
+++ b/pkg/resources/fluentd/configsecret.go
@@ -35,6 +35,7 @@ type fluentdConfig struct {
 		Enabled     bool
 		Port        int32
 		EnabledIPv6 bool
+		Bind        string
 		Path        string
 	}
 	IgnoreSameLogInterval     string
@@ -76,6 +77,7 @@ func (r *Reconciler) generateConfigSecret(fluentdSpec v1beta1.FluentdSpec) (map[
 		input.Monitor.Enabled = true
 		input.Monitor.Port = fluentdSpec.Metrics.Port
 		input.Monitor.EnabledIPv6 = fluentdSpec.EnabledIPv6
+		input.Monitor.Bind = fluentdSpec.Metrics.BindAddress(fluentdSpec.EnabledIPv6)
 		input.Monitor.Path = fluentdSpec.Metrics.Path
 	}
 

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -72,9 +72,9 @@ type Reconciler struct {
 	fluentdSpec   *v1beta1.FluentdSpec
 	fluentdConfig *v1beta1.FluentdConfig
 	*reconciler.GenericResourceReconciler
-	config         *string
-	secrets        *secret.MountSecrets
-	clusterHasIPv6 bool
+	config          *string
+	secrets         *secret.MountSecrets
+	clusterFamilies []corev1.IPFamily
 }
 
 type Desire struct {
@@ -114,7 +114,7 @@ func (r *Reconciler) getServiceAccount() string {
 }
 
 func New(client client.Client, log logr.Logger,
-	logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, fluentdConfig *v1beta1.FluentdConfig, config *string, secrets *secret.MountSecrets, opts reconciler.ReconcilerOpts, clusterHasIPv6 bool,
+	logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, fluentdConfig *v1beta1.FluentdConfig, config *string, secrets *secret.MountSecrets, opts reconciler.ReconcilerOpts, clusterFamilies []corev1.IPFamily,
 ) *Reconciler {
 	return &Reconciler{
 		Logging:                   logging,
@@ -123,7 +123,7 @@ func New(client client.Client, log logr.Logger,
 		GenericResourceReconciler: reconciler.NewGenericReconciler(client, log, opts),
 		config:                    config,
 		secrets:                   secrets,
-		clusterHasIPv6:            clusterHasIPv6,
+		clusterFamilies:           clusterFamilies,
 	}
 }
 

--- a/pkg/resources/fluentd/fluentd.go
+++ b/pkg/resources/fluentd/fluentd.go
@@ -72,8 +72,9 @@ type Reconciler struct {
 	fluentdSpec   *v1beta1.FluentdSpec
 	fluentdConfig *v1beta1.FluentdConfig
 	*reconciler.GenericResourceReconciler
-	config  *string
-	secrets *secret.MountSecrets
+	config         *string
+	secrets        *secret.MountSecrets
+	clusterHasIPv6 bool
 }
 
 type Desire struct {
@@ -113,7 +114,7 @@ func (r *Reconciler) getServiceAccount() string {
 }
 
 func New(client client.Client, log logr.Logger,
-	logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, fluentdConfig *v1beta1.FluentdConfig, config *string, secrets *secret.MountSecrets, opts reconciler.ReconcilerOpts,
+	logging *v1beta1.Logging, fluentdSpec *v1beta1.FluentdSpec, fluentdConfig *v1beta1.FluentdConfig, config *string, secrets *secret.MountSecrets, opts reconciler.ReconcilerOpts, clusterHasIPv6 bool,
 ) *Reconciler {
 	return &Reconciler{
 		Logging:                   logging,
@@ -122,6 +123,7 @@ func New(client client.Client, log logr.Logger,
 		GenericResourceReconciler: reconciler.NewGenericReconciler(client, log, opts),
 		config:                    config,
 		secrets:                   secrets,
+		clusterHasIPv6:            clusterHasIPv6,
 	}
 }
 

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -59,7 +59,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 	}
 
 	if r.fluentdSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 	}
 
 	beforeUpdateHook := reconciler.DesiredStateHook(func(current runtime.Object) error {
@@ -107,7 +107,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 		}
 
 		if r.fluentdSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -208,7 +208,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 		}
 
 		if r.fluentdSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -292,7 +292,7 @@ func (r *Reconciler) headlessService() (runtime.Object, reconciler.DesiredState,
 	}
 
 	if r.fluentdSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 	}
 
 	return desired, reconciler.StatePresent, nil

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -69,7 +69,10 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 			if len(s.Spec.ClusterIPs) > 0 {
 				desired.Spec.ClusterIPs = s.Spec.ClusterIPs
 			}
-			v1beta1.PreserveAllocatedIPFamilies(&desired.Spec, s.Spec)
+			if v1beta1.PreserveAllocatedIPFamilies(&desired.Spec, s.Spec) {
+				r.Log.Info("ignoring the requested single-stack policy, the service already has both IP families allocated",
+					"service", desired.Name)
+			}
 		} else {
 			return errors.Errorf("failed to cast service object %+v", current)
 		}

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -59,7 +59,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 	}
 
 	if r.fluentdSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 	}
 
 	beforeUpdateHook := reconciler.DesiredStateHook(func(current runtime.Object) error {
@@ -107,7 +107,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 		}
 
 		if r.fluentdSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -208,7 +208,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 		}
 
 		if r.fluentdSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -292,7 +292,7 @@ func (r *Reconciler) headlessService() (runtime.Object, reconciler.DesiredState,
 	}
 
 	if r.fluentdSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 	}
 
 	return desired, reconciler.StatePresent, nil

--- a/pkg/resources/fluentd/service.go
+++ b/pkg/resources/fluentd/service.go
@@ -69,6 +69,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 			if len(s.Spec.ClusterIPs) > 0 {
 				desired.Spec.ClusterIPs = s.Spec.ClusterIPs
 			}
+			v1beta1.PreserveAllocatedIPFamilies(&desired.Spec, s.Spec)
 		} else {
 			return errors.Errorf("failed to cast service object %+v", current)
 		}

--- a/pkg/resources/fluentd/service_test.go
+++ b/pkg/resources/fluentd/service_test.go
@@ -1,0 +1,194 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fluentd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cisco-open/operator-tools/pkg/reconciler"
+	"github.com/cisco-open/operator-tools/pkg/typeoverride"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+// The API server rejects an update whose ipFamilies[0] disagrees with the already-allocated
+// clusterIPs[0], and operator-tools cannot recognize that error as immutable, so the Logging
+// stops converging until someone deletes the Service by hand.
+func TestServiceKeepsExistingPrimaryIPFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  *corev1.Service
+		expected []corev1.IPFamily
+	}{
+		{
+			name:     "no existing service keeps the desired IPv6-primary order",
+			current:  nil,
+			expected: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		},
+		{
+			name: "IPv4-primary dual-stack service allocated by an earlier release is left alone",
+			current: existingService(
+				[]corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+				"10.96.35.208", "fd00:10:96::989d",
+			),
+			expected: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+		},
+		{
+			name: "single-stack IPv4 service cannot gain an IPv6 primary",
+			current: existingService(
+				[]corev1.IPFamily{corev1.IPv4Protocol}, "10.96.35.208",
+			),
+			expected: []corev1.IPFamily{corev1.IPv4Protocol},
+		},
+		{
+			name: "already IPv6-primary service stays as desired",
+			current: existingService(
+				[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+				"fd00:10:96::989d", "10.96.35.208",
+			),
+			expected: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		},
+		{
+			name:     "service with no allocated clusterIPs takes the desired order",
+			current:  existingService(nil),
+			expected: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		},
+		{
+			name: "headless service has nothing allocated to preserve",
+			current: existingService(
+				[]corev1.IPFamily{corev1.IPv4Protocol}, corev1.ClusterIPNone,
+			),
+			expected: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := ipv6Reconciler()
+
+			object, state, err := r.service()
+			require.NoError(t, err)
+
+			if test.current != nil {
+				hook, ok := state.(reconciler.DesiredStateHook)
+				require.True(t, ok, "service() must return a before-update hook")
+				require.NoError(t, hook(test.current))
+			}
+
+			service, ok := object.(*corev1.Service)
+			require.True(t, ok)
+			require.Equal(t, test.expected, service.Spec.IPFamilies)
+			requireIPFamiliesMatchClusterIPs(t, service)
+		})
+	}
+}
+
+// The policy decides whether the API server may widen the pinned families or must truncate them,
+// so pinning it in the wrong direction either strands an existing Service on IPv4 or releases an
+// already-allocated address.
+func TestServiceIPFamilyPolicyOnlyResistsNarrowing(t *testing.T) {
+	singleStack := corev1.IPFamilyPolicySingleStack
+	preferDualStack := corev1.IPFamilyPolicyPreferDualStack
+
+	tests := []struct {
+		name        string
+		enabledIPv6 bool
+		overrides   *corev1.ServiceSpec
+		current     *corev1.Service
+		expected    corev1.IPFamilyPolicy
+	}{
+		{
+			name:        "enabling IPv6 on a single-stack service still widens it",
+			enabledIPv6: true,
+			current:     serviceWithPolicy(singleStack, []corev1.IPFamily{corev1.IPv4Protocol}, "10.96.35.208"),
+			expected:    preferDualStack,
+		},
+		{
+			name:      "narrowing a dual-stack service keeps its policy so no address is released",
+			overrides: &corev1.ServiceSpec{IPFamilyPolicy: &singleStack, IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol}},
+			current: serviceWithPolicy(preferDualStack,
+				[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+				"fd00:10:96::989d", "10.96.35.208"),
+			expected: preferDualStack,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := ipv6Reconciler()
+			r.fluentdSpec.EnabledIPv6 = test.enabledIPv6
+			if test.overrides != nil {
+				r.fluentdSpec.ServiceOverrides = &typeoverride.Service{Spec: *test.overrides}
+			}
+
+			object, state, err := r.service()
+			require.NoError(t, err)
+
+			hook, ok := state.(reconciler.DesiredStateHook)
+			require.True(t, ok)
+			require.NoError(t, hook(test.current))
+
+			service, ok := object.(*corev1.Service)
+			require.True(t, ok)
+			require.NotNil(t, service.Spec.IPFamilyPolicy)
+			require.Equal(t, test.expected, *service.Spec.IPFamilyPolicy)
+		})
+	}
+}
+
+func serviceWithPolicy(policy corev1.IPFamilyPolicy, families []corev1.IPFamily, clusterIPs ...string) *corev1.Service {
+	service := existingService(families, clusterIPs...)
+	service.Spec.IPFamilyPolicy = &policy
+	return service
+}
+
+func requireIPFamiliesMatchClusterIPs(t *testing.T, service *corev1.Service) {
+	t.Helper()
+
+	for i, clusterIP := range service.Spec.ClusterIPs {
+		if clusterIP == corev1.ClusterIPNone {
+			continue
+		}
+		require.Less(t, i, len(service.Spec.IPFamilies), "clusterIPs is longer than ipFamilies")
+		family := corev1.IPv4Protocol
+		if strings.Contains(clusterIP, ":") {
+			family = corev1.IPv6Protocol
+		}
+		require.Equal(t, family, service.Spec.IPFamilies[i], "clusterIPs[%d] %q contradicts ipFamilies[%d]", i, clusterIP, i)
+	}
+}
+
+func ipv6Reconciler() *Reconciler {
+	logging := &v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
+	}
+	return &Reconciler{
+		Logging:     logging,
+		fluentdSpec: &v1beta1.FluentdSpec{EnabledIPv6: true},
+	}
+}
+
+func existingService(families []corev1.IPFamily, clusterIPs ...string) *corev1.Service {
+	spec := corev1.ServiceSpec{IPFamilies: families, ClusterIPs: clusterIPs}
+	if len(clusterIPs) > 0 {
+		spec.ClusterIP = clusterIPs[0]
+	}
+	return &corev1.Service{Spec: spec}
+}

--- a/pkg/resources/fluentd/service_test.go
+++ b/pkg/resources/fluentd/service_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	"github.com/cisco-open/operator-tools/pkg/typeoverride"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,9 +181,10 @@ func ipv6Reconciler() *Reconciler {
 		Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
 	}
 	return &Reconciler{
-		Logging:         logging,
-		fluentdSpec:     &v1beta1.FluentdSpec{EnabledIPv6: true},
-		clusterFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		Logging:                   logging,
+		fluentdSpec:               &v1beta1.FluentdSpec{EnabledIPv6: true},
+		clusterFamilies:           []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		GenericResourceReconciler: reconciler.NewGenericReconciler(nil, logr.Discard(), reconciler.ReconcilerOpts{}),
 	}
 }
 
@@ -192,4 +194,22 @@ func existingService(families []corev1.IPFamily, clusterIPs ...string) *corev1.S
 		spec.ClusterIP = clusterIPs[0]
 	}
 	return &corev1.Service{Spec: spec}
+}
+
+// A discarded single-stack request must be reported, otherwise the user sees no sign that the
+// operator did not carry it out.
+func TestPreserveAllocatedIPFamiliesReportsADiscardedPolicy(t *testing.T) {
+	singleStack := corev1.IPFamilyPolicySingleStack
+	preferDualStack := corev1.IPFamilyPolicyPreferDualStack
+	dualStack := existingService(
+		[]corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		"fd00:10:96::989d", "10.96.35.208",
+	)
+	dualStack.Spec.IPFamilyPolicy = &preferDualStack
+
+	desired := corev1.ServiceSpec{IPFamilyPolicy: &singleStack}
+	require.True(t, v1beta1.PreserveAllocatedIPFamilies(&desired, dualStack.Spec))
+
+	untouched := corev1.ServiceSpec{IPFamilyPolicy: &preferDualStack}
+	require.False(t, v1beta1.PreserveAllocatedIPFamilies(&untouched, dualStack.Spec))
 }

--- a/pkg/resources/fluentd/service_test.go
+++ b/pkg/resources/fluentd/service_test.go
@@ -180,9 +180,9 @@ func ipv6Reconciler() *Reconciler {
 		Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
 	}
 	return &Reconciler{
-		Logging:        logging,
-		fluentdSpec:    &v1beta1.FluentdSpec{EnabledIPv6: true},
-		clusterHasIPv6: true,
+		Logging:         logging,
+		fluentdSpec:     &v1beta1.FluentdSpec{EnabledIPv6: true},
+		clusterFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
 	}
 }
 

--- a/pkg/resources/fluentd/service_test.go
+++ b/pkg/resources/fluentd/service_test.go
@@ -180,8 +180,9 @@ func ipv6Reconciler() *Reconciler {
 		Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
 	}
 	return &Reconciler{
-		Logging:     logging,
-		fluentdSpec: &v1beta1.FluentdSpec{EnabledIPv6: true},
+		Logging:        logging,
+		fluentdSpec:    &v1beta1.FluentdSpec{EnabledIPv6: true},
+		clusterHasIPv6: true,
 	}
 }
 

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -419,7 +419,8 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 		if r.fluentdSpec.BufferVolumeMetrics.Port != 0 {
 			port = r.fluentdSpec.BufferVolumeMetrics.Port
 		}
-		portParam := fmt.Sprintf("--web.listen-address=:%d", port)
+		// An unset bind keeps the wildcard address, which listens on both families.
+		portParam := fmt.Sprintf("--web.listen-address=%s:%d", r.fluentdSpec.BufferVolumeMetrics.Bind, port)
 		args := []string{portParam}
 		if len(r.fluentdSpec.BufferVolumeArgs) != 0 {
 			args = append(args, r.fluentdSpec.BufferVolumeArgs...)

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -411,7 +411,8 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 		if r.fluentdSpec.BufferVolumeMetrics.Port != 0 {
 			port = r.fluentdSpec.BufferVolumeMetrics.Port
 		}
-		portParam := fmt.Sprintf("--web.listen-address=:%d", port)
+		// An unset bind keeps the wildcard address, which listens on both families.
+		portParam := fmt.Sprintf("--web.listen-address=%s:%d", r.fluentdSpec.BufferVolumeMetrics.Bind, port)
 		args := []string{portParam}
 		if len(r.fluentdSpec.BufferVolumeArgs) != 0 {
 			args = append(args, r.fluentdSpec.BufferVolumeArgs...)

--- a/pkg/resources/ipfamily/detector.go
+++ b/pkg/resources/ipfamily/detector.go
@@ -28,51 +28,65 @@ import (
 // dryRunner reports whether the API server would accept a Service pinned to the given family.
 type dryRunner func(ctx context.Context, namespace string, family corev1.IPFamily) error
 
-// Detector answers whether the cluster can allocate IPv6 Service addresses. Naming a family the
-// cluster has no range for is rejected at create with no recovery path, so the answer has to come
-// from the API server rather than from the user's intent.
+// Detector reports which Service IP families the cluster can allocate. Naming a family the cluster
+// has no range for is rejected at create with no recovery path, so the answer has to come from the
+// API server rather than from the user's intent.
 type Detector struct {
 	dryRun dryRunner
 	log    logr.Logger
 
 	mu       sync.Mutex
 	resolved bool
-	ipv6     bool
+	families []corev1.IPFamily
 }
 
 func NewDetector(c client.Client, log logr.Logger) *Detector {
 	return &Detector{dryRun: dryRunService(c), log: log}
 }
 
-// SupportsIPv6 defaults to false while the answer is unknown: a needless IPv4 primary costs a
-// metrics scrape, whereas an IPv6 primary the cluster cannot allocate is unrecoverable.
-func (d *Detector) SupportsIPv6(ctx context.Context, namespace string) bool {
+// Families lists the allocatable families, IPv6 first. It returns nil while the answer is unknown,
+// and nil for a plain IPv4 cluster, so the caller leaves the choice to the API server.
+func (d *Detector) Families(ctx context.Context, namespace string) []corev1.IPFamily {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if d.resolved {
-		return d.ipv6
+		return d.families
 	}
 
-	err := d.dryRun(ctx, namespace, corev1.IPv6Protocol)
+	hasIPv6, err := d.allocatable(ctx, namespace, corev1.IPv6Protocol)
+	if err != nil {
+		return nil
+	}
+	hasIPv4, err := d.allocatable(ctx, namespace, corev1.IPv4Protocol)
+	if err != nil {
+		return nil
+	}
+
+	switch {
+	case hasIPv6 && hasIPv4:
+		d.families = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+	case hasIPv6:
+		d.families = []corev1.IPFamily{corev1.IPv6Protocol}
+	default:
+		d.log.Info("cluster has no IPv6 service range, leaving the IP families to the cluster")
+	}
+	d.resolved = true
+	return d.families
+}
+
+// An admission webhook that rejects every Service is indistinguishable from a missing range, so an
+// error here leaves the answer unresolved rather than caching a guess.
+func (d *Detector) allocatable(ctx context.Context, namespace string, family corev1.IPFamily) (bool, error) {
+	err := d.dryRun(ctx, namespace, family)
 	if err == nil {
-		d.resolved, d.ipv6 = true, true
-		return true
+		return true, nil
 	}
-	if !apierrors.IsInvalid(err) {
-		d.log.Error(err, "could not determine cluster IPv6 support, assuming none for now")
-		return false
+	if apierrors.IsInvalid(err) {
+		return false, nil
 	}
-
-	// An admission webhook rejecting every Service looks identical to a missing IPv6 range.
-	if controlErr := d.dryRun(ctx, namespace, corev1.IPv4Protocol); controlErr != nil {
-		d.log.Error(controlErr, "cluster rejects the IP family probe outright, assuming no IPv6 for now")
-		return false
-	}
-
-	d.log.Info("cluster has no IPv6 service range, leaving the IP families to the cluster")
-	d.resolved, d.ipv6 = true, false
-	return false
+	d.log.Error(err, "could not probe the cluster IP families, leaving them to the cluster for now", "family", family)
+	return false, err
 }
 
 func dryRunService(c client.Client) dryRunner {

--- a/pkg/resources/ipfamily/detector.go
+++ b/pkg/resources/ipfamily/detector.go
@@ -63,6 +63,13 @@ func (d *Detector) Families(ctx context.Context, namespace string) []corev1.IPFa
 		return nil
 	}
 
+	// No cluster serves neither family, so something rejects every Service and the answer is not
+	// ours to cache. An admission webhook doing that would otherwise pin nil until a restart.
+	if !hasIPv6 && !hasIPv4 {
+		d.log.Info("every IP family probe was rejected, leaving the IP families to the cluster for now")
+		return nil
+	}
+
 	switch {
 	case hasIPv6 && hasIPv4:
 		d.families = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
@@ -75,8 +82,6 @@ func (d *Detector) Families(ctx context.Context, namespace string) []corev1.IPFa
 	return d.families
 }
 
-// An admission webhook that rejects every Service is indistinguishable from a missing range, so an
-// error here leaves the answer unresolved rather than caching a guess.
 func (d *Detector) allocatable(ctx context.Context, namespace string, family corev1.IPFamily) (bool, error) {
 	err := d.dryRun(ctx, namespace, family)
 	if err == nil {

--- a/pkg/resources/ipfamily/detector.go
+++ b/pkg/resources/ipfamily/detector.go
@@ -70,13 +70,15 @@ func (d *Detector) Families(ctx context.Context, namespace string) []corev1.IPFa
 		return nil
 	}
 
-	switch {
-	case hasIPv6 && hasIPv4:
-		d.families = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
-	case hasIPv6:
-		d.families = []corev1.IPFamily{corev1.IPv6Protocol}
-	default:
-		d.log.Info("cluster has no IPv6 service range, leaving the IP families to the cluster")
+	if !hasIPv6 {
+		// Re-probed every time, so a range added to a running cluster is picked up without a restart.
+		d.log.V(1).Info("cluster has no IPv6 service range, leaving the IP families to the cluster")
+		return nil
+	}
+
+	d.families = []corev1.IPFamily{corev1.IPv6Protocol}
+	if hasIPv4 {
+		d.families = append(d.families, corev1.IPv4Protocol)
 	}
 	d.resolved = true
 	return d.families

--- a/pkg/resources/ipfamily/detector.go
+++ b/pkg/resources/ipfamily/detector.go
@@ -16,6 +16,8 @@ package ipfamily
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -44,36 +46,37 @@ func NewDetector(c client.Client, log logr.Logger) *Detector {
 	return &Detector{dryRun: dryRunService(c), log: log}
 }
 
-// Families lists the allocatable families, IPv6 first. It returns nil while the answer is unknown,
-// and nil for a plain IPv4 cluster, so the caller leaves the choice to the API server.
-func (d *Detector) Families(ctx context.Context, namespace string) []corev1.IPFamily {
+// Families lists the allocatable families, IPv6 first, and nil for a plain IPv4 cluster so the
+// caller leaves the choice to the API server. An error means the cluster could not be asked: the
+// caller must not carry on, because nil would then be indistinguishable from a real IPv4-only
+// answer and the Service and the listener would disagree about which family to use.
+func (d *Detector) Families(ctx context.Context, namespace string) ([]corev1.IPFamily, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if d.resolved {
-		return d.families
+		return d.families, nil
 	}
 
 	hasIPv6, err := d.allocatable(ctx, namespace, corev1.IPv6Protocol)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	hasIPv4, err := d.allocatable(ctx, namespace, corev1.IPv4Protocol)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	// No cluster serves neither family, so something rejects every Service and the answer is not
 	// ours to cache. An admission webhook doing that would otherwise pin nil until a restart.
 	if !hasIPv6 && !hasIPv4 {
-		d.log.Info("every IP family probe was rejected, leaving the IP families to the cluster for now")
-		return nil
+		return nil, errors.New("every service IP family probe was rejected, cannot determine the cluster families")
 	}
 
 	if !hasIPv6 {
 		// Re-probed every time, so a range added to a running cluster is picked up without a restart.
 		d.log.V(1).Info("cluster has no IPv6 service range, leaving the IP families to the cluster")
-		return nil
+		return nil, nil
 	}
 
 	d.families = []corev1.IPFamily{corev1.IPv6Protocol}
@@ -81,7 +84,7 @@ func (d *Detector) Families(ctx context.Context, namespace string) []corev1.IPFa
 		d.families = append(d.families, corev1.IPv4Protocol)
 	}
 	d.resolved = true
-	return d.families
+	return d.families, nil
 }
 
 func (d *Detector) allocatable(ctx context.Context, namespace string, family corev1.IPFamily) (bool, error) {
@@ -92,8 +95,7 @@ func (d *Detector) allocatable(ctx context.Context, namespace string, family cor
 	if apierrors.IsInvalid(err) {
 		return false, nil
 	}
-	d.log.Error(err, "could not probe the cluster IP families, leaving them to the cluster for now", "family", family)
-	return false, err
+	return false, fmt.Errorf("probing the %s service range: %w", family, err)
 }
 
 func dryRunService(c client.Client) dryRunner {

--- a/pkg/resources/ipfamily/detector.go
+++ b/pkg/resources/ipfamily/detector.go
@@ -1,0 +1,92 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipfamily
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// dryRunner reports whether the API server would accept a Service pinned to the given family.
+type dryRunner func(ctx context.Context, namespace string, family corev1.IPFamily) error
+
+// Detector answers whether the cluster can allocate IPv6 Service addresses. Naming a family the
+// cluster has no range for is rejected at create with no recovery path, so the answer has to come
+// from the API server rather than from the user's intent.
+type Detector struct {
+	dryRun dryRunner
+	log    logr.Logger
+
+	mu       sync.Mutex
+	resolved bool
+	ipv6     bool
+}
+
+func NewDetector(c client.Client, log logr.Logger) *Detector {
+	return &Detector{dryRun: dryRunService(c), log: log}
+}
+
+// SupportsIPv6 defaults to false while the answer is unknown: a needless IPv4 primary costs a
+// metrics scrape, whereas an IPv6 primary the cluster cannot allocate is unrecoverable.
+func (d *Detector) SupportsIPv6(ctx context.Context, namespace string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.resolved {
+		return d.ipv6
+	}
+
+	err := d.dryRun(ctx, namespace, corev1.IPv6Protocol)
+	if err == nil {
+		d.resolved, d.ipv6 = true, true
+		return true
+	}
+	if !apierrors.IsInvalid(err) {
+		d.log.Error(err, "could not determine cluster IPv6 support, assuming none for now")
+		return false
+	}
+
+	// An admission webhook rejecting every Service looks identical to a missing IPv6 range.
+	if controlErr := d.dryRun(ctx, namespace, corev1.IPv4Protocol); controlErr != nil {
+		d.log.Error(controlErr, "cluster rejects the IP family probe outright, assuming no IPv6 for now")
+		return false
+	}
+
+	d.log.Info("cluster has no IPv6 service range, leaving the IP families to the cluster")
+	d.resolved, d.ipv6 = true, false
+	return false
+}
+
+func dryRunService(c client.Client) dryRunner {
+	return func(ctx context.Context, namespace string, family corev1.IPFamily) error {
+		probe := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "logging-ipfamily-probe-",
+				Namespace:    namespace,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:      []corev1.ServicePort{{Port: 1}},
+				IPFamilies: []corev1.IPFamily{family},
+			},
+		}
+		return c.Create(ctx, probe, client.DryRunAll)
+	}
+}

--- a/pkg/resources/ipfamily/detector_test.go
+++ b/pkg/resources/ipfamily/detector_test.go
@@ -27,41 +27,36 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func TestSupportsIPv6(t *testing.T) {
+func TestFamilies(t *testing.T) {
 	tests := []struct {
 		name     string
 		results  map[corev1.IPFamily]error
-		expected bool
+		expected []corev1.IPFamily
 		resolved bool
 	}{
 		{
-			name:     "dual-stack cluster accepts the IPv6 probe",
-			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: nil},
-			expected: true,
+			name:     "a dual-stack cluster is named IPv6 first",
+			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: nil, corev1.IPv4Protocol: nil},
+			expected: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
 			resolved: true,
 		},
 		{
-			name: "single-stack cluster rejects IPv6 but accepts the IPv4 control",
-			results: map[corev1.IPFamily]error{
-				corev1.IPv6Protocol: invalidFamilyErr(),
-				corev1.IPv4Protocol: nil,
-			},
-			expected: false,
+			// Naming IPv4 here is rejected exactly as naming IPv6 is on an IPv4-only cluster.
+			name:     "an IPv6-only cluster is never told about IPv4",
+			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: nil, corev1.IPv4Protocol: invalidFamilyErr()},
+			expected: []corev1.IPFamily{corev1.IPv6Protocol},
 			resolved: true,
 		},
 		{
-			name: "a webhook rejecting every service leaves the answer unknown",
-			results: map[corev1.IPFamily]error{
-				corev1.IPv6Protocol: invalidFamilyErr(),
-				corev1.IPv4Protocol: invalidFamilyErr(),
-			},
-			expected: false,
-			resolved: false,
+			name:     "an IPv4-only cluster is left to choose for itself",
+			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: invalidFamilyErr(), corev1.IPv4Protocol: nil},
+			expected: nil,
+			resolved: true,
 		},
 		{
 			name:     "a denied probe leaves the answer unknown",
 			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: apierrors.NewForbidden(schema.GroupResource{Resource: "services"}, "probe", errors.New("nope"))},
-			expected: false,
+			expected: nil,
 			resolved: false,
 		},
 	}
@@ -77,10 +72,10 @@ func TestSupportsIPv6(t *testing.T) {
 				},
 			}
 
-			require.Equal(t, test.expected, d.SupportsIPv6(context.Background(), "default"))
+			require.Equal(t, test.expected, d.Families(context.Background(), "default"))
 
 			before := calls
-			require.Equal(t, test.expected, d.SupportsIPv6(context.Background(), "default"))
+			require.Equal(t, test.expected, d.Families(context.Background(), "default"))
 			if test.resolved {
 				require.Equal(t, before, calls, "a resolved answer must not re-probe")
 			} else {
@@ -91,7 +86,7 @@ func TestSupportsIPv6(t *testing.T) {
 }
 
 // A cluster that gains an IPv6 range must be picked up without restarting the operator.
-func TestSupportsIPv6RecoversAfterATransientFailure(t *testing.T) {
+func TestFamiliesRecoverAfterATransientFailure(t *testing.T) {
 	failing := true
 	d := &Detector{
 		log: logr.Discard(),
@@ -103,10 +98,10 @@ func TestSupportsIPv6RecoversAfterATransientFailure(t *testing.T) {
 		},
 	}
 
-	require.False(t, d.SupportsIPv6(context.Background(), "default"))
+	require.Nil(t, d.Families(context.Background(), "default"))
 
 	failing = false
-	require.True(t, d.SupportsIPv6(context.Background(), "default"))
+	require.Equal(t, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, d.Families(context.Background(), "default"))
 }
 
 func invalidFamilyErr() error {

--- a/pkg/resources/ipfamily/detector_test.go
+++ b/pkg/resources/ipfamily/detector_test.go
@@ -48,10 +48,10 @@ func TestFamilies(t *testing.T) {
 			resolved: true,
 		},
 		{
-			name:     "an IPv4-only cluster is left to choose for itself",
+			name:     "an IPv4-only cluster is left to choose for itself, and re-probed",
 			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: invalidFamilyErr(), corev1.IPv4Protocol: nil},
 			expected: nil,
-			resolved: true,
+			resolved: false,
 		},
 		{
 			name: "a webhook rejecting every service leaves the answer unknown",

--- a/pkg/resources/ipfamily/detector_test.go
+++ b/pkg/resources/ipfamily/detector_test.go
@@ -33,6 +33,7 @@ func TestFamilies(t *testing.T) {
 		results  map[corev1.IPFamily]error
 		expected []corev1.IPFamily
 		resolved bool
+		wantErr  bool
 	}{
 		{
 			name:     "a dual-stack cluster is named IPv6 first",
@@ -54,7 +55,8 @@ func TestFamilies(t *testing.T) {
 			resolved: false,
 		},
 		{
-			name: "a webhook rejecting every service leaves the answer unknown",
+			name:    "a webhook rejecting every service is an error, not an IPv4 cluster",
+			wantErr: true,
 			results: map[corev1.IPFamily]error{
 				corev1.IPv6Protocol: invalidFamilyErr(),
 				corev1.IPv4Protocol: invalidFamilyErr(),
@@ -63,10 +65,11 @@ func TestFamilies(t *testing.T) {
 			resolved: false,
 		},
 		{
-			name:     "a denied probe leaves the answer unknown",
+			name:     "a denied probe is an error, not an IPv4 cluster",
 			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: apierrors.NewForbidden(schema.GroupResource{Resource: "services"}, "probe", errors.New("nope"))},
 			expected: nil,
 			resolved: false,
+			wantErr:  true,
 		},
 	}
 
@@ -81,10 +84,13 @@ func TestFamilies(t *testing.T) {
 				},
 			}
 
-			require.Equal(t, test.expected, d.Families(context.Background(), "default"))
+			got, err := d.Families(context.Background(), "default")
+			require.Equal(t, test.wantErr, err != nil)
+			require.Equal(t, test.expected, got)
 
 			before := calls
-			require.Equal(t, test.expected, d.Families(context.Background(), "default"))
+			got, _ = d.Families(context.Background(), "default")
+			require.Equal(t, test.expected, got)
 			if test.resolved {
 				require.Equal(t, before, calls, "a resolved answer must not re-probe")
 			} else {
@@ -107,10 +113,13 @@ func TestFamiliesRecoverAfterATransientFailure(t *testing.T) {
 		},
 	}
 
-	require.Nil(t, d.Families(context.Background(), "default"))
+	_, err := d.Families(context.Background(), "default")
+	require.Error(t, err)
 
 	failing = false
-	require.Equal(t, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, d.Families(context.Background(), "default"))
+	got, err := d.Families(context.Background(), "default")
+	require.NoError(t, err)
+	require.Equal(t, []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}, got)
 }
 
 func invalidFamilyErr() error {

--- a/pkg/resources/ipfamily/detector_test.go
+++ b/pkg/resources/ipfamily/detector_test.go
@@ -54,6 +54,15 @@ func TestFamilies(t *testing.T) {
 			resolved: true,
 		},
 		{
+			name: "a webhook rejecting every service leaves the answer unknown",
+			results: map[corev1.IPFamily]error{
+				corev1.IPv6Protocol: invalidFamilyErr(),
+				corev1.IPv4Protocol: invalidFamilyErr(),
+			},
+			expected: nil,
+			resolved: false,
+		},
+		{
 			name:     "a denied probe leaves the answer unknown",
 			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: apierrors.NewForbidden(schema.GroupResource{Resource: "services"}, "probe", errors.New("nope"))},
 			expected: nil,

--- a/pkg/resources/ipfamily/detector_test.go
+++ b/pkg/resources/ipfamily/detector_test.go
@@ -1,0 +1,122 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipfamily
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestSupportsIPv6(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  map[corev1.IPFamily]error
+		expected bool
+		resolved bool
+	}{
+		{
+			name:     "dual-stack cluster accepts the IPv6 probe",
+			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: nil},
+			expected: true,
+			resolved: true,
+		},
+		{
+			name: "single-stack cluster rejects IPv6 but accepts the IPv4 control",
+			results: map[corev1.IPFamily]error{
+				corev1.IPv6Protocol: invalidFamilyErr(),
+				corev1.IPv4Protocol: nil,
+			},
+			expected: false,
+			resolved: true,
+		},
+		{
+			name: "a webhook rejecting every service leaves the answer unknown",
+			results: map[corev1.IPFamily]error{
+				corev1.IPv6Protocol: invalidFamilyErr(),
+				corev1.IPv4Protocol: invalidFamilyErr(),
+			},
+			expected: false,
+			resolved: false,
+		},
+		{
+			name:     "a denied probe leaves the answer unknown",
+			results:  map[corev1.IPFamily]error{corev1.IPv6Protocol: apierrors.NewForbidden(schema.GroupResource{Resource: "services"}, "probe", errors.New("nope"))},
+			expected: false,
+			resolved: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			d := &Detector{
+				log: logr.Discard(),
+				dryRun: func(_ context.Context, _ string, family corev1.IPFamily) error {
+					calls++
+					return test.results[family]
+				},
+			}
+
+			require.Equal(t, test.expected, d.SupportsIPv6(context.Background(), "default"))
+
+			before := calls
+			require.Equal(t, test.expected, d.SupportsIPv6(context.Background(), "default"))
+			if test.resolved {
+				require.Equal(t, before, calls, "a resolved answer must not re-probe")
+			} else {
+				require.Greater(t, calls, before, "an unresolved answer must be retried")
+			}
+		})
+	}
+}
+
+// A cluster that gains an IPv6 range must be picked up without restarting the operator.
+func TestSupportsIPv6RecoversAfterATransientFailure(t *testing.T) {
+	failing := true
+	d := &Detector{
+		log: logr.Discard(),
+		dryRun: func(_ context.Context, _ string, _ corev1.IPFamily) error {
+			if failing {
+				return apierrors.NewServiceUnavailable("apiserver is having a moment")
+			}
+			return nil
+		},
+	}
+
+	require.False(t, d.SupportsIPv6(context.Background(), "default"))
+
+	failing = false
+	require.True(t, d.SupportsIPv6(context.Background(), "default"))
+}
+
+func invalidFamilyErr() error {
+	return apierrors.NewInvalid(
+		schema.GroupKind{Kind: "Service"},
+		"probe",
+		field.ErrorList{field.Invalid(
+			field.NewPath("spec", "ipFamilies").Index(0),
+			"IPv6",
+			"not configured on this cluster",
+		)},
+	)
+}

--- a/pkg/resources/syslogng/service.go
+++ b/pkg/resources/syslogng/service.go
@@ -69,7 +69,10 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 			if len(s.Spec.ClusterIPs) > 0 {
 				desired.Spec.ClusterIPs = s.Spec.ClusterIPs
 			}
-			v1beta1.PreserveAllocatedIPFamilies(&desired.Spec, s.Spec)
+			if v1beta1.PreserveAllocatedIPFamilies(&desired.Spec, s.Spec) {
+				r.Log.Info("ignoring the requested single-stack policy, the service already has both IP families allocated",
+					"service", desired.Name)
+			}
 		} else {
 			return errors.Errorf("failed to cast service object %+v", current)
 		}

--- a/pkg/resources/syslogng/service.go
+++ b/pkg/resources/syslogng/service.go
@@ -59,7 +59,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 	}
 
 	if r.syslogNGSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 	}
 
 	beforeUpdateHook := reconciler.DesiredStateHook(func(current runtime.Object) error {
@@ -111,7 +111,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 		}
 
 		if r.syslogNGSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -216,7 +216,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 		}
 
 		if r.syslogNGSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -298,7 +298,7 @@ func (r *Reconciler) headlessService() (runtime.Object, reconciler.DesiredState,
 	}
 
 	if r.syslogNGSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterFamilies)
 	}
 
 	return desired, reconciler.StatePresent, nil

--- a/pkg/resources/syslogng/service.go
+++ b/pkg/resources/syslogng/service.go
@@ -106,6 +106,10 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 			},
 		}
 
+		if err := merge.Merge(desired, r.syslogNGSpec.MetricsServiceOverrides); err != nil {
+			return desired, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
+		}
+
 		if r.syslogNGSpec.EnabledIPv6 {
 			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 		}
@@ -205,6 +209,10 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 				Type:      corev1.ServiceTypeClusterIP,
 				ClusterIP: corev1.ClusterIPNone,
 			},
+		}
+
+		if err := merge.Merge(desired, r.syslogNGSpec.BufferVolumeMetricsServiceOverrides); err != nil {
+			return desired, reconciler.StatePresent, errors.WrapIf(err, "unable to merge overrides to base object")
 		}
 
 		if r.syslogNGSpec.EnabledIPv6 {

--- a/pkg/resources/syslogng/service.go
+++ b/pkg/resources/syslogng/service.go
@@ -59,7 +59,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 	}
 
 	if r.syslogNGSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 	}
 
 	beforeUpdateHook := reconciler.DesiredStateHook(func(current runtime.Object) error {
@@ -107,7 +107,7 @@ func (r *Reconciler) serviceMetrics() (runtime.Object, reconciler.DesiredState, 
 		}
 
 		if r.syslogNGSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -208,7 +208,7 @@ func (r *Reconciler) serviceBufferMetrics() (runtime.Object, reconciler.DesiredS
 		}
 
 		if r.syslogNGSpec.EnabledIPv6 {
-			v1beta1.EnableIPv6Options(&desired.Spec)
+			v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 		}
 
 		return desired, reconciler.StatePresent, nil
@@ -290,7 +290,7 @@ func (r *Reconciler) headlessService() (runtime.Object, reconciler.DesiredState,
 	}
 
 	if r.syslogNGSpec.EnabledIPv6 {
-		v1beta1.EnableIPv6Options(&desired.Spec)
+		v1beta1.EnableIPv6Options(&desired.Spec, r.clusterHasIPv6)
 	}
 
 	return desired, reconciler.StatePresent, nil

--- a/pkg/resources/syslogng/service.go
+++ b/pkg/resources/syslogng/service.go
@@ -69,6 +69,7 @@ func (r *Reconciler) service() (runtime.Object, reconciler.DesiredState, error) 
 			if len(s.Spec.ClusterIPs) > 0 {
 				desired.Spec.ClusterIPs = s.Spec.ClusterIPs
 			}
+			v1beta1.PreserveAllocatedIPFamilies(&desired.Spec, s.Spec)
 		} else {
 			return errors.Errorf("failed to cast service object %+v", current)
 		}

--- a/pkg/resources/syslogng/service_test.go
+++ b/pkg/resources/syslogng/service_test.go
@@ -31,7 +31,8 @@ func TestServiceKeepsExistingPrimaryIPFamily(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
 		},
-		syslogNGSpec: &v1beta1.SyslogNGSpec{EnabledIPv6: true},
+		syslogNGSpec:   &v1beta1.SyslogNGSpec{EnabledIPv6: true},
+		clusterHasIPv6: true,
 	}
 
 	object, state, err := r.service()

--- a/pkg/resources/syslogng/service_test.go
+++ b/pkg/resources/syslogng/service_test.go
@@ -15,13 +15,16 @@
 package syslogng
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
+	"github.com/cisco-open/operator-tools/pkg/typeoverride"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kube-logging/logging-operator/pkg/resources/model"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
@@ -49,4 +52,41 @@ func TestServiceKeepsExistingPrimaryIPFamily(t *testing.T) {
 	service, ok := object.(*corev1.Service)
 	require.True(t, ok)
 	require.Equal(t, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, service.Spec.IPFamilies)
+}
+
+// The metrics service overrides were declared on the CRD but never read, so anything a user set
+// under spec.syslogNG.metricsService was silently dropped.
+func TestMetricsServiceOverridesAreApplied(t *testing.T) {
+	metricsEnabled := true
+	r := &Reconciler{
+		Logging: &v1beta1.Logging{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
+		},
+		syslogNGSpec: &v1beta1.SyslogNGSpec{
+			Metrics:             &v1beta1.Metrics{Enabled: &metricsEnabled, Port: 9577},
+			BufferVolumeMetrics: &v1beta1.BufferMetrics{Metrics: v1beta1.Metrics{Enabled: &metricsEnabled, Port: 9578}},
+			MetricsServiceOverrides: &typeoverride.Service{
+				ObjectMeta: typeoverride.ObjectMeta{Annotations: map[string]string{"metrics": "yes"}},
+			},
+			BufferVolumeMetricsServiceOverrides: &typeoverride.Service{
+				ObjectMeta: typeoverride.ObjectMeta{Annotations: map[string]string{"buffer": "yes"}},
+			},
+		},
+	}
+
+	metrics, _, err := r.serviceMetrics()
+	require.NoError(t, err)
+	require.Equal(t, "yes", metrics.(*corev1.Service).Annotations["metrics"])
+
+	buffer, _, err := r.serviceBufferMetrics()
+	require.NoError(t, err)
+	require.Equal(t, "yes", buffer.(*corev1.Service).Annotations["buffer"])
+}
+
+// The reloader binary defaults to its own port, which is not the one the ServiceMonitor scrapes.
+func TestConfigReloaderListensOnTheScrapedPort(t *testing.T) {
+	container := configReloadContainer(&v1beta1.SyslogNGSpec{ConfigReloadImage: &v1beta1.BasicImageSpec{}})
+	require.Contains(t, container.Args, "-port")
+	require.Contains(t, container.Args, fmt.Sprint(model.ConfigReloaderMetricsPort))
 }

--- a/pkg/resources/syslogng/service_test.go
+++ b/pkg/resources/syslogng/service_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2026 Kube logging authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syslogng
+
+import (
+	"testing"
+
+	"github.com/cisco-open/operator-tools/pkg/reconciler"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+)
+
+func TestServiceKeepsExistingPrimaryIPFamily(t *testing.T) {
+	r := &Reconciler{
+		Logging: &v1beta1.Logging{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
+		},
+		syslogNGSpec: &v1beta1.SyslogNGSpec{EnabledIPv6: true},
+	}
+
+	object, state, err := r.service()
+	require.NoError(t, err)
+
+	hook, ok := state.(reconciler.DesiredStateHook)
+	require.True(t, ok, "service() must return a before-update hook")
+	require.NoError(t, hook(&corev1.Service{Spec: corev1.ServiceSpec{
+		ClusterIP:  "10.96.35.208",
+		ClusterIPs: []string{"10.96.35.208", "fd00:10:96::989d"},
+		IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+	}}))
+
+	service, ok := object.(*corev1.Service)
+	require.True(t, ok)
+	require.Equal(t, []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}, service.Spec.IPFamilies)
+}

--- a/pkg/resources/syslogng/service_test.go
+++ b/pkg/resources/syslogng/service_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
 	"github.com/cisco-open/operator-tools/pkg/typeoverride"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +35,9 @@ func TestServiceKeepsExistingPrimaryIPFamily(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
 		},
-		syslogNGSpec:    &v1beta1.SyslogNGSpec{EnabledIPv6: true},
-		clusterFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		syslogNGSpec:              &v1beta1.SyslogNGSpec{EnabledIPv6: true},
+		clusterFamilies:           []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
+		GenericResourceReconciler: reconciler.NewGenericReconciler(nil, logr.Discard(), reconciler.ReconcilerOpts{}),
 	}
 
 	object, state, err := r.service()

--- a/pkg/resources/syslogng/service_test.go
+++ b/pkg/resources/syslogng/service_test.go
@@ -15,7 +15,6 @@
 package syslogng
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cisco-open/operator-tools/pkg/reconciler"
@@ -25,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kube-logging/logging-operator/pkg/resources/model"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
@@ -84,11 +82,4 @@ func TestMetricsServiceOverridesAreApplied(t *testing.T) {
 	buffer, _, err := r.serviceBufferMetrics()
 	require.NoError(t, err)
 	require.Equal(t, "yes", buffer.(*corev1.Service).Annotations["buffer"])
-}
-
-// The reloader binary defaults to its own port, which is not the one the ServiceMonitor scrapes.
-func TestConfigReloaderListensOnTheScrapedPort(t *testing.T) {
-	container := configReloadContainer(&v1beta1.SyslogNGSpec{ConfigReloadImage: &v1beta1.BasicImageSpec{}})
-	require.Contains(t, container.Args, "-port")
-	require.Contains(t, container.Args, fmt.Sprint(model.ConfigReloaderMetricsPort))
 }

--- a/pkg/resources/syslogng/service_test.go
+++ b/pkg/resources/syslogng/service_test.go
@@ -34,8 +34,8 @@ func TestServiceKeepsExistingPrimaryIPFamily(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			Spec:       v1beta1.LoggingSpec{ControlNamespace: "default"},
 		},
-		syslogNGSpec:   &v1beta1.SyslogNGSpec{EnabledIPv6: true},
-		clusterHasIPv6: true,
+		syslogNGSpec:    &v1beta1.SyslogNGSpec{EnabledIPv6: true},
+		clusterFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol},
 	}
 
 	object, state, err := r.service()

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -270,7 +270,8 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 		if r.syslogNGSpec.BufferVolumeMetrics.Port != 0 {
 			port = r.syslogNGSpec.BufferVolumeMetrics.Port
 		}
-		portParam := fmt.Sprintf("--web.listen-address=:%d", port)
+		// An unset bind keeps the wildcard address, which listens on both families.
+		portParam := fmt.Sprintf("--web.listen-address=%s:%d", r.syslogNGSpec.BufferVolumeMetrics.Bind, port)
 		args := []string{portParam, "--collector.disable-defaults", "--collector.filesystem", "--collector.textfile", "--collector.textfile.directory=/prometheus/node_exporter/textfile_collector/"}
 
 		nodeExporterCmd := fmt.Sprintf("nodeexporter -> ./bin/node_exporter %v", strings.Join(args, " "))

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -269,7 +269,8 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 		if r.syslogNGSpec.BufferVolumeMetrics.Port != 0 {
 			port = r.syslogNGSpec.BufferVolumeMetrics.Port
 		}
-		portParam := fmt.Sprintf("--web.listen-address=:%d", port)
+		// An unset bind keeps the wildcard address, which listens on both families.
+		portParam := fmt.Sprintf("--web.listen-address=%s:%d", r.syslogNGSpec.BufferVolumeMetrics.Bind, port)
 		args := []string{portParam, "--collector.disable-defaults", "--collector.filesystem", "--collector.textfile", "--collector.textfile.directory=/prometheus/node_exporter/textfile_collector/"}
 
 		nodeExporterCmd := fmt.Sprintf("nodeexporter -> ./bin/node_exporter %v", strings.Join(args, " "))

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -66,8 +66,9 @@ type Reconciler struct {
 	syslogNGSpec   *v1beta1.SyslogNGSpec
 	syslogNGConfig *v1beta1.SyslogNGConfig
 	*reconciler.GenericResourceReconciler
-	config  string
-	secrets *secret.MountSecrets
+	config         string
+	secrets        *secret.MountSecrets
+	clusterHasIPv6 bool
 }
 
 type Desire struct {
@@ -87,6 +88,7 @@ func New(
 	config string,
 	secrets *secret.MountSecrets,
 	opts reconciler.ReconcilerOpts,
+	clusterHasIPv6 bool,
 ) *Reconciler {
 	return &Reconciler{
 		Logging:                   logging,
@@ -95,6 +97,7 @@ func New(
 		GenericResourceReconciler: reconciler.NewGenericReconciler(client, log, opts),
 		config:                    config,
 		secrets:                   secrets,
+		clusterHasIPv6:            clusterHasIPv6,
 	}
 }
 

--- a/pkg/resources/syslogng/syslogng.go
+++ b/pkg/resources/syslogng/syslogng.go
@@ -66,9 +66,9 @@ type Reconciler struct {
 	syslogNGSpec   *v1beta1.SyslogNGSpec
 	syslogNGConfig *v1beta1.SyslogNGConfig
 	*reconciler.GenericResourceReconciler
-	config         string
-	secrets        *secret.MountSecrets
-	clusterHasIPv6 bool
+	config          string
+	secrets         *secret.MountSecrets
+	clusterFamilies []corev1.IPFamily
 }
 
 type Desire struct {
@@ -88,7 +88,7 @@ func New(
 	config string,
 	secrets *secret.MountSecrets,
 	opts reconciler.ReconcilerOpts,
-	clusterHasIPv6 bool,
+	clusterFamilies []corev1.IPFamily,
 ) *Reconciler {
 	return &Reconciler{
 		Logging:                   logging,
@@ -97,7 +97,7 @@ func New(
 		GenericResourceReconciler: reconciler.NewGenericReconciler(client, log, opts),
 		config:                    config,
 		secrets:                   secrets,
-		clusterHasIPv6:            clusterHasIPv6,
+		clusterFamilies:           clusterFamilies,
 	}
 }
 

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -227,11 +227,12 @@ func EnableIPv6Options(serviceSpec *corev1.ServiceSpec, clusterFamilies []corev1
 
 // PreserveAllocatedIPFamilies pins ipFamilies and ipFamilyPolicy to what the API server allocated.
 // A change to an existing Service's primary family is rejected as invalid, not as immutable, so the
-// recreate fallback never fires.
-func PreserveAllocatedIPFamilies(desired *corev1.ServiceSpec, current corev1.ServiceSpec) {
+// recreate fallback never fires. It reports whether it overrode a single-stack policy the caller
+// asked for, which the caller should surface: the request is silently not carried out.
+func PreserveAllocatedIPFamilies(desired *corev1.ServiceSpec, current corev1.ServiceSpec) (overrodePolicy bool) {
 	allocated := len(current.ClusterIPs) > 0 && current.ClusterIPs[0] != corev1.ClusterIPNone
 	if len(current.IPFamilies) == 0 || !allocated {
-		return
+		return false
 	}
 	desired.IPFamilies = current.IPFamilies
 
@@ -240,5 +241,7 @@ func PreserveAllocatedIPFamilies(desired *corev1.ServiceSpec, current corev1.Ser
 	// The API server truncates the restored families to the policy, releasing the dropped address.
 	if narrowsToSingleStack && wouldDropAFamily {
 		desired.IPFamilyPolicy = current.IPFamilyPolicy
+		return true
 	}
+	return false
 }

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -228,8 +228,8 @@ func EnableIPv6Options(serviceSpec *corev1.ServiceSpec, clusterFamilies []corev1
 // PreserveAllocatedIPFamilies pins ipFamilies and ipFamilyPolicy to what the API server allocated.
 // A change to an existing Service's primary family is rejected as invalid, not as immutable, so the
 // recreate fallback never fires. It reports whether it overrode a single-stack policy the caller
-// asked for, which the caller should surface: the request is silently not carried out.
-func PreserveAllocatedIPFamilies(desired *corev1.ServiceSpec, current corev1.ServiceSpec) (overrodePolicy bool) {
+// asked for, so the caller can say that the request was not carried out.
+func PreserveAllocatedIPFamilies(desired *corev1.ServiceSpec, current corev1.ServiceSpec) bool {
 	allocated := len(current.ClusterIPs) > 0 && current.ClusterIPs[0] != corev1.ClusterIPNone
 	if len(current.IPFamilies) == 0 || !allocated {
 		return false

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -67,17 +67,31 @@ func RepositoryWithTag(repository, tag string) string {
 type Metrics struct {
 	// Enabled controls whether the metrics endpoint should be exposed. Defaults to false.
 	// When false, the metrics HTTP server will not be started and no metrics port will be exposed.
-	Enabled                 *bool                     `json:"enabled,omitempty"`
-	Interval                string                    `json:"interval,omitempty"`
-	Timeout                 string                    `json:"timeout,omitempty"`
-	Port                    int32                     `json:"port,omitempty"`
-	Path                    string                    `json:"path,omitempty"`
+	Enabled  *bool  `json:"enabled,omitempty"`
+	Interval string `json:"interval,omitempty"`
+	Timeout  string `json:"timeout,omitempty"`
+	Port     int32  `json:"port,omitempty"`
+	Path     string `json:"path,omitempty"`
+	// Bind is the address the metrics endpoint listens on. Defaults to 0.0.0.0, or to [::] when enabledIPv6 is set.
+	Bind                    string                    `json:"bind,omitempty"`
 	ServiceMonitor          bool                      `json:"serviceMonitor,omitempty"`
 	ServiceMonitorConfig    ServiceMonitorConfig      `json:"serviceMonitorConfig,omitempty"`
 	PrometheusAnnotations   bool                      `json:"prometheusAnnotations,omitempty"`
 	PrometheusRules         bool                      `json:"prometheusRules,omitempty"`
 	PrometheusRulesOverride []PrometheusRulesOverride `json:"prometheusRulesOverride,omitempty"`
 	PrometheusRulesLabels   map[string]string         `json:"prometheusRulesLabels,omitempty"`
+}
+
+// BindAddress resolves the metrics listen address. enabledIPv6 only picks the default, so a cluster
+// that needs a specific address can still name one.
+func (m *Metrics) BindAddress(enabledIPv6 bool) string {
+	if m != nil && m.Bind != "" {
+		return m.Bind
+	}
+	if enabledIPv6 {
+		return "[::]"
+	}
+	return "0.0.0.0"
 }
 
 func (m *Metrics) IsEnabled() bool {

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -75,6 +75,7 @@ type Metrics struct {
 	Port     int32  `json:"port,omitempty"`
 	Path     string `json:"path,omitempty"`
 	// Bind is the address the metrics endpoint listens on. Defaults to 0.0.0.0, or to [::] when enabledIPv6 is set.
+	// The syslog-ng metrics exporter has no listen address option, so it ignores this field.
 	Bind                    string                    `json:"bind,omitempty"`
 	ServiceMonitor          bool                      `json:"serviceMonitor,omitempty"`
 	ServiceMonitorConfig    ServiceMonitorConfig      `json:"serviceMonitorConfig,omitempty"`

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -203,3 +203,21 @@ func EnableIPv6Options(serviceSpec *corev1.ServiceSpec) {
 	serviceSpec.IPFamilyPolicy = &ipFamilyPolicy
 	serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
 }
+
+// PreserveAllocatedIPFamilies pins ipFamilies and ipFamilyPolicy to what the API server allocated.
+// A change to an existing Service's primary family is rejected as invalid, not as immutable, so the
+// recreate fallback never fires.
+func PreserveAllocatedIPFamilies(desired *corev1.ServiceSpec, current corev1.ServiceSpec) {
+	allocated := len(current.ClusterIPs) > 0 && current.ClusterIPs[0] != corev1.ClusterIPNone
+	if len(current.IPFamilies) == 0 || !allocated {
+		return
+	}
+	desired.IPFamilies = current.IPFamilies
+
+	narrowsToSingleStack := desired.IPFamilyPolicy != nil && *desired.IPFamilyPolicy == corev1.IPFamilyPolicySingleStack
+	wouldDropAFamily := len(current.IPFamilies) > 1 && current.IPFamilyPolicy != nil
+	// The API server truncates the restored families to the policy, releasing the dropped address.
+	if narrowsToSingleStack && wouldDropAFamily {
+		desired.IPFamilyPolicy = current.IPFamilyPolicy
+	}
+}

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -198,10 +198,14 @@ type ReadinessDefaultCheck struct {
 	FailureThreshold         int32 `json:"failureThreshold,omitempty"`
 }
 
-func EnableIPv6Options(serviceSpec *corev1.ServiceSpec) {
+// EnableIPv6Options prefers dual-stack, naming IPv6 as the primary family only where the cluster
+// can allocate it: the API server rejects a family it has no range for, with no recovery path.
+func EnableIPv6Options(serviceSpec *corev1.ServiceSpec, clusterHasIPv6 bool) {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	serviceSpec.IPFamilyPolicy = &ipFamilyPolicy
-	serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+	if clusterHasIPv6 {
+		serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+	}
 }
 
 // PreserveAllocatedIPFamilies pins ipFamilies and ipFamilyPolicy to what the API server allocated.

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -15,6 +15,8 @@
 package v1beta1
 
 import (
+	"slices"
+
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -212,13 +214,14 @@ type ReadinessDefaultCheck struct {
 	FailureThreshold         int32 `json:"failureThreshold,omitempty"`
 }
 
-// EnableIPv6Options prefers dual-stack, naming IPv6 as the primary family only where the cluster
-// can allocate it: the API server rejects a family it has no range for, with no recovery path.
-func EnableIPv6Options(serviceSpec *corev1.ServiceSpec, clusterHasIPv6 bool) {
+// EnableIPv6Options prefers dual-stack and names only the families the cluster can allocate, since
+// the API server rejects one it has no range for and the create has no recovery path.
+func EnableIPv6Options(serviceSpec *corev1.ServiceSpec, clusterFamilies []corev1.IPFamily) {
 	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 	serviceSpec.IPFamilyPolicy = &ipFamilyPolicy
-	if clusterHasIPv6 {
-		serviceSpec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+	if len(clusterFamilies) > 0 {
+		// The caller memoizes its slice and every Service would otherwise alias the same array.
+		serviceSpec.IPFamilies = slices.Clone(clusterFamilies)
 	}
 }
 

--- a/pkg/sdk/logging/api/v1beta1/common_types_test.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -322,6 +323,36 @@ func TestBufferMetricsIsEnabled(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("IsEnabled() = %v, expected %v", result, tt.expected)
 			}
+		})
+	}
+}
+
+func TestMetricsBindAddress(t *testing.T) {
+	tests := map[string]struct {
+		metrics     *Metrics
+		enabledIPv6 bool
+		expected    string
+	}{
+		"unset metrics listen on every IPv4 address": {expected: "0.0.0.0"},
+		"enabledIPv6 switches the default to the IPv6 wildcard": {
+			metrics:     &Metrics{},
+			enabledIPv6: true,
+			expected:    "[::]",
+		},
+		"an explicit bind wins over the IPv6 default": {
+			metrics:     &Metrics{Bind: "127.0.0.1"},
+			enabledIPv6: true,
+			expected:    "127.0.0.1",
+		},
+		"an explicit bind is kept without IPv6": {
+			metrics:  &Metrics{Bind: "[::1]"},
+			expected: "[::1]",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.expected, test.metrics.BindAddress(test.enabledIPv6))
 		})
 	}
 }

--- a/pkg/sdk/logging/model/syslogng/config/config.go
+++ b/pkg/sdk/logging/model/syslogng/config/config.go
@@ -182,6 +182,13 @@ func configRenderer(in Input) (render.Renderer, error) {
 		}, nil))
 	}
 
+	// syslog-ng defaults to ip(0.0.0.0) ip-protocol(4), so an IPv6-primary Service would route to a
+	// port nothing is listening on. "::" still accepts IPv4-mapped clients where bindv6only is off.
+	sourceIP, sourceIPProtocol := "", 0
+	if in.SyslogNGSpec.EnabledIPv6 {
+		sourceIP, sourceIPProtocol = "::", 6
+	}
+
 	return render.AllFrom(seqs.Intersperse(
 		seqs.Filter(
 			seqs.Concat(
@@ -194,6 +201,8 @@ func configRenderer(in Input) (render.Renderer, error) {
 							sourceDefStmt("", renderDriver(Field{
 								Value: reflect.ValueOf(NetworkSourceDriver{
 									Transport:      "tcp",
+									IP:             sourceIP,
+									IPProtocol:     sourceIPProtocol,
 									Port:           uint16(in.SourcePort),
 									MaxConnections: in.SyslogNGSpec.MaxConnections,
 									LogIWSize:      logIWSizeCalculator(in),

--- a/pkg/sdk/logging/model/syslogng/config/config.go
+++ b/pkg/sdk/logging/model/syslogng/config/config.go
@@ -55,6 +55,7 @@ type Input struct {
 	Flows                []v1beta1.SyslogNGFlow
 	SecretLoaderFactory  SecretLoaderFactory
 	SourcePort           int
+	ClusterHasIPv6       bool
 	SkipInvalidResources bool
 	Logger               logr.Logger
 }
@@ -185,7 +186,9 @@ func configRenderer(in Input) (render.Renderer, error) {
 	// syslog-ng defaults to ip(0.0.0.0) ip-protocol(4), so an IPv6-primary Service would route to a
 	// port nothing is listening on. "::" still accepts IPv4-mapped clients where bindv6only is off.
 	sourceIP, sourceIPProtocol := "", 0
-	if in.SyslogNGSpec.EnabledIPv6 {
+	// Binding IPv6 only reaches IPv4 clients through v4-mapped addresses, which net.ipv6.bindv6only
+	// turns off. A cluster without IPv6 gives the source an IPv4 Service, so leave it on IPv4 there.
+	if in.SyslogNGSpec.EnabledIPv6 && in.ClusterHasIPv6 {
 		sourceIP, sourceIPProtocol = "::", 6
 	}
 

--- a/pkg/sdk/logging/model/syslogng/config/config_test.go
+++ b/pkg/sdk/logging/model/syslogng/config/config_test.go
@@ -1202,10 +1202,26 @@ func TestRenderConfigIntoBindsTheSourceForIPv6(t *testing.T) {
 				Name:                "test",
 				Namespace:           "config-test",
 				SyslogNGSpec:        &v1beta1.SyslogNGSpec{EnabledIPv6: test.enabledIPv6},
+				ClusterHasIPv6:      true,
 				SecretLoaderFactory: &TestSecretLoaderFactory{},
 			}, &buf)
 			require.NoError(t, err)
 			require.Contains(t, buf.String(), test.wantSource)
 		})
 	}
+}
+
+// Binding IPv6 only reaches IPv4 clients through v4-mapped addresses, which bindv6only disables.
+func TestRenderConfigIntoKeepsIPv4WhenTheClusterHasNoIPv6(t *testing.T) {
+	var buf strings.Builder
+	err := RenderConfigInto(Input{
+		SourcePort:          601,
+		Name:                "test",
+		Namespace:           "config-test",
+		SyslogNGSpec:        &v1beta1.SyslogNGSpec{EnabledIPv6: true},
+		ClusterHasIPv6:      false,
+		SecretLoaderFactory: &TestSecretLoaderFactory{},
+	}, &buf)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), `network(flags("no-parse") port(601) transport("tcp"));`)
 }

--- a/pkg/sdk/logging/model/syslogng/config/config_test.go
+++ b/pkg/sdk/logging/model/syslogng/config/config_test.go
@@ -1176,3 +1176,36 @@ source "main_input" {
 		})
 	}
 }
+
+// syslog-ng binds ip(0.0.0.0) ip-protocol(4) by default, so an IPv6-primary Service would send
+// Fluent Bit to a port with no listener behind it.
+func TestRenderConfigIntoBindsTheSourceForIPv6(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		enabledIPv6 bool
+		wantSource  string
+	}{
+		{
+			name:       "default stays on the syslog-ng default bind",
+			wantSource: `network(flags("no-parse") port(601) transport("tcp"));`,
+		},
+		{
+			name:        "enabledIPv6 binds the wildcard address",
+			enabledIPv6: true,
+			wantSource:  `network(flags("no-parse") ip("::") ip-protocol(6) port(601) transport("tcp"));`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var buf strings.Builder
+			err := RenderConfigInto(Input{
+				SourcePort:          601,
+				Name:                "test",
+				Namespace:           "config-test",
+				SyslogNGSpec:        &v1beta1.SyslogNGSpec{EnabledIPv6: test.enabledIPv6},
+				SecretLoaderFactory: &TestSecretLoaderFactory{},
+			}, &buf)
+			require.NoError(t, err)
+			require.Contains(t, buf.String(), test.wantSource)
+		})
+	}
+}

--- a/pkg/sdk/logging/model/syslogng/config/source.go
+++ b/pkg/sdk/logging/model/syslogng/config/source.go
@@ -22,6 +22,7 @@ type NetworkSourceDriver struct {
 	__meta         struct{} `syslog-ng:"name=network"` //lint:ignore U1000 field used for adding tag to the type
 	Flags          []string `syslog-ng:"name=flags,optional"`
 	IP             string   `syslog-ng:"name=ip,optional"`
+	IPProtocol     int      `syslog-ng:"name=ip-protocol,optional"`
 	Port           uint16   `syslog-ng:"name=port,optional"`
 	Transport      string   `syslog-ng:"name=transport,optional"`
 	MaxConnections int      `syslog-ng:"name=max-connections,optional"`


### PR DESCRIPTION
## Summary

`enabledIPv6` produced Services the cluster could not accept, and listeners that did not
match those Services. Three regressions landed after 6.7.0, all from one shared helper.

`0321c1d2` changed the requested primary IP family from IPv4 to IPv6. Kubernetes does not
allow the primary family of an existing Service to change. It reports the refusal as
invalid, not as immutable, so operator-tools does not recognise it and never recreates the
Service. Upgrading a cluster with `enabledIPv6` left the fluentd or syslog-ng Service
failing to reconcile forever, which stalled every reconciler behind it.

The same helper also names a family outright. A cluster with no range for that family
rejects the Service at create, where there is no recovery path. This branch asks the API
server which families it can allocate, with a dry-run Service, and names only those. The
probe needs no new RBAC and has no version floor.

syslog-ng was affected differently. Its `network()` source never set `ip()`, so it listened
on IPv4 only while its Service became IPv6-primary. Fluent Bit resolved the Service to an
AAAA record and the connection reached a pod address with no listener. That took ingestion
down, not just metrics.

The last commits remove the cause. A `bind` address on the `Metrics` type decouples the
metrics endpoint from the Service IP families, so wanting IPv6 metrics no longer forces an
IPv6-primary Service. Three smaller defects found on the way are fixed too: the Fluent Bit
config used an invalid `Listen` key, the syslog-ng config-reloader listened on a port
nothing scraped, and the syslog-ng metrics service overrides were never read.

Context: #2100, #2238, #1835 and #2090 are all closed. #2100 was closed by the commit that
caused two of the regressions above.

## Test plan

Verified on a KIND cluster (v1.36.1, service CIDR `10.96.0.0/16`) and on envtest API
servers driving the real reconcilers.

- [x] `make lint && make test`
- [x] Upgrade a dual-stack cluster running 6.7.0 with `fluentd.enabledIPv6: true`. The
      Service reconciles and keeps its allocated addresses.
- [x] Install on a single-stack IPv4 cluster with `enabledIPv6: true`. Services are created
      and the Logging converges. The families the previous code asked for are rejected with
      `spec.ipFamilies[0]: Invalid value: "IPv6": not configured on this cluster`.
- [x] Install on an IPv6-only cluster with `enabledIPv6: true`. Services are created.
- [x] Send logs through syslog-ng with `syslogNG.enabledIPv6: true`. A message reaches the
      `ip("::") ip-protocol(6)` listener through an IPv4 Service.
- [x] Scrape the syslog-ng config-reloader on 9533.
- [x] Set `metrics.bind` and confirm it reaches the rendered aggregator config.

Not covered: there is no e2e suite for `enabledIPv6`, so the dual-stack IPv6-primary
ingestion path is verified only at the layers below a cluster. The bind was run against
`ghcr.io/axoflow/axosyslog:4.25.0` and the Services against envtest.