### PR TITLE
fix: adopt custom-runner v1.0.0

### DIFF
--- a/images/fluentd-drain-watch/drain-watch.sh
+++ b/images/fluentd-drain-watch/drain-watch.sh
@@ -64,7 +64,7 @@ do
     then
       if [ "$CUSTOM_RUNNER_AVAILABLE" = "true" ]
       then
-        echo '['$(date)']' 'exiting node exporter custom runner:' "$(curl --silent --show-error http://$CUSTOM_RUNNER_ADDRESS/exit)"
+        echo '['$(date)']' 'exiting node exporter custom runner:' "$(curl --silent --show-error -X POST http://$CUSTOM_RUNNER_ADDRESS/exit)"
       fi
       echo '['$(date)']' 'no buffers left, terminating workers:' "$(curl --silent --show-error http://$RPC_ADDRESS/api/processes.killWorkers)"
       WORKERS_KILLED=true

--- a/images/node-exporter/Dockerfile
+++ b/images/node-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/kube-logging/custom-runner:v0.16.0 AS custom-runner
+FROM ghcr.io/kube-logging/custom-runner:v1.0.0 AS custom-runner
 
 FROM quay.io/prometheus/node-exporter:v1.11.1
 

--- a/images/syslog-ng-reloader/Dockerfile
+++ b/images/syslog-ng-reloader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/kube-logging/custom-runner:v0.16.0 AS custom-runner
+FROM ghcr.io/kube-logging/custom-runner:v1.0.0 AS custom-runner
 
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 

--- a/pkg/resources/fluentbit/daemonset.go
+++ b/pkg/resources/fluentbit/daemonset.go
@@ -340,6 +340,9 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 			Image:           r.fluentbitSpec.BufferVolumeImage.RepositoryWithTag(),
 			ImagePullPolicy: corev1.PullPolicy(r.fluentbitSpec.BufferVolumeImage.PullPolicy),
 			Args: []string{
+				// This pod already has something on the runner's default metrics
+				// port, and the runner's own metrics are not scraped here.
+				"--metrics-port", "0",
 				"--exec", nodeExporterCmd,
 				"--exec", bufferSizeCmd,
 			},

--- a/pkg/resources/fluentd/statefulset.go
+++ b/pkg/resources/fluentd/statefulset.go
@@ -449,6 +449,9 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 			Image:           r.fluentdSpec.BufferVolumeImage.RepositoryWithTag(),
 			ImagePullPolicy: corev1.PullPolicy(r.fluentdSpec.BufferVolumeImage.PullPolicy),
 			Args: []string{
+				// This pod already has something on the runner's default metrics
+				// port, and the runner's own metrics are not scraped here.
+				"--metrics-port", "0",
 				"--exec", nodeExporterCmd,
 				"--exec", bufferSizeCmd,
 			},

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kube-logging/logging-operator/pkg/resources/kubetool"
 	"github.com/kube-logging/logging-operator/pkg/resources/model"
@@ -388,7 +389,19 @@ func configReloadContainer(spec *v1beta1.SyslogNGSpec) corev1.Container {
 			"-cfgjson",
 			generateConfigReloaderConfig(configDir),
 		},
-		Ports:        model.GeneratePortsConfigReloader(),
+		Ports: model.GeneratePortsConfigReloader(),
+		// A watch that fails to register leaves this container Running while it
+		// silently never reloads again. readyz is 503 in that state.
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.FromString(model.ConfigReloaderMetricsPortName),
+				},
+			},
+			PeriodSeconds:    10,
+			FailureThreshold: 3,
+		},
 		VolumeMounts: generateVolumeMounts(spec),
 	}
 

--- a/pkg/resources/syslogng/statefulset.go
+++ b/pkg/resources/syslogng/statefulset.go
@@ -290,6 +290,9 @@ func (r *Reconciler) bufferMetricsSidecarContainer() *corev1.Container {
 			Image:           r.syslogNGSpec.BufferVolumeMetricsImage.RepositoryWithTag(),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Args: []string{
+				// This pod already has something on the runner's default metrics
+				// port, and the runner's own metrics are not scraped here.
+				"--metrics-port", "0",
 				"--port", "7358",
 				"--exec", nodeExporterCmd,
 				"--exec", bufferSizeCmd,
@@ -379,6 +382,9 @@ func configReloadContainer(spec *v1beta1.SyslogNGSpec) corev1.Container {
 		Image:           spec.ConfigReloadImage.RepositoryWithTag(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args: []string{
+			// Metrics land on the port the Service exposes and the ServiceMonitor
+			// scrapes. The command API keeps its own default and stays on loopback.
+			"-metrics-port", fmt.Sprint(model.ConfigReloaderMetricsPort),
 			"-cfgjson",
 			generateConfigReloaderConfig(configDir),
 		},


### PR DESCRIPTION
Adopts [custom-runner v1.0.0](https://github.com/kube-logging/custom-runner/releases/tag/v1.0.0),
which changes the HTTP contract and moves metrics to their own listener.

> [!NOTE]
> The operator now passes `-metrics-port`, which only exists in custom-runner
> v1.0 — Go rejects unknown flags, so an older runner exits immediately with
> `flag provided but not defined`. CI rebuilds and republishes the sidecar images
> from the merge commit (`type=raw,value=latest,enable={{is_default_branch}}`), so
> the operator and its images move together automatically. This only bites someone
> who pins a sidecar image below `v1.0.0` by hand.

## What breaks without this

**Pods running two listeners on 9533 crash-loop.** v1.0 serves metrics on a
separate listener defaulting to `9533`:

| Pod | custom-runner containers | other `:9533` listener | collides |
|---|---|---|---|
| syslog-ng | `config-reloader`, `buffer-metrics-sidecar` | — (with each other) | when buffer metrics are enabled |
| fluentd | `buffer-metrics-sidecar` | `config-reloader` (always present) | when buffer metrics are enabled |
| fluentbit | `buffer-metrics-sidecar` | `config-reloader` (opt-in, `configHotReload`) | only with `configHotReload` |

```
metrics server: listen tcp 0.0.0.0:9533: bind: address already in use
```

**The fluentd drain never stopped the node exporter.** `drain-watch.sh` calls
`GET /exit`; v1.0 matches methods, so that returns `405`.

## Changes

- `drain-watch.sh` uses `-X POST` for `/exit`.
- Buffer-metrics sidecars pass `--metrics-port 0`. Nothing scraped the runner's
  own metrics there before, so this preserves current behaviour.
- The syslog-ng `config-reloader` publishes metrics on `ConfigReloaderMetricsPort`.
  **This fixes an existing bug**: `syslogng/service.go` already points a
  ServiceMonitor at 9533, but the runner served metrics on its command port, so
  that target has never returned data.
- The syslog-ng `config-reloader` gains a readiness probe on `/readyz`, new in
  v1.0. It returns 503 naming the path when a configured watch fails to register
  — the failure where the container stays Running while silently never reloading
  again. **Behaviour change:** a config volume mounted somewhere unexpected now
  blocks pod readiness instead of degrading silently.
- Image pins moved to `v1.0.0`.

## Compatibility audit

Every breaking change in the v1.0
[MIGRATION.md](https://github.com/kube-logging/custom-runner/blob/main/MIGRATION.md):

| Breaking change | Impact here |
|---|---|
| Mutating verbs require `POST` | `drain-watch` `/exit`, fixed. No other mutating calls |
| Metrics on their own listener | Fixed in all three workloads |
| Command API binds loopback | Safe. Only reached from inside the pod; probes target `buffer-metrics` (9200, node_exporter), and 7357/7358 appear in no Service or manifest |
| Process keys validated | `nodeexporter`, `buffersize`, `info`, `reload` all match |
| Images run as uid 65534 | N/A — the binary is copied into images that set their own `USER` |
| Single-object API responses | N/A — `drain-watch` never parses a body |
| Config rejects unknown keys | v1.0 accepts the exact `-cfgjson` from `generateConfigReloaderConfig` |
| `/config` returns typed output | Not used |

## Verification

On a KIND cluster, operator built from this branch, sidecar images rebuilt on
custom-runner v1.0:

- [x] `go build ./...`, `go test ./pkg/...`
- [x] **No restarts.** `cr-test-syslog-ng-0` 3/3 Running, 0 restarts; fluentbit
      2/2 with `buffer-metrics-sidecar`, 0 restarts
- [x] **Rendered args are correct** — `config-reloader: [-metrics-port 9533 -cfgjson ...]`,
      `buffer-metrics-sidecar: [--metrics-port 0 --exec ...]`
- [x] **`/metrics` on 9533 serves `sidecar_reloader_*`** from the live
      config-reloader — the ServiceMonitor target that previously returned nothing
- [x] **`/readyz` returns 200** on the live config-reloader; the probe passes
- [x] **Collision and fix reproduced directly**: a second runner in the same
      network namespace fails with `bind: address already in use`; with
      `--metrics-port 0` it starts clean
- [x] v1.0 accepts the generated `-cfgjson` (negative control: a typo is rejected)
- [x] **fluentd drain end to end** — ran the real `drain-watch.sh` against a live
      v1.0 runner with a stubbed fluentd RPC: the script polls the runner, posts
      `/exit`, kills workers and exits 0, and the runner exits 0 with it.
      Negative control: the previous `GET /exit` returns `405` and leaves the
      runner running, i.e. the node exporter was never being stopped
