### PR TITLE
Enable the modernize analyzer and apply it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters:
     - errcheck
     - ineffassign
     - misspell
+    - modernize
     - nolintlint
     - revive
     - gocyclo

--- a/e2e/common/setup/loggingoperator.go
+++ b/e2e/common/setup/loggingoperator.go
@@ -87,7 +87,7 @@ func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOpti
 	}
 	actionConfig := new(action.Configuration)
 
-	if err := actionConfig.Init(restClientGetter, opt.Namespace, "memory", func(format string, v ...interface{}) {
+	if err := actionConfig.Init(restClientGetter, opt.Namespace, "memory", func(format string, v ...any) {
 		t.Logf(format, v...)
 	}); err != nil {
 		t.Fatalf("helm action config init: %s", err)
@@ -129,29 +129,29 @@ func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOpti
 		t.Fatalf("kind load images: %s", err)
 	}
 
-	_, err = installer.Run(chartReq, map[string]interface{}{
+	_, err = installer.Run(chartReq, map[string]any{
 		"nameOverride": opt.NameOverride,
-		"image": map[string]interface{}{
+		"image": map[string]any{
 			"repository": loggingOperatorImage.repository,
 			"tag":        loggingOperatorImage.tag,
 			"pullPolicy": corev1.PullNever,
 		},
-		"testReceiver": map[string]interface{}{
+		"testReceiver": map[string]any{
 			"enabled": true,
 		},
-		"volumes": []map[string]interface{}{
+		"volumes": []map[string]any{
 			{
 				"name":     "coverage-data",
 				"emptyDir": map[string]string{},
 			},
 		},
-		"volumeMounts": []map[string]interface{}{
+		"volumeMounts": []map[string]any{
 			{
 				"mountPath": "/covdatafiles",
 				"name":      "coverage-data",
 			},
 		},
-		"env": []map[string]interface{}{
+		"env": []map[string]any{
 			{
 				"name":  "GOCOVERDIR",
 				"value": "/covdatafiles",

--- a/e2e/fluentd-aggregator/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator/fluentd_aggregator_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -412,11 +413,9 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 				return false
 			}
 			if logging.Status.ProblemsCount > 0 {
-				for _, problem := range logging.Status.Problems {
-					if configCheckFailure.MatchString(problem) {
-						t.Logf("Found the problem in Logging status: %v", logging.Status)
-						return true
-					}
+				if slices.ContainsFunc(logging.Status.Problems, configCheckFailure.MatchString) {
+					t.Logf("Found the problem in Logging status: %v", logging.Status)
+					return true
 				}
 			}
 			t.Logf("Waiting for the problem to appear in Logging status: %v", logging.Status.Problems)
@@ -433,11 +432,9 @@ func TestFluentdAggregator_ConfigChecks(t *testing.T) {
 				return false
 			}
 			if logging.Status.ProblemsCount > 0 {
-				for _, problem := range logging.Status.Problems {
-					if configCheckFailure.MatchString(problem) {
-						t.Logf("Waiting for the problem to be cleared in Logging status: %v", logging.Status.Problems)
-						return false
-					}
+				if slices.ContainsFunc(logging.Status.Problems, configCheckFailure.MatchString) {
+					t.Logf("Waiting for the problem to be cleared in Logging status: %v", logging.Status.Problems)
+					return false
 				}
 			}
 			t.Logf("Problem cleared in Logging status: %v", logging.Status)

--- a/pkg/sdk/extensions/api/v1alpha1/eventtailer_types.go
+++ b/pkg/sdk/extensions/api/v1alpha1/eventtailer_types.go
@@ -27,12 +27,12 @@ import (
 
 // +name:"EventTailer"
 // +weight:"200"
-type _hugoEventTailer = interface{} //nolint:deadcode,unused
+type _hugoEventTailer = any //nolint:deadcode,unused
 
 // +name:"EventTailer"
 // +version:"v1alpha1"
 // +description:"Eventtailer's main goal is to listen kubernetes events and transmit their changes to stdout. This way the logging-operator is able to process them."
-type _metaEventTailer = interface{} //nolint:deadcode,unused
+type _metaEventTailer = any //nolint:deadcode,unused
 
 // EventTailerSpec defines the desired state of EventTailer
 type EventTailerSpec struct {

--- a/pkg/sdk/extensions/api/v1alpha1/hosttailer_types.go
+++ b/pkg/sdk/extensions/api/v1alpha1/hosttailer_types.go
@@ -26,12 +26,12 @@ import (
 
 // +name:"HostTailer"
 // +weight:"200"
-type _hugoHostTailer = interface{} //nolint:deadcode,unused
+type _hugoHostTailer = any //nolint:deadcode,unused
 
 // +name:"HostTailer"
 // +version:"v1alpha1"
 // +description:"HostTailer's main goal is to tail custom files and transmit their changes to stdout. This way the logging-operator is able to process them."
-type _metaHostTailer = interface{} //nolint:deadcode,unused
+type _metaHostTailer = any //nolint:deadcode,unused
 
 // HostTailerSpec defines the desired state of HostTailer
 type HostTailerSpec struct {

--- a/pkg/sdk/extensions/extensionsconfig/config_test.go
+++ b/pkg/sdk/extensions/extensionsconfig/config_test.go
@@ -96,7 +96,6 @@ func TestFluentBitConfigFilePath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if got := fluentBitConfigFilePath(tt.args.image, tt.args.filePath); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("FluentBitConfigFilePath() = %v, want %v", got, tt.want)

--- a/pkg/sdk/logging/api/v1alpha1/clusterflow_types.go
+++ b/pkg/sdk/logging/api/v1alpha1/clusterflow_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"ClusterFlow"
 // +weight:"200"
-type _hugoClusterFlow interface{} //nolint:deadcode,unused
+type _hugoClusterFlow any //nolint:deadcode,unused
 
 // +name:"ClusterFlow"
 // +version:"v1alpha1"
 // +description:"ClusterFlow is the Schema for the clusterflows API"
-type _metaClusterFlow interface{} //nolint:deadcode,unused
+type _metaClusterFlow any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1alpha1/clusteroutput_types.go
+++ b/pkg/sdk/logging/api/v1alpha1/clusteroutput_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"ClusterOutput"
 // +weight:"200"
-type _hugoClusterOutput interface{} //nolint:deadcode,unused
+type _hugoClusterOutput any //nolint:deadcode,unused
 
 // +name:"ClusterOutput"
 // +version:"v1alpha1"
 // +description:"ClusterOutput is the Schema for the clusteroutputs API"
-type _metaClusterOutput interface{} //nolint:deadcode,unused
+type _metaClusterOutput any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1alpha1/output_types.go
+++ b/pkg/sdk/logging/api/v1alpha1/output_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"OutputSpec"
 // +weight:"200"
-type _hugoOutputSpec interface{} //nolint:deadcode,unused
+type _hugoOutputSpec any //nolint:deadcode,unused
 
 // +name:"OutputSpec"
 // +version:"v1alpha1"
 // +description:"OutputSpec defines the desired state of Output"
-type _metaOutputSpec interface{} //nolint:deadcode,unused
+type _metaOutputSpec any //nolint:deadcode,unused
 
 // OutputSpec defines the desired state of Output
 type OutputSpec struct {

--- a/pkg/sdk/logging/api/v1beta1/clusterflow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/clusterflow_types.go
@@ -20,12 +20,12 @@ import (
 
 // +name:"ClusterFlow"
 // +weight:"200"
-type _hugoClusterFlow interface{} //nolint:deadcode,unused
+type _hugoClusterFlow any //nolint:deadcode,unused
 
 // +name:"ClusterFlow"
 // +version:"v1beta1"
 // +description:"ClusterFlow is the Schema for the clusterflows API"
-type _metaClusterFlow interface{} //nolint:deadcode,unused
+type _metaClusterFlow any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1beta1/clusteroutput_types.go
+++ b/pkg/sdk/logging/api/v1beta1/clusteroutput_types.go
@@ -20,12 +20,12 @@ import (
 
 // +name:"ClusterOutput"
 // +weight:"200"
-type _hugoClusterOutput interface{} //nolint:deadcode,unused
+type _hugoClusterOutput any //nolint:deadcode,unused
 
 // +name:"ClusterOutput"
 // +version:"v1beta1"
 // +description:"ClusterOutput is the Schema for the clusteroutputs API"
-type _metaClusterOutput interface{} //nolint:deadcode,unused
+type _metaClusterOutput any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1beta1/common_types.go
+++ b/pkg/sdk/logging/api/v1beta1/common_types.go
@@ -24,12 +24,12 @@ import (
 
 // +name:"Common"
 // +weight:"200"
-type _hugoCommon interface{} //nolint:deadcode,unused
+type _hugoCommon any //nolint:deadcode,unused
 
 // +name:"Common"
 // +version:"v1beta1"
 // +description:"ImageSpec Metrics Security"
-type _metaCommon interface{} //nolint:deadcode,unused
+type _metaCommon any //nolint:deadcode,unused
 
 const (
 	HostPath = "/opt/logging-operator/%s/%s"

--- a/pkg/sdk/logging/api/v1beta1/flow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/flow_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"FlowSpec"
 // +weight:"200"
-type _hugoFlowSpec interface{} //nolint:deadcode,unused
+type _hugoFlowSpec any //nolint:deadcode,unused
 
 // +name:"FlowSpec"
 // +version:"v1beta1"
 // +description:"FlowSpec is the Kubernetes spec for Flows"
-type _metaFlowSpec interface{} //nolint:deadcode,unused
+type _metaFlowSpec any //nolint:deadcode,unused
 
 // FlowSpec is the Kubernetes spec for Flows
 type FlowSpec struct {

--- a/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentbit_types.go
@@ -28,12 +28,12 @@ import (
 
 // +name:"FluentbitSpec"
 // +weight:"200"
-type _hugoFluentbitSpec interface{} //nolint:deadcode,unused
+type _hugoFluentbitSpec any //nolint:deadcode,unused
 
 // +name:"FluentbitSpec"
 // +version:"v1beta1"
 // +description:"FluentbitSpec defines the desired state of FluentbitAgent"
-type _metaFluentbitSpec interface{} //nolint:deadcode,unused
+type _metaFluentbitSpec any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -515,7 +515,7 @@ type Operation struct {
 	Value string `json:"Value,omitempty"`
 }
 
-func getOperation(c interface{}) (result Operation) {
+func getOperation(c any) (result Operation) {
 	vc := reflect.ValueOf(c)
 	for i := 0; i < vc.NumField(); i++ {
 		field := vc.Field(i)

--- a/pkg/sdk/logging/api/v1beta1/fluentd_config_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_config_types.go
@@ -20,12 +20,12 @@ import (
 
 // +name:"FluentdConfig"
 // +weight:"200"
-type _hugoFluent interface{} //nolint:deadcode,unused
+type _hugoFluent any //nolint:deadcode,unused
 
 // +name:"Fluent"
 // +version:"v1beta1"
 // +description:"FluentdConfig is a reference to the desired Fluentd state"
-type _metaFluentdConfig interface{} //nolint:deadcode,unused
+type _metaFluentdConfig any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1beta1/fluentd_types.go
+++ b/pkg/sdk/logging/api/v1beta1/fluentd_types.go
@@ -31,12 +31,12 @@ import (
 
 // +name:"FluentdSpec"
 // +weight:"200"
-type _hugoFluentdSpec interface{} //nolint:deadcode,unused
+type _hugoFluentdSpec any //nolint:deadcode,unused
 
 // +name:"FluentdSpec"
 // +version:"v1beta1"
 // +description:"FluentdSpec defines the desired state of Fluentd"
-type _metaFluentdSpec interface{} //nolint:deadcode,unused
+type _metaFluentdSpec any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 
@@ -268,7 +268,7 @@ func (f *FluentdSpec) SetDefaults() error { //nolint: gocyclo
 				}
 			}
 			if f.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeClaimSpec.VolumeMode == nil {
-				f.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeClaimSpec.VolumeMode = persistentVolumeModePointer(corev1.PersistentVolumeFilesystem)
+				f.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeClaimSpec.VolumeMode = new(corev1.PersistentVolumeFilesystem)
 			}
 			if f.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeSource.ClaimName == "" {
 				f.BufferStorageVolume.PersistentVolumeClaim.PersistentVolumeSource.ClaimName = DefaultFluentdBufferStorageVolumeName

--- a/pkg/sdk/logging/api/v1beta1/logging_types.go
+++ b/pkg/sdk/logging/api/v1beta1/logging_types.go
@@ -30,7 +30,7 @@ import (
 
 // +name:"LoggingSpec"
 // +weight:"200"
-type _hugoLoggingSpec interface{} //nolint:deadcode,unused
+type _hugoLoggingSpec any //nolint:deadcode,unused
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -38,7 +38,7 @@ type _hugoLoggingSpec interface{} //nolint:deadcode,unused
 // +name:"Logging"
 // +version:"v1beta1"
 // +description:"Logging system configuration"
-type _metaLoggingSpec interface{} //nolint:deadcode,unused
+type _metaLoggingSpec any //nolint:deadcode,unused
 
 // LoggingSpec defines the desired state of Logging
 type LoggingSpec struct {
@@ -568,10 +568,6 @@ func (l *Logging) ClusterDomainAsSuffix() string {
 		return ""
 	}
 	return fmt.Sprintf(".%s", *l.Spec.ClusterDomain)
-}
-
-func persistentVolumeModePointer(mode corev1.PersistentVolumeMode) *corev1.PersistentVolumeMode {
-	return &mode
 }
 
 // FluentdObjectMeta creates an objectMeta for resource fluentd

--- a/pkg/sdk/logging/api/v1beta1/loggingroute_types.go
+++ b/pkg/sdk/logging/api/v1beta1/loggingroute_types.go
@@ -18,12 +18,12 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // +name:"LoggingRouteSpec"
 // +weight:"200"
-type _hugoLoggingRouteSpec interface{} //nolint:deadcode,unused
+type _hugoLoggingRouteSpec any //nolint:deadcode,unused
 
 // +name:"LoggingRouteSpec"
 // +version:"v1beta1"
 // +description:"LoggingRouteSpec defines the desired state of LoggingRoute"
-type _metaLoggingRouteSpec interface{} //nolint:deadcode,unused
+type _metaLoggingRouteSpec any //nolint:deadcode,unused
 
 // LoggingRouteSpec defines the desired state of LoggingRoute
 type LoggingRouteSpec struct {

--- a/pkg/sdk/logging/api/v1beta1/output_types.go
+++ b/pkg/sdk/logging/api/v1beta1/output_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"OutputSpec"
 // +weight:"200"
-type _hugoOutputSpec interface{} //nolint:deadcode,unused
+type _hugoOutputSpec any //nolint:deadcode,unused
 
 // +name:"OutputSpec"
 // +version:"v1beta1"
 // +description:"OutputSpec defines the desired state of Output"
-type _metaOutputSpec interface{} //nolint:deadcode,unused
+type _metaOutputSpec any //nolint:deadcode,unused
 
 // OutputSpec defines the desired state of Output
 type OutputSpec struct {

--- a/pkg/sdk/logging/api/v1beta1/suite_test.go
+++ b/pkg/sdk/logging/api/v1beta1/suite_test.go
@@ -51,7 +51,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	done := make(chan interface{})
+	done := make(chan any)
 	go func() {
 		zapLog, err := zap.NewDevelopment(zap.ErrorOutput(zapcore.AddSync(GinkgoWriter)))
 		if err != nil {

--- a/pkg/sdk/logging/api/v1beta1/syslogng_clusterflow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_clusterflow_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"SyslogNGClusterFlow"
 // +weight:"200"
-type _hugoSyslogNGClusterFlow interface{} //nolint:deadcode,unused
+type _hugoSyslogNGClusterFlow any //nolint:deadcode,unused
 
 // +name:"SyslogNGClusterFlow"
 // +version:"v1beta1"
 // +description:"SyslogNGClusterFlow is the Schema for the syslog-ng clusterflows API"
-type _metaSyslogNGClusterFlow interface{} //nolint:deadcode,unused
+type _metaSyslogNGClusterFlow any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1beta1/syslogng_clusteroutput_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_clusteroutput_types.go
@@ -20,12 +20,12 @@ import (
 
 // +name:"SyslogNGClusterOutput"
 // +weight:"200"
-type _hugoSyslogNGClusterOutput interface{} //nolint:deadcode,unused
+type _hugoSyslogNGClusterOutput any //nolint:deadcode,unused
 
 // +name:"SyslogNGClusterOutput"
 // +version:"v1beta1"
 // +description:"SyslogNGClusterOutput is the Schema for the syslog-ng clusteroutputs API"
-type _metaSyslogNGClusterOutput interface{} //nolint:deadcode,unused
+type _metaSyslogNGClusterOutput any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1beta1/syslogng_config_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_config_types.go
@@ -20,12 +20,12 @@ import (
 
 // +name:"SyslogNGConfig"
 // +weight:"200"
-type _hugoSyslogNGConfig interface{} //nolint:deadcode,unused
+type _hugoSyslogNGConfig any //nolint:deadcode,unused
 
 // +name:"SyslogNG"
 // +version:"v1beta1"
 // +description:"SyslogNGConfig is a standalone reference to the desired SyslogNG configuration"
-type _metaSyslogNGConfig interface{} //nolint:deadcode,unused
+type _metaSyslogNGConfig any //nolint:deadcode,unused
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:categories=logging-all

--- a/pkg/sdk/logging/api/v1beta1/syslogng_flow_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_flow_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"SyslogNGFlowSpec"
 // +weight:"200"
-type _hugoSyslogNGFlowSpec interface{} //nolint:deadcode,unused
+type _hugoSyslogNGFlowSpec any //nolint:deadcode,unused
 
 // +name:"SyslogNGFlowSpec"
 // +version:"v1beta1"
 // +description:"SyslogNGFlowSpec is the Kubernetes spec for SyslogNGFlows"
-type _metaSyslogNGFlowSpec interface{} //nolint:deadcode,unused
+type _metaSyslogNGFlowSpec any //nolint:deadcode,unused
 
 // SyslogNGFlowSpec is the Kubernetes spec for SyslogNGFlows
 type SyslogNGFlowSpec struct {

--- a/pkg/sdk/logging/api/v1beta1/syslogng_output_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_output_types.go
@@ -22,12 +22,12 @@ import (
 
 // +name:"SyslogNGOutputSpec"
 // +weight:"200"
-type _hugoSyslogNGOutputSpec interface{} //nolint:deadcode,unused
+type _hugoSyslogNGOutputSpec any //nolint:deadcode,unused
 
 // +name:"SyslogNGOutputSpec"
 // +version:"v1beta1"
 // +description:"SyslogNGOutputSpec defines the desired state of SyslogNGOutput"
-type _metaSyslogNGOutputSpec interface{} //nolint:deadcode,unused
+type _metaSyslogNGOutputSpec any //nolint:deadcode,unused
 
 // SyslogNGOutputSpec defines the desired state of SyslogNGOutput
 type SyslogNGOutputSpec struct {

--- a/pkg/sdk/logging/api/v1beta1/syslogng_types.go
+++ b/pkg/sdk/logging/api/v1beta1/syslogng_types.go
@@ -25,12 +25,12 @@ import (
 
 // +name:"SyslogNGSpec"
 // +weight:"200"
-type _hugoSyslogNGSpec interface{} //nolint:deadcode,unused
+type _hugoSyslogNGSpec any //nolint:deadcode,unused
 
 // +name:"SyslogNGSpec"
 // +version:"v1beta1"
 // +description:"SyslogNGSpec defines the desired state of SyslogNG"
-type _metaSyslogNGSpec interface{} //nolint:deadcode,unused
+type _metaSyslogNGSpec any //nolint:deadcode,unused
 
 const (
 	defaultSyslogngImageRepository           = "ghcr.io/axoflow/axosyslog"

--- a/pkg/sdk/logging/maps/mapstrstr/helpers.go
+++ b/pkg/sdk/logging/maps/mapstrstr/helpers.go
@@ -14,6 +14,8 @@
 
 package mapstrstr
 
+import "maps"
+
 // Keys returns the keys of a map[string]string
 func Keys(m map[string]string) []string {
 	keys := make([]string, 0, len(m))
@@ -28,9 +30,7 @@ func MergeInto(dst, src map[string]string) map[string]string {
 		if dst == nil {
 			dst = make(map[string]string)
 		}
-		for k, v := range src {
-			dst[k] = v
-		}
+		maps.Copy(dst, src)
 	}
 	return dst
 }

--- a/pkg/sdk/logging/model/common/security.go
+++ b/pkg/sdk/logging/model/common/security.go
@@ -22,10 +22,10 @@ import (
 
 // +name:"Security"
 // +weight:"200"
-type _hugoSecurity interface{} //nolint:deadcode,unused
+type _hugoSecurity any //nolint:deadcode,unused
 
 // +name:"Security"
-type _metaSecurity interface{} //nolint:deadcode,unused
+type _metaSecurity any //nolint:deadcode,unused
 
 type Security struct {
 	// Hostname

--- a/pkg/sdk/logging/model/common/transport.go
+++ b/pkg/sdk/logging/model/common/transport.go
@@ -22,10 +22,10 @@ import (
 
 // +name:"Transport"
 // +weight:"200"
-type _hugoTransport interface{} //nolint:deadcode,unused
+type _hugoTransport any //nolint:deadcode,unused
 
 // +name:"Transport"
-type _metaTransport interface{} //nolint:deadcode,unused
+type _metaTransport any //nolint:deadcode,unused
 
 type Transport struct {
 	// Protocol Default: :tcp

--- a/pkg/sdk/logging/model/filter/concat.go
+++ b/pkg/sdk/logging/model/filter/concat.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Concat"
 // +weight:"200"
-type _hugoConcat interface{} //nolint:deadcode,unused
+type _hugoConcat any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Concat Filter](https://github.com/fluent-plugins-nursery/fluent-plugin-concat)"
 // Fluentd Filter plugin to concatenate multiline log separated in multiple events.
-type _docConcat interface{} //nolint:deadcode,unused
+type _docConcat any //nolint:deadcode,unused
 
 // +name:"Concat"
 // +url:"https://github.com/fluent-plugins-nursery/fluent-plugin-concat"
 // +version:"2.5.0"
 // +description:"Fluentd Filter plugin to concatenate multiline log separated in multiple events."
 // +status:"GA"
-type _metaConcat interface{} //nolint:deadcode,unused
+type _metaConcat any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type Concat struct {
@@ -111,7 +111,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expConcat interface{} //nolint:deadcode,unused
+type _expConcat any //nolint:deadcode,unused
 
 func (c *Concat) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "concat"

--- a/pkg/sdk/logging/model/filter/dedot.go
+++ b/pkg/sdk/logging/model/filter/dedot.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Dedot"
 // +weight:"200"
-type _hugoDedot interface{} //nolint:deadcode,unused
+type _hugoDedot any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Dedot Filter](https://github.com/lunardial/fluent-plugin-dedot_filter)"
 // Fluentd Filter plugin to de-dot field name for elasticsearch.
-type _docDedot interface{} //nolint:deadcode,unused
+type _docDedot any //nolint:deadcode,unused
 
 // +name:"Dedot"
 // +url:"https://github.com/lunardial/fluent-plugin-dedot_filter"
 // +version:"1.0.0"
 // +description:"Fluentd Filter plugin to de-dot field name for elasticsearch"
 // +status:"GA"
-type _metaDedot interface{} //nolint:deadcode,unused
+type _metaDedot any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type DedotFilterConfig struct {
@@ -74,7 +74,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expDedot interface{} //nolint:deadcode,unused
+type _expDedot any //nolint:deadcode,unused
 
 func NewDedotFilterConfig() *DedotFilterConfig {
 	return &DedotFilterConfig{}

--- a/pkg/sdk/logging/model/filter/detect_exceptions.go
+++ b/pkg/sdk/logging/model/filter/detect_exceptions.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Exception Detector"
 // +weight:"200"
-type _hugoExceptionDetector interface{} //nolint:deadcode,unused
+type _hugoExceptionDetector any //nolint:deadcode,unused
 
 // +docName:"Exception Detector"
 /*
@@ -39,14 +39,14 @@ filters:
     multiline_flush_interval: 0.1
 ```
 */
-type _docExceptionDetector interface{} //nolint:deadcode,unused
+type _docExceptionDetector any //nolint:deadcode,unused
 
 // +name:"Exception Detector"
 // +url:"https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions"
 // +version:"0.0.14"
 // +description:"Exception Detector"
 // +status:"GA"
-type _metaDDetectExceptions interface{} //nolint:deadcode,unused
+type _metaDDetectExceptions any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type DetectExceptions struct {
@@ -103,7 +103,7 @@ Fluentd config result:
 </match>
 {{</ highlight >}}
 */
-type _expDetectExceptions interface{} //nolint:deadcode,unused
+type _expDetectExceptions any //nolint:deadcode,unused
 
 func (d *DetectExceptions) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "detect_exceptions"

--- a/pkg/sdk/logging/model/filter/elasticsearch_genid.go
+++ b/pkg/sdk/logging/model/filter/elasticsearch_genid.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"ElasticSearch GenId"
 // +weight:"200"
-type _hugoElasticsearchGenId interface{} //nolint:deadcode,unused
+type _hugoElasticsearchGenId any //nolint:deadcode,unused
 
 // +docName:"ElasticSearch GenId"
 /*
@@ -52,13 +52,13 @@ Fluentd Config Result
 </filter>
 {{</ highlight >}}
 */
-type _docElasticsearchGenId interface{} //nolint:deadcode,unused
+type _docElasticsearchGenId any //nolint:deadcode,unused
 
 // +name:"ElasticSearch GenId"
 // +url:"TODO"
 // +description:""
 // +status:""
-type _metaElasticsearchGenId interface{} //nolint:deadcode,unused
+type _metaElasticsearchGenId any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type ElasticsearchGenId struct {

--- a/pkg/sdk/logging/model/filter/geoip.go
+++ b/pkg/sdk/logging/model/filter/geoip.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Geo IP"
 // +weight:"200"
-type _hugoGeoIP interface{} //nolint:deadcode,unused
+type _hugoGeoIP any //nolint:deadcode,unused
 
 // +docName:"Fluentd GeoIP filter"
 // Fluentd Filter plugin to add information about geographical location of IP addresses with Maxmind GeoIP databases.
 // More information at https://github.com/y-ken/fluent-plugin-geoip
-type _docGeoIP interface{} //nolint:deadcode,unused
+type _docGeoIP any //nolint:deadcode,unused
 
 // +name:"Geo IP"
 // +url:"https://github.com/y-ken/fluent-plugin-geoip"
 // +version:"1.3.2"
 // +description:"Fluentd GeoIP filter"
 // +status:"GA"
-type _metaGeoIP interface{} //nolint:deadcode,unused
+type _metaGeoIP any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type GeoIP struct {
@@ -94,7 +94,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expGeoIP interface{} //nolint:deadcode,unused
+type _expGeoIP any //nolint:deadcode,unused
 
 func (g *GeoIP) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "geoip"

--- a/pkg/sdk/logging/model/filter/grep.go
+++ b/pkg/sdk/logging/model/filter/grep.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Grep"
 // +weight:"200"
-type _hugoGrep interface{} //nolint:deadcode,unused
+type _hugoGrep any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Grep Filter](https://docs.fluentd.org/filter/grep)"
 // The grep filter plugin "greps" events by the values of specified fields.
-type _docGrep interface{} //nolint:deadcode,unused
+type _docGrep any //nolint:deadcode,unused
 
 // +name:"Grep"
 // +url:"https://docs.fluentd.org/filter/grep"
 // +version:"more info"
 // +description:"Grep events by the values"
 // +status:"GA"
-type _metaGrep interface{} //nolint:deadcode,unused
+type _metaGrep any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type GrepConfig struct {
@@ -91,7 +91,7 @@ Fluentd config result:
   </filter>
 {{</ highlight >}}
 */
-type _expRegexp interface{} //nolint:deadcode,unused
+type _expRegexp any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Exclude Directive"
@@ -136,7 +136,7 @@ Fluentd config result:
   </filter>
 {{</ highlight >}}
 */
-type _expExclude interface{} //nolint:deadcode,unused
+type _expExclude any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Or Directive"
@@ -187,7 +187,7 @@ Fluentd config result:
 </or>
 {{</ highlight >}}
 */
-type _expOR interface{} //nolint:deadcode,unused
+type _expOR any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"And Directive"
@@ -238,7 +238,7 @@ Fluentd config result:
 	</and>
 {{</ highlight >}}
 */
-type _expAND interface{} //nolint:deadcode,unused
+type _expAND any //nolint:deadcode,unused
 
 func (r *RegexpSection) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	meta := types.PluginMeta{

--- a/pkg/sdk/logging/model/filter/kube_events_timestamp.go
+++ b/pkg/sdk/logging/model/filter/kube_events_timestamp.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Kubernetes Events Timestamp"
 // +weight:"200"
-type _hugoKubeEventsTimestamp interface{} //nolint:deadcode,unused
+type _hugoKubeEventsTimestamp any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Kubernetes Events Timestamp Filter](https://github.com/kube-logging/fluentd-filter-kube-events-timestamp)"
 // Fluentd Filter plugin to select particular timestamp into an additional field
-type _docKubeEventsTimestamp interface{} //nolint:deadcode,unused
+type _docKubeEventsTimestamp any //nolint:deadcode,unused
 
 // +name:"Kubernetes Events Timestamp"
 // +url:"https://github.com/kube-logging/fluentd-filter-kube-events-timestamp"
 // +version:"0.1.4"
 // +description:"Fluentd Filter plugin to select particular timestamp into an additional field"
 // +status:"GA"
-type _metaKubeEventsTimestamp interface{} //nolint:deadcode,unused
+type _metaKubeEventsTimestamp any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type KubeEventsTimestampConfig struct {
@@ -77,7 +77,7 @@ Fluentd config result:
  </filter>
 {{</ highlight >}}
 */
-type _expKubeEventsTimestamp interface{} //nolint:deadcode,unused
+type _expKubeEventsTimestamp any //nolint:deadcode,unused
 
 func NewKubeEventsTimestampConfig() *KubeEventsTimestampConfig {
 	return &KubeEventsTimestampConfig{}

--- a/pkg/sdk/logging/model/filter/parser.go
+++ b/pkg/sdk/logging/model/filter/parser.go
@@ -25,19 +25,19 @@ import (
 
 // +name:"Parser"
 // +weight:"200"
-type _hugoParser interface{} //nolint:deadcode,unused
+type _hugoParser any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Parser Filter](https://docs.fluentd.org/filter/parser)"
 // Parses a string field in event records and mutates its event record with the parsed result.
-type _docParser interface{} //nolint:deadcode,unused
+type _docParser any //nolint:deadcode,unused
 
 // +name:"Parser"
 // +url:"https://docs.fluentd.org/filter/parser"
 // +version:"more info"
 // +description:"Parses a string field in event records and mutates its event record with the parsed result."
 // +status:"GA"
-type _metaParser interface{} //nolint:deadcode,unused
+type _metaParser any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type ParserConfig struct {
@@ -256,7 +256,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expParser interface{} //nolint:deadcode,unused
+type _expParser any //nolint:deadcode,unused
 
 func (p *SingleParseSection) ToPatternDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	parseSection := &types.GenericDirective{

--- a/pkg/sdk/logging/model/filter/prometheus.go
+++ b/pkg/sdk/logging/model/filter/prometheus.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Prometheus"
 // +weight:"200"
-type _hugoPrometheus interface{} //nolint:deadcode,unused
+type _hugoPrometheus any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Prometheus Filter](https://github.com/fluent/fluent-plugin-prometheus#prometheus-outputfilter-plugin)"
 // Prometheus Filter Plugin to count Incoming Records
-type _docPrometheus interface{} //nolint:deadcode,unused
+type _docPrometheus any //nolint:deadcode,unused
 
 // +name:"Prometheus"
 // +url:"https://github.com/fluent/fluent-plugin-prometheus#prometheus-outputfilter-plugin"
 // +version:"2.0.2"
 // +description:"Prometheus Filter Plugin to count Incoming Records"
 // +status:"GA"
-type _metaPrometheus interface{} //nolint:deadcode,unused
+type _metaPrometheus any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type PrometheusConfig struct {
@@ -115,7 +115,7 @@ Fluentd config result:
   </filter>
 {{</ highlight >}}
 */
-type _expPrometheus interface{} //nolint:deadcode,unused
+type _expPrometheus any //nolint:deadcode,unused
 
 type Label map[string]string
 

--- a/pkg/sdk/logging/model/filter/raw.go
+++ b/pkg/sdk/logging/model/filter/raw.go
@@ -27,7 +27,7 @@ import (
 
 // +name:"Raw"
 // +weight:"200"
-type _hugoRaw interface{} //nolint:deadcode,unused
+type _hugoRaw any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Raw"
@@ -104,14 +104,14 @@ Fluentd Config Result
 {{</ highlight >}}
 
 */
-type _docRaw interface{} //nolint:deadcode,unused
+type _docRaw any //nolint:deadcode,unused
 
 // +name:"Raw"
 // +url:""
 // +version:""
 // +description:"Configure raw filter."
 // +status:""
-type _metaRaw interface{} //nolint:deadcode,unused
+type _metaRaw any //nolint:deadcode,unused
 
 var (
 	sectionPattern = regexp.MustCompile(`^<([^\s>/]+)\s*([^>]*)>$`)

--- a/pkg/sdk/logging/model/filter/record_modifier.go
+++ b/pkg/sdk/logging/model/filter/record_modifier.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Record Modifier"
 // +weight:"200"
-type _hugoRecordModifier interface{} //nolint:deadcode,unused
+type _hugoRecordModifier any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Record Modifier](https://github.com/repeatedly/fluent-plugin-record-modifier)"
 // Modify each event record.
-type _docRecordModifier interface{} //nolint:deadcode,unused
+type _docRecordModifier any //nolint:deadcode,unused
 
 // +name:"Record Modifier"
 // +url:"https://github.com/repeatedly/fluent-plugin-record-modifier"
 // +version:"2.1.0"
 // +description:"Modify each event record."
 // +status:"GA"
-type _metaRecordModifier interface{} //nolint:deadcode,unused
+type _metaRecordModifier any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type RecordModifier struct {
@@ -84,7 +84,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expRecordModifier interface{} //nolint:deadcode,unused
+type _expRecordModifier any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Replace Directive](https://github.com/repeatedly/fluent-plugin-record-modifier#replace_keys_value)"

--- a/pkg/sdk/logging/model/filter/record_transformer.go
+++ b/pkg/sdk/logging/model/filter/record_transformer.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Record Transformer"
 // +weight:"200"
-type _hugoRecordTransformer interface{} //nolint:deadcode,unused
+type _hugoRecordTransformer any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Record Transformer](https://docs.fluentd.org/filter/record_transformer)"
 // Mutates/transforms incoming event streams.
-type _docRecordTransformer interface{} //nolint:deadcode,unused
+type _docRecordTransformer any //nolint:deadcode,unused
 
 // +name:"Record Transformer"
 // +url:"https://docs.fluentd.org/filter/record_transformer"
 // +version:"more info"
 // +description:"Mutates/transforms incoming event streams."
 // +status:"GA"
-type _metaRecordTransformer interface{} //nolint:deadcode,unused
+type _metaRecordTransformer any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type RecordTransformer struct {
@@ -86,7 +86,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expRecordTransformer interface{} //nolint:deadcode,unused
+type _expRecordTransformer any //nolint:deadcode,unused
 
 // Parameters inside record directives are considered to be new key-value pairs
 type Record map[string]string

--- a/pkg/sdk/logging/model/filter/stdout.go
+++ b/pkg/sdk/logging/model/filter/stdout.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"StdOut"
 // +weight:"200"
-type _hugoStdOut interface{} //nolint:deadcode,unused
+type _hugoStdOut any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Stdout Filter](https://docs.fluentd.org/filter/stdout)"
 // Fluentd Filter plugin to print events to stdout
-type _docStdOut interface{} //nolint:deadcode,unused
+type _docStdOut any //nolint:deadcode,unused
 
 // +name:"Stdout"
 // +url:"https://docs.fluentd.org/filter/stdout"
 // +version:"more info"
 // +description:"Prints events to stdout"
 // +status:"GA"
-type _metaStdOut interface{} //nolint:deadcode,unused
+type _metaStdOut any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type StdOutFilterConfig struct {
@@ -70,7 +70,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expStdOut interface{} //nolint:deadcode,unused
+type _expStdOut any //nolint:deadcode,unused
 
 func NewStdOutFilterConfig() *StdOutFilterConfig {
 	return &StdOutFilterConfig{}

--- a/pkg/sdk/logging/model/filter/tagnormaliser.go
+++ b/pkg/sdk/logging/model/filter/tagnormaliser.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Tag Normaliser"
 // +weight:"200"
-type _hugoTagNormaliser interface{} //nolint:deadcode,unused
+type _hugoTagNormaliser any //nolint:deadcode,unused
 
 // +docName:"Fluentd Plugin to re-tag based on log metadata"
 /*
@@ -41,14 +41,14 @@ More info at https://github.com/kube-logging/fluent-plugin-tag-normaliser
 | `${docker_id}` | Docker UUID of the container | 3a38148aa37aa3... |
 
 */
-type _docTagNormaliser interface{} //nolint:deadcode,unused
+type _docTagNormaliser any //nolint:deadcode,unused
 
 // +name:"Tag Normaliser"
 // +url:"https://github.com/kube-logging/fluent-plugin-tag-normaliser"
 // +version:"0.1.1"
 // +description:"Re-tag based on log metadata"
 // +status:"GA"
-type _metaTagNormaliser interface{} //nolint:deadcode,unused
+type _metaTagNormaliser any //nolint:deadcode,unused
 
 // +docName:"Tag Normaliser parameters"
 type TagNormaliser struct {
@@ -86,7 +86,7 @@ Fluentd config result:
 </match>
 {{</ highlight >}}
 */
-type _expTagNormaliser interface{} //nolint:deadcode,unused
+type _expTagNormaliser any //nolint:deadcode,unused
 
 func (t *TagNormaliser) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "tag_normaliser"

--- a/pkg/sdk/logging/model/filter/throttle.go
+++ b/pkg/sdk/logging/model/filter/throttle.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Throttle"
 // +weight:"200"
-type _hugoThrottle interface{} //nolint:deadcode,unused
+type _hugoThrottle any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Throttle Filter](https://github.com/rubrikinc/fluent-plugin-throttle)"
 // A sentry plugin to throttle logs. Logs are grouped by a configurable key. When a group exceeds a configuration rate, logs are dropped for this group.
-type _docThrottle interface{} //nolint:deadcode,unused
+type _docThrottle any //nolint:deadcode,unused
 
 // +name:"Throttle"
 // +url:"https://github.com/rubrikinc/fluent-plugin-throttle"
 // +version:"0.0.5"
 // +description:"A sentry plugin to throttle logs. Logs are grouped by a configurable key. When a group exceeds a configuration rate, logs are dropped for this group."
 // +status:"GA"
-type _metaThrottle interface{} //nolint:deadcode,unused
+type _metaThrottle any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type Throttle struct {
@@ -80,7 +80,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expThrottle interface{} //nolint:deadcode,unused
+type _expThrottle any //nolint:deadcode,unused
 
 func (t *Throttle) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "throttle"

--- a/pkg/sdk/logging/model/filter/useragent.go
+++ b/pkg/sdk/logging/model/filter/useragent.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"User Agent"
 // +weight:"200"
-type _hugoUserAgent interface{} //nolint:deadcode,unused
+type _hugoUserAgent any //nolint:deadcode,unused
 
 // +docName:"Fluentd UserAgent filter"
 // Fluentd Filter plugin to parse user-agent
 // More information at https://github.com/bungoume/fluent-plugin-ua-parser
-type _docUserAgent interface{} //nolint:deadcode,unused
+type _docUserAgent any //nolint:deadcode,unused
 
 // +name:"UserAgent"
 // +url:"https://github.com/bungoume/fluent-plugin-ua-parser"
 // +version:"1.2.0"
 // +description:"Fluentd UserAgent filter"
 // +status:"GA"
-type _metaUserAgent interface{} //nolint:deadcode,unused
+type _metaUserAgent any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type UserAgent struct {
@@ -82,7 +82,7 @@ Fluentd config result:
 </filter>
 {{</ highlight >}}
 */
-type _expUserAgent interface{} //nolint:deadcode,unused
+type _expUserAgent any //nolint:deadcode,unused
 
 func (g *UserAgent) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "ua_parser"

--- a/pkg/sdk/logging/model/output/aws_elasticsearch.go
+++ b/pkg/sdk/logging/model/output/aws_elasticsearch.go
@@ -23,7 +23,7 @@ import (
 
 // +name:"Amazon Elasticsearch"
 // +weight:"200"
-type _hugoAwsElasticsearch interface{} //nolint:deadcode,unused
+type _hugoAwsElasticsearch any //nolint:deadcode,unused
 
 // +docName:"Amazon Elasticsearch output plugin for Fluentd"
 /*
@@ -46,14 +46,14 @@ spec:
         value: aws_secret
 {{</ highlight >}}
 */
-type _docAwsElasticsearch interface{} //nolint:deadcode,unused
+type _docAwsElasticsearch any //nolint:deadcode,unused
 
 // +name:"Amazon Elasticsearch"
 // +url:"https://github.com/atomita/fluent-plugin-aws-elasticsearch-service"
 // +version:"2.4.1"
 // +description:"Fluent plugin for Amazon Elasticsearch"
 // +status:"Testing"
-type _metaAwsElasticsearch interface{} //nolint:deadcode,unused
+type _metaAwsElasticsearch any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Amazon Elasticsearch"

--- a/pkg/sdk/logging/model/output/azurestore.go
+++ b/pkg/sdk/logging/model/output/azurestore.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Azure Storage"
 // +weight:"200"
-type _hugoAzure interface{} //nolint:deadcode,unused
+type _hugoAzure any //nolint:deadcode,unused
 
 // +docName:"Azure Storage output plugin for Fluentd"
 // Azure Storage output plugin buffers logs in local file and upload them to Azure Storage periodically.
 // More info at https://github.com/microsoft/fluent-plugin-azure-storage-append-blob
-type _docAzure interface{} //nolint:deadcode,unused
+type _docAzure any //nolint:deadcode,unused
 
 // +name:"Azure Storage"
 // +url:"https://github.com/microsoft/fluent-plugin-azure-storage-append-blob"
 // +version:"0.2.1"
 // +description:"Store logs in Azure Storage"
 // +status:"GA"
-type _metaAzure interface{} //nolint:deadcode,unused
+type _metaAzure any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/buffer.go
+++ b/pkg/sdk/logging/model/output/buffer.go
@@ -24,14 +24,14 @@ import (
 
 // +name:"Buffer"
 // +weight:"200"
-type _hugoBuffer interface{} //nolint:deadcode,unused
+type _hugoBuffer any //nolint:deadcode,unused
 
 // +name:"Buffer"
 // +url:"https://docs.fluentd.org/configuration/buffer-section"
 // +version:"mode info"
 // +description:"Fluentd event buffer"
 // +status:"GA"
-type _metaBuffer interface{} //nolint:deadcode,unused
+type _metaBuffer any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 

--- a/pkg/sdk/logging/model/output/cloudwatch.go
+++ b/pkg/sdk/logging/model/output/cloudwatch.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Amazon CloudWatch"
 // +weight:"200"
-type _hugoCloudWatch interface{} //nolint:deadcode,unused
+type _hugoCloudWatch any //nolint:deadcode,unused
 
 // +docName:"CloudWatch output plugin for Fluentd"
 /*
@@ -52,14 +52,14 @@ cloudwatch:
     timekey_use_utc: true
 ```
 */
-type _docCloudWatch interface{} //nolint:deadcode,unused
+type _docCloudWatch any //nolint:deadcode,unused
 
 // +name:"Amazon CloudWatch"
 // +url:"https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/releases/tag/v0.14.2"
 // +version:"0.14.2"
 // +description:"Send your logs to AWS CloudWatch"
 // +status:"GA"
-type _metaCloudWatch interface{} //nolint:deadcode,unused
+type _metaCloudWatch any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/datadog.go
+++ b/pkg/sdk/logging/model/output/datadog.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Datadog"
 // +weight:"200"
-type _hugoDatadog interface{} //nolint:deadcode,unused
+type _hugoDatadog any //nolint:deadcode,unused
 
 // +docName:"Datadog output plugin for Fluentd"
 /*
@@ -40,14 +40,14 @@ spec:
     dd_sourcecategory: '<YOUR_SOURCE_CATEGORY>'
 ```
 */
-type _docDatadog interface{} //nolint:deadcode,unused
+type _docDatadog any //nolint:deadcode,unused
 
 // +name:"Datadog"
 // +url:"https://github.com/DataDog/fluent-plugin-datadog/releases/tag/v0.14.1"
 // +version:"0.14.1"
 // +description:"Send your logs to Datadog"
 // +status:"Testing"
-type _metaDatadog interface{} //nolint:deadcode,unused
+type _metaDatadog any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/elasticsearch.go
+++ b/pkg/sdk/logging/model/output/elasticsearch.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Elasticsearch"
 // +weight:"200"
-type _hugoElasticsearch interface{} //nolint:deadcode,unused
+type _hugoElasticsearch any //nolint:deadcode,unused
 
 // +docName:"Elasticsearch output plugin for Fluentd"
 /* For details, see [https://github.com/uken/fluent-plugin-elasticsearch](https://github.com/uken/fluent-plugin-elasticsearch).
@@ -45,14 +45,14 @@ spec:
       timekey_use_utc: true
 ```
 */
-type _docElasticsearch interface{} //nolint:deadcode,unused
+type _docElasticsearch any //nolint:deadcode,unused
 
 // +name:"Elasticsearch"
 // +url:"https://github.com/uken/fluent-plugin-elasticsearch/releases/tag/v5.1.4"
 // +version:"5.1.1"
 // +description:"Send your logs to Elasticsearch"
 // +status:"GA"
-type _metaElasticsearch interface{} //nolint:deadcode,unused
+type _metaElasticsearch any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Elasticsearch"

--- a/pkg/sdk/logging/model/output/file.go
+++ b/pkg/sdk/logging/model/output/file.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"File"
 // +weight:"200"
-type _hugoFile interface{} //nolint:deadcode,unused
+type _hugoFile any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[File Output](https://docs.fluentd.org/output/file)"
 // This plugin has been designed to output logs or metrics to File.
-type _docFile interface{} //nolint:deadcode,unused
+type _docFile any //nolint:deadcode,unused
 
 // +name:"File"
 // +url:"https://docs.fluentd.org/output/file"
 // +version:"more info"
 // +description:"Output plugin writes events to files"
 // +status:"GA"
-type _metaFile interface{} //nolint:deadcode,unused
+type _metaFile any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type FileOutputConfig struct {
@@ -103,7 +103,7 @@ Fluentd config result:
 </match>
 {{</ highlight >}}
 */
-type _expFile interface{} //nolint:deadcode,unused
+type _expFile any //nolint:deadcode,unused
 
 func (c *FileOutputConfig) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "file"

--- a/pkg/sdk/logging/model/output/format.go
+++ b/pkg/sdk/logging/model/output/format.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Format"
 // +weight:"200"
-type _hugoFormat interface{} //nolint:deadcode,unused
+type _hugoFormat any //nolint:deadcode,unused
 
 // +docName:"Format output records"
 /*
@@ -40,14 +40,14 @@ spec:
       message_key: msg
 ```
 */
-type _docFormat interface{} //nolint:deadcode,unused
+type _docFormat any //nolint:deadcode,unused
 
 // +name:"Format"
 // +url:"https://docs.fluentd.org/configuration/format-section"
 // +version:"more info"
 // +description:"Specify how to format output record."
 // +status:"GA"
-type _metaFormat interface{} //nolint:deadcode,unused
+type _metaFormat any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type Format struct {

--- a/pkg/sdk/logging/model/output/format_rfc5424.go
+++ b/pkg/sdk/logging/model/output/format_rfc5424.go
@@ -22,14 +22,14 @@ import (
 
 // +name:"Format rfc5424"
 // +weight:"200"
-type _hugoFormatRfc5424 interface{} //nolint:deadcode,unused
+type _hugoFormatRfc5424 any //nolint:deadcode,unused
 
 // +name:"Format rfc5424"
 // +url:"https://github.com/cloudfoundry/fluent-plugin-syslog_rfc5424#format-section"
 // +version:"more info"
 // +description:"Specify how to format output record."
 // +status:"GA"
-type _metaFormatRfc5424 interface{} //nolint:deadcode,unused
+type _metaFormatRfc5424 any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type FormatRfc5424 struct {

--- a/pkg/sdk/logging/model/output/forward.go
+++ b/pkg/sdk/logging/model/output/forward.go
@@ -23,14 +23,14 @@ import (
 
 // +name:"Forward"
 // +weight:"200"
-type _hugoForward interface{} //nolint:deadcode,unused
+type _hugoForward any //nolint:deadcode,unused
 
 // +name:"Forward"
 // +url:"https://docs.fluentd.org/output/forward"
 // +version:"more info"
 // +description:"Forwards events to other fluentd nodes."
 // +status:"GA"
-type _metaForward interface{} //nolint:deadcode,unused
+type _metaForward any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type ForwardOutput struct {

--- a/pkg/sdk/logging/model/output/gcs.go
+++ b/pkg/sdk/logging/model/output/gcs.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Google Cloud Storage"
 // +weight:"200"
-type _hugoGCS interface{} //nolint:deadcode,unused
+type _hugoGCS any //nolint:deadcode,unused
 
 // +docName:"Google Cloud Storage"
 /*
@@ -38,14 +38,14 @@ spec:
     path: logs/${tag}/%Y/%m/%d/
 ```
 */
-type _docGCS interface{} //nolint:deadcode,unused
+type _docGCS any //nolint:deadcode,unused
 
 // +name:"Google Cloud Storage"
 // +url:"https://github.com/kube-logging/fluent-plugin-gcs"
 // +version:"0.4.0"
 // +description:"Store logs in Google Cloud Storage"
 // +status:"GA"
-type _metaGCS interface{} //nolint:deadcode,unused
+type _metaGCS any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type GCSOutput struct {

--- a/pkg/sdk/logging/model/output/gelf.go
+++ b/pkg/sdk/logging/model/output/gelf.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Gelf"
 // +weight:"200"
-type _hugoGelf interface{} //nolint:deadcode,unused
+type _hugoGelf any //nolint:deadcode,unused
 
 // +docName:"Gelf output plugin for Fluentd"
 /*
@@ -36,14 +36,14 @@ spec:
     port: 12201
 ```
 */
-type _docGelf interface{} //nolint:deadcode,unused
+type _docGelf any //nolint:deadcode,unused
 
 // +name:"Gelf"
 // +url:"https://github.com/bmichalkiewicz/fluent-plugin-gelf-best"
 // +version:"1.3.4"
 // +description:"Output plugin writes logs to Graylog"
 // +status:"Testing"
-type _metaGelf interface{} //nolint:deadcode,unused
+type _metaGelf any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/http.go
+++ b/pkg/sdk/logging/model/output/http.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Http"
 // +weight:"200"
-type _hugoHTTP interface{} //nolint:deadcode,unused
+type _hugoHTTP any //nolint:deadcode,unused
 
 // +docName:"Http plugin for Fluentd"
 /*
@@ -39,14 +39,14 @@ spec:
       flush_interval: 10s
 ```
 */
-type _docHTTP interface{} //nolint:deadcode,unused
+type _docHTTP any //nolint:deadcode,unused
 
 // +name:"Http"
 // +url:"https://docs.fluentd.org/output/http"
 // +version:"more info"
 // +description:"Sends logs to HTTP/HTTPS endpoints."
 // +status:"GA"
-type _metaHTTP interface{} //nolint:deadcode,unused
+type _metaHTTP any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/kafka.go
+++ b/pkg/sdk/logging/model/output/kafka.go
@@ -24,7 +24,7 @@ import (
 
 // +name:"Kafka"
 // +weight:"200"
-type _hugoKafka interface{} //nolint:deadcode,unused
+type _hugoKafka any //nolint:deadcode,unused
 
 // +docName:"Kafka output plugin for Fluentd"
 //
@@ -50,14 +50,14 @@ spec:
       timekey_use_utc: true
 ```
 */
-type _docKafka interface{} //nolint:deadcode,unused
+type _docKafka any //nolint:deadcode,unused
 
 // +name:"Kafka"
 // +url:"https://github.com/fluent/fluent-plugin-kafka/releases/tag/v0.17.5"
 // +version:"0.17.5"
 // +description:"Send your logs to Kafka"
 // +status:"GA"
-type _metaKafka interface{} //nolint:deadcode,unused
+type _metaKafka any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Kafka"

--- a/pkg/sdk/logging/model/output/kinesis_firehose.go
+++ b/pkg/sdk/logging/model/output/kinesis_firehose.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Amazon Kinesis"
 // +weight:"200"
-type _hugoKinesisFirehose interface{} //nolint:deadcode,unused
+type _hugoKinesisFirehose any //nolint:deadcode,unused
 
 // +docName:"Kinesis Firehose output plugin for Fluentd"
 //
@@ -40,14 +40,14 @@ spec:
       type: json
 ```
 */
-type _docKinesisFirehose interface{} //nolint:deadcode,unused
+type _docKinesisFirehose any //nolint:deadcode,unused
 
 // +name:"Amazon Kinesis Firehose"
 // +url:"https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.4.2"
 // +version:"3.4.2"
 // +description:"Fluent plugin for Amazon Kinesis"
 // +status:"Testing"
-type _metaKinesisFirehose interface{} //nolint:deadcode,unused
+type _metaKinesisFirehose any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"KinesisFirehose"

--- a/pkg/sdk/logging/model/output/kinesis_stream.go
+++ b/pkg/sdk/logging/model/output/kinesis_stream.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Amazon Kinesis"
 // +weight:"200"
-type _hugoKinesisStream interface{} //nolint:deadcode,unused
+type _hugoKinesisStream any //nolint:deadcode,unused
 
 // +docName:"Kinesis Stream output plugin for Fluentd"
 //
@@ -40,14 +40,14 @@ spec:
       type: json
 ```
 */
-type _docKinesisStream interface{} //nolint:deadcode,unused
+type _docKinesisStream any //nolint:deadcode,unused
 
 // +name:"Amazon Kinesis Stream"
 // +url:"https://github.com/awslabs/aws-fluent-plugin-kinesis/releases/tag/v3.4.2"
 // +version:"3.4.2"
 // +description:"Fluent plugin for Amazon Kinesis"
 // +status:"GA"
-type _metaKinesis interface{} //nolint:deadcode,unused
+type _metaKinesis any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"KinesisStream"

--- a/pkg/sdk/logging/model/output/lm_logs.go
+++ b/pkg/sdk/logging/model/output/lm_logs.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"LogicMonitor Logs"
 // +weight:"200"
-type _hugoLMLogs interface{} //nolint:deadcode,unused
+type _hugoLMLogs any //nolint:deadcode,unused
 
 // +docName:"LogicMonitor Logs output plugin for Fluentd"
 /*
@@ -53,14 +53,14 @@ spec:
     debug: false
 ```
 */
-type _docLMLogs interface{} //nolint:deadcode,unused
+type _docLMLogs any //nolint:deadcode,unused
 
 // +name:"LogicMonitorLogs"
 // +url:"https://github.com/logicmonitor/lm-logs-fluentd/releases/tag/v.1.2.5"
 // +version:"v1.2.5"
 // +description:"Send your logs to LogicMonitor Logs"
 // +status:"GA"
-type _metaLMLogs interface{} //nolint:deadcode,unused
+type _metaLMLogs any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"LogicMonitorLogs"

--- a/pkg/sdk/logging/model/output/logdna.go
+++ b/pkg/sdk/logging/model/output/logdna.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"LogDNA"
 // +weight:"200"
-type _hugoLogDNA interface{} //nolint:deadcode,unused
+type _hugoLogDNA any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[LogDNA Output](https://github.com/logdna/fluent-plugin-logdna)"
 // This plugin has been designed to output logs to LogDNA.
-type _docLogDNA interface{} //nolint:deadcode,unused
+type _docLogDNA any //nolint:deadcode,unused
 
 // +name:"LogDNA"
 // +url:"https://github.com/logdna/fluent-plugin-logdna/releases/tag/v0.4.0"
 // +version:"0.4.0"
 // +description:"Send your logs to LogDNA"
 // +status:"GA"
-type _metaLogDNA interface{} //nolint:deadcode,unused
+type _metaLogDNA any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"LogDNA"
@@ -95,7 +95,7 @@ Fluentd config result:
 </match>
 {{</ highlight >}}
 */
-type _expLogDNA interface{} //nolint:deadcode,unused
+type _expLogDNA any //nolint:deadcode,unused
 
 func (l *LogDNAOutput) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "logdna"

--- a/pkg/sdk/logging/model/output/logz.go
+++ b/pkg/sdk/logging/model/output/logz.go
@@ -25,7 +25,7 @@ import (
 
 // +name:"LogZ"
 // +weight:"200"
-type _hugoLogZ interface{} //nolint:deadcode,unused
+type _hugoLogZ any //nolint:deadcode,unused
 
 // +docName:"LogZ output plugin for Fluentd"
 /*
@@ -55,14 +55,14 @@ spec:
       queue_limit_length: 4096
 ```
 */
-type _docLogZ interface{} //nolint:deadcode,unused
+type _docLogZ any //nolint:deadcode,unused
 
 // +name:"LogZ"
 // +url:"https://github.com/logzio/fluent-plugin-logzio/releases/tag/v0.0.21"
 // +version:"0.0.21"
 // +description:"Store logs in LogZ.io"
 // +status:"GA"
-type _metaLogZ interface{} //nolint:deadcode,unused
+type _metaLogZ any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Logzio"

--- a/pkg/sdk/logging/model/output/loki.go
+++ b/pkg/sdk/logging/model/output/loki.go
@@ -15,6 +15,8 @@
 package output
 
 import (
+	"maps"
+
 	"github.com/cisco-open/operator-tools/pkg/secret"
 	util "github.com/cisco-open/operator-tools/pkg/utils"
 
@@ -23,7 +25,7 @@ import (
 
 // +name:"Grafana Loki"
 // +weight:"200"
-type _hugoLoki interface{} //nolint:deadcode,unused
+type _hugoLoki any //nolint:deadcode,unused
 
 // +docName:"Loki output plugin "
 /*
@@ -43,14 +45,14 @@ spec:
       timekey_use_utc: true
 ```
 */
-type _docLoki interface{} //nolint:deadcode,unused
+type _docLoki any //nolint:deadcode,unused
 
 // +name:"Grafana Loki"
 // +url:"https://github.com/grafana/loki/tree/master/fluentd/fluent-plugin-grafana-loki"
 // +version:"1.2.19"
 // +description:"Transfer logs to Loki"
 // +status:"GA"
-type _metaLoki interface{} //nolint:deadcode,unused
+type _metaLoki any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"
@@ -114,9 +116,7 @@ func (r Label) ToDirective(secretLoader secret.SecretLoader, id string) (types.D
 }
 
 func (r Label) merge(input Label) {
-	for k, v := range input {
-		r[k] = v
-	}
+	maps.Copy(r, input)
 }
 
 func (l *LokiOutput) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {

--- a/pkg/sdk/logging/model/output/mattermost.go
+++ b/pkg/sdk/logging/model/output/mattermost.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Mattermost"
 // +weight:"200"
-type _hugoMattermost interface{} //nolint:deadcode,unused
+type _hugoMattermost any //nolint:deadcode,unused
 
 // +docName:"Mattermost plugin for Fluentd"
 /*
@@ -40,14 +40,14 @@ spec:
     enable_tls: false
 ```
 */
-type _docMattermost interface{} //nolint:deadcode,unused
+type _docMattermost any //nolint:deadcode,unused
 
 // +name:"Mattermost"
 // +url:"https://github.com/levigo-systems/fluent-plugin-mattermost"
 // +version:"0.2.2"
 // +description:"Sends logs to Mattermost via webhooks."
 // +status:"GA"
-type _metaMattermost interface{} //nolint:deadcode,unused
+type _metaMattermost any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/newrelic.go
+++ b/pkg/sdk/logging/model/output/newrelic.go
@@ -24,7 +24,7 @@ import (
 
 // +name:"NewRelic"
 // +weight:"200"
-type _hugoNewRelic interface{} //nolint:deadcode,unused
+type _hugoNewRelic any //nolint:deadcode,unused
 
 // +docName:"New Relic Logs plugin for Fluentd"
 /*
@@ -42,14 +42,14 @@ spec:
           key: licenseKey
 ```
 */
-type _docNewRelic interface{} //nolint:deadcode,unused
+type _docNewRelic any //nolint:deadcode,unused
 
 // +name:"NewRelic Logs"
 // +url:"https://github.com/newrelic/newrelic-fluentd-output"
 // +version:"1.2.1"
 // +description:"Send logs to New Relic Logs"
 // +status:"GA"
-type _metaNewRelic interface{} //nolint:deadcode,unused
+type _metaNewRelic any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/null.go
+++ b/pkg/sdk/logging/model/output/null.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Null"
 // +weight:"200"
-type _hugoNull interface{} //nolint:deadcode,unused
+type _hugoNull any //nolint:deadcode,unused
 
 // +docName:"Null output plugin for Fluentd"
 //
@@ -37,14 +37,14 @@ spec:
     never_flush: false
 ```
 */
-type _docNull interface{} //nolint:deadcode,unused
+type _docNull any //nolint:deadcode,unused
 
 // +name:"Null"
 // +url:"https://docs.fluentd.org/output/null"
 // +version:"more info"
 // +description:"Null output plugin just throws away events."
 // +status:"GA"
-type _metaNull interface{} //nolint:deadcode,unused
+type _metaNull any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 

--- a/pkg/sdk/logging/model/output/opensearch.go
+++ b/pkg/sdk/logging/model/output/opensearch.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"OpenSearch"
 // +weight:"200"
-type _hugoOpenSearch interface{} //nolint:deadcode,unused
+type _hugoOpenSearch any //nolint:deadcode,unused
 
 // +docName:"OpenSearch output plugin for Fluentd"
 /*
@@ -46,14 +46,14 @@ spec:
       timekey_use_utc: true
 ```
 */
-type _docOpenSearch interface{} //nolint:deadcode,unused
+type _docOpenSearch any //nolint:deadcode,unused
 
 // +name:"OpenSearch"
 // +url:"https://github.com/fluent/fluent-plugin-opensearch/releases/tag/v1.0.5"
 // +version:"1.0.5"
 // +description:"Send your logs to OpenSearch"
 // +status:"GA"
-type _metaOpenSearch interface{} //nolint:deadcode,unused
+type _metaOpenSearch any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"OpenSearch"

--- a/pkg/sdk/logging/model/output/oss.go
+++ b/pkg/sdk/logging/model/output/oss.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Alibaba Cloud"
 // +weight:"200"
-type _hugoOss interface{} //nolint:deadcode,unused
+type _hugoOss any //nolint:deadcode,unused
 
 // +docName:"Aliyun OSS plugin for Fluentd"
 /*
@@ -38,14 +38,14 @@ This plugin uses MNS on the same region of the OSS bucket. We must setup MNS and
 
 This plugin will poll events from MNS queue and extract object keys from these events, and then will read those objects from OSS. For details, see [https://github.com/aliyun/fluent-plugin-oss](https://github.com/aliyun/fluent-plugin-oss).
 */
-type _docOss interface{} //nolint:deadcode,unused
+type _docOss any //nolint:deadcode,unused
 
 // +name:"Alibaba Cloud Storage"
 // +url:"https://github.com/aliyun/fluent-plugin-oss"
 // +version:"0.0.2"
 // +description:"Store logs the Alibaba Cloud Object Storage Service"
 // +status:"GA"
-type _metaOSS interface{} //nolint:deadcode,unused
+type _metaOSS any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/rabbitmq.go
+++ b/pkg/sdk/logging/model/output/rabbitmq.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"RabbitMQ"
 // +weight:"200"
-type _hugoRabbitMQ interface{} //nolint:deadcode,unused
+type _hugoRabbitMQ any //nolint:deadcode,unused
 
 // +docName:"RabbitMQ plugin for Fluentd"
 /*
@@ -43,14 +43,14 @@ spec:
 			timekey_use_utc: true
 ```
 */
-type _docRabbitMQ interface{} //nolint:deadcode,unused
+type _docRabbitMQ any //nolint:deadcode,unused
 
 // +name:"RabbitMQ"
 // +url:"https://github.com/nttcom/fluent-plugin-rabbitmq"
 // +version:"0.1.5"
 // +description:"Sends logs to RabbitMQ Queues."
 // +status:"GA"
-type _metaRabbitMQ interface{} //nolint:deadcode,unused
+type _metaRabbitMQ any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/redis.go
+++ b/pkg/sdk/logging/model/output/redis.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Redis"
 // +weight:"200"
-type _hugoRedis interface{} //nolint:deadcode,unused
+type _hugoRedis any //nolint:deadcode,unused
 
 // +docName:"Redis plugin for Fluentd"
 /*
@@ -39,14 +39,14 @@ spec:
       flush_interval: 10s
 ```
 */
-type _docRedis interface{} //nolint:deadcode,unused
+type _docRedis any //nolint:deadcode,unused
 
 // +name:"Redis"
 // +url:"https://github.com/fluent-plugins-nursery/fluent-plugin-redis"
 // +version:"0.3.5"
 // +description:"Sends logs to Redis endpoints."
 // +status:"GA"
-type _metaRedis interface{} //nolint:deadcode,unused
+type _metaRedis any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/relabel.go
+++ b/pkg/sdk/logging/model/output/relabel.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"Relabel"
 // +weight:"200"
-type _hugoRelabel interface{} //nolint:deadcode,unused
+type _hugoRelabel any //nolint:deadcode,unused
 
 // +docName:"Relabel"
 /*
@@ -85,14 +85,14 @@ spec:
 
 Using the relabel output also makes it possible to pass the messages emitted by the {{% xref "/docs/configuration/plugins/filters/concat.md" %}} plugin in case of a timeout. Set the `timeout_label` of the concat plugin to the flowLabel of the flow where you want to send the timeout messages.
 */
-type _docRelabel interface{} //nolint:deadcode,unused
+type _docRelabel any //nolint:deadcode,unused
 
 // +name:"Relabel"
 // +url:"https://docs.fluentd.org/output/relabel"
 // +version:"more info"
 // +description:"Relabel output plugin re-labels events."
 // +status:"GA"
-type _metaRelabel interface{} //nolint:deadcode,unused
+type _metaRelabel any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"

--- a/pkg/sdk/logging/model/output/s3.go
+++ b/pkg/sdk/logging/model/output/s3.go
@@ -25,7 +25,7 @@ import (
 
 // +name:"Amazon S3"
 // +weight:"200"
-type _hugoS3 interface{} //nolint:deadcode,unused
+type _hugoS3 any //nolint:deadcode,unused
 
 // +docName:"Amazon S3 plugin for Fluentd"
 /*
@@ -57,14 +57,14 @@ spec:
       timekey_use_utc: true
 ```
 */
-type _docS3 interface{} //nolint:deadcode,unused
+type _docS3 any //nolint:deadcode,unused
 
 // +name:"Amazon S3"
 // +url:"https://github.com/fluent/fluent-plugin-s3/releases/tag/v1.6.1"
 // +version:"1.6.1"
 // +description:"Store logs in Amazon S3"
 // +status:"GA"
-type _metaS3 interface{} //nolint:deadcode,unused
+type _metaS3 any //nolint:deadcode,unused
 
 const (
 	OneEyePathTemplate    string = "%v/%%Y/%%m/%%d/${$.kubernetes.namespace_name}/${$.kubernetes.pod_name}/${$.kubernetes.container_name}/"

--- a/pkg/sdk/logging/model/output/splunk_hec.go
+++ b/pkg/sdk/logging/model/output/splunk_hec.go
@@ -24,7 +24,7 @@ import (
 
 // +name:"Splunk"
 // +weight:"200"
-type _hugoSplunk interface{} //nolint:deadcode,unused
+type _hugoSplunk any //nolint:deadcode,unused
 
 // +docName:"Splunk via Hec output plugin for Fluentd"
 /*
@@ -41,14 +41,14 @@ spec:
     protocol: http
 ```
 */
-type _docSplunkHec interface{} //nolint:deadcode,unused
+type _docSplunkHec any //nolint:deadcode,unused
 
 // +name:"Splunk Hec"
 // +url:"https://github.com/splunk/fluent-plugin-splunk-hec/releases/tag/1.2.9
 // +version:"1.2.9"
 // +description:"Fluent Plugin Splunk Hec Release"
 // +status:"GA"
-type _metaSplunkHec interface{} //nolint:deadcode,unused
+type _metaSplunkHec any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"SplunkHecOutput"

--- a/pkg/sdk/logging/model/output/sqs.go
+++ b/pkg/sdk/logging/model/output/sqs.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"SQS"
 // +weight:"200"
-type _hugoSQS interface{} //nolint:deadcode,unused
+type _hugoSQS any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[SQS Output](https://github.com/ixixi/fluent-plugin-sqs)"
 // Fluentd output plugin for SQS.
-type _docSQS interface{} //nolint:deadcode,unused
+type _docSQS any //nolint:deadcode,unused
 
 // +name:"SQS"
 // +url:"https://github.com/ixixi/fluent-plugin-sqs"
 // +version:"v2.1.0"
 // +description:"Output plugin writes fluent-events as queue messages to Amazon SQS"
 // +status:"Testing"
-type _metaSQS interface{} //nolint:deadcode,unused
+type _metaSQS any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Output Config"
@@ -95,7 +95,7 @@ Fluentd config result:
 </match>
 ```
 */
-type _expSQS interface{} //nolint:deadcode,unused
+type _expSQS any //nolint:deadcode,unused
 
 func (s *SQSOutputConfig) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	pluginType := "sqs"

--- a/pkg/sdk/logging/model/output/syslog.go
+++ b/pkg/sdk/logging/model/output/syslog.go
@@ -22,19 +22,19 @@ import (
 
 // +name:"Syslog"
 // +weight:"200"
-type _hugoSyslog interface{} //nolint:deadcode,unused
+type _hugoSyslog any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Syslog Output](https://github.com/cloudfoundry/fluent-plugin-syslog_rfc5424)"
 // Fluentd output plugin for remote syslog with RFC5424 headers logs.
-type _docSyslog interface{} //nolint:deadcode,unused
+type _docSyslog any //nolint:deadcode,unused
 
 // +name:"Syslog"
 // +url:"https://github.com/cloudfoundry/fluent-plugin-syslog_rfc5424"
 // +version:"0.9.0.rc.8"
 // +description:"Output plugin writes events to syslog"
 // +status:"GA"
-type _metaSyslog interface{} //nolint:deadcode,unused
+type _metaSyslog any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type SyslogOutputConfig struct {
@@ -120,7 +120,7 @@ Fluentd config result:
 </match>
 {{</ highlight >}}
 */
-type _expSyslog interface{} //nolint:deadcode,unused
+type _expSyslog any //nolint:deadcode,unused
 
 func (s *SyslogOutputConfig) ToDirective(secretLoader secret.SecretLoader, id string) (types.Directive, error) {
 	const pluginType = "syslog_rfc5424"

--- a/pkg/sdk/logging/model/output/vmware_log_intelligence.go
+++ b/pkg/sdk/logging/model/output/vmware_log_intelligence.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"VMware Log Intelligence"
 // +weight:"200"
-type _hugoVMwareLogIntelligence interface{} //nolint:deadcode,unused
+type _hugoVMwareLogIntelligence any //nolint:deadcode,unused
 
 // +docName:"VMware Log Intelligence output plugin for Fluentd"
 /*
@@ -48,14 +48,14 @@ spec:
       retry_max_times: 3
 ```
 */
-type _docVMwareLogIntelligence interface{} //nolint:deadcode,unused
+type _docVMwareLogIntelligence any //nolint:deadcode,unused
 
 // +name:"VMwareLogIntelligence"
 // +url:"https://github.com/vmware/fluent-plugin-vmware-log-intelligence/releases/tag/v2.0.8"
 // +version:"v2.0.8"
 // +description:"Send your logs to VMware Log Intelligence"
 // +status:"GA"
-type _metaVMwareLogIntelligence interface{} //nolint:deadcode,unused
+type _metaVMwareLogIntelligence any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"VMwareLogIntelligence"

--- a/pkg/sdk/logging/model/output/vmware_loginsight.go
+++ b/pkg/sdk/logging/model/output/vmware_loginsight.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"VMware LogInsight"
 // +weight:"200"
-type _hugoVMwareLogInsight interface{} //nolint:deadcode,unused
+type _hugoVMwareLogInsight any //nolint:deadcode,unused
 
 // +docName:"VMware LogInsight output plugin for Fluentd"
 /*
@@ -45,14 +45,14 @@ spec:
     http_conn_debug: false
 ```
 */
-type _docVMwareLogInsight interface{} //nolint:deadcode,unused
+type _docVMwareLogInsight any //nolint:deadcode,unused
 
 // +name:"VMware LogInsight"
 // +url:"https://github.com/vmware/fluent-plugin-vmware-loginsight/releases/tag/v1.4.2"
 // +version:"1.4.2"
 // +description:"Store logs in VMware LogInsight"
 // +status:"GA"
-type _metaVMwareLogInsight interface{} //nolint:deadcode,unused
+type _metaVMwareLogInsight any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"VMwareLogInsight"

--- a/pkg/sdk/logging/model/syslogng/filter/match.go
+++ b/pkg/sdk/logging/model/syslogng/filter/match.go
@@ -16,7 +16,7 @@ package filter
 
 // +name:"Match"
 // +weight:"200"
-type _hugoMatch interface{} //nolint:deadcode,unused
+type _hugoMatch any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"Match"
@@ -37,14 +37,14 @@ filters:
         type: string
 {{</ highlight >}}
 */
-type _docMatch interface{} //nolint:deadcode,unused
+type _docMatch any //nolint:deadcode,unused
 
 // +name:"Syslog-NG Match"
 // +url:"https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/65#TOPIC-1829159"
 // +version:"more info"
 // +description:"Selectively keep records"
 // +status:"GA"
-type _metaMatch interface{} //nolint:deadcode,unused
+type _metaMatch any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type MatchConfig MatchExpr
@@ -123,4 +123,4 @@ log {
 };
 ```
 */
-type _expRegexpMatch interface{} //nolint:deadcode,unused
+type _expRegexpMatch any //nolint:deadcode,unused

--- a/pkg/sdk/logging/model/syslogng/filter/parser.go
+++ b/pkg/sdk/logging/model/syslogng/filter/parser.go
@@ -16,7 +16,7 @@ package filter
 
 // +name:"Parser"
 // +weight:"200"
-type _hugoParser interface{} //nolint:deadcode,unused
+type _hugoParser any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Parser](https://axoflow.com/docs/axosyslog-core/chapter-parsers/)"
@@ -53,14 +53,14 @@ The syslog parser can parse syslog messages. For details, see the [documentation
       syslog-parser: {}
 {{</ highlight >}}
 */
-type _docParser interface{} //nolint:deadcode,unused
+type _docParser any //nolint:deadcode,unused
 
 // +name:"Syslog-NG Parser"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-parsers/"
 // +version:"more info"
 // +description:"Parse data from records"
 // +status:"GA"
-type _metaParser interface{} //nolint:deadcode,unused
+type _metaParser any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Parser](https://axoflow.com/docs/axosyslog-core/chapter-parsers/)"

--- a/pkg/sdk/logging/model/syslogng/filter/rewrite.go
+++ b/pkg/sdk/logging/model/syslogng/filter/rewrite.go
@@ -16,7 +16,7 @@ package filter
 
 // +name:"Rewrite"
 // +weight:"200"
-type _hugoRewrite interface{} //nolint:deadcode,unused
+type _hugoRewrite any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // +docName:"[Rewrite](https://axoflow.com/docs/axosyslog-core/chapter-manipulating-messages/modifying-messages/)"
@@ -106,14 +106,14 @@ You can unset macros or fields of the message.
 
 For details, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-manipulating-messages/modifying-messages/rewrite-unset/).
 */
-type _docRewrite interface{} //nolint:deadcode,unused
+type _docRewrite any //nolint:deadcode,unused
 
 // +name:"Syslog-NG Rewrite"
 // +url:"https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.37/administration-guide/77"
 // +version:"more info"
 // +description:"Rewrite parts of the message"
 // +status:"GA"
-type _metaRewrite interface{} //nolint:deadcode,unused
+type _metaRewrite any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type RewriteConfig struct {

--- a/pkg/sdk/logging/model/syslogng/output/auth.go
+++ b/pkg/sdk/logging/model/syslogng/output/auth.go
@@ -16,16 +16,16 @@ package output
 
 // +name:"Authentication config for syslog-ng outputs"
 // +weight:"200"
-type _hugoAuth interface{} //nolint:deadcode,unused
+type _hugoAuth any //nolint:deadcode,unused
 
 // +docName:"Authentication config for syslog-ng outputs"
 // GRPC-based outputs use this configuration instead of the simple `tls` field found at most HTTP based destinations. For details, see the documentation of a related syslog-ng destination, for example, [Grafana Loki](https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-loki/#auth).
-type _docAuth interface{} //nolint:deadcode,unused
+type _docAuth any //nolint:deadcode,unused
 
 // +name:"Authentication config for syslog-ng outputs"
 // +description:"Authentication config for syslog-ng outputs"
 // +status:"Testing"
-type _metaAuth interface{} //nolint:deadcode,unused
+type _metaAuth any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // Authentication settings. Only one authentication method can be set. Default: Insecure

--- a/pkg/sdk/logging/model/syslogng/output/disk_buffer.go
+++ b/pkg/sdk/logging/model/syslogng/output/disk_buffer.go
@@ -16,18 +16,18 @@ package output
 
 // +name:"Disk buffer"
 // +weight:"200"
-type _hugoDiskBuffer interface{} //nolint:deadcode,unused
+type _hugoDiskBuffer any //nolint:deadcode,unused
 
 // +docName:"Disk buffer configuration"
 // The parameters of the syslog-ng disk buffer. Using a disk buffer on the output helps avoid message loss in case of a system failure on the destination side.
 // For details on how [syslog-ng disk buffers work, see the documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-routing-filters/concepts-diskbuffer/).
-type _docDiskBuffer interface{} //nolint:deadcode,unused
+type _docDiskBuffer any //nolint:deadcode,unused
 
 // +name:"disk-buffer configuration"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-routing-filters/concepts-diskbuffer/"
 // +description:"disk-buffer configuration"
 // +status:"Testing"
-type _metaDiskBuffer interface{} //nolint:deadcode,unused
+type _metaDiskBuffer any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // Documentation: https://axoflow.com/docs/axosyslog-core/chapter-routing-filters/concepts-diskbuffer/

--- a/pkg/sdk/logging/model/syslogng/output/elasticsearch.go
+++ b/pkg/sdk/logging/model/syslogng/output/elasticsearch.go
@@ -18,7 +18,7 @@ import "fmt"
 
 // +name:"Elasticsearch"
 // +weight:"200"
-type _hugoElasticsearch interface{} //nolint:deadcode,unused
+type _hugoElasticsearch any //nolint:deadcode,unused
 
 // +docName:"Sending messages over Elasticsearch"
 /*
@@ -44,13 +44,13 @@ spec:
           key: password
 {{</ highlight >}}
 */
-type _docSElasticsearch interface{} //nolint:deadcode,unused
+type _docSElasticsearch any //nolint:deadcode,unused
 
 // +name:"Elasticsearch"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-elasticsearch-http/"
 // +description:"Sending messages over Elasticsearch"
 // +status:"Testing"
-type _metaElasticsearch interface{} //nolint:deadcode,unused
+type _metaElasticsearch any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type ElasticsearchOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/elasticsearch_datastream.go
+++ b/pkg/sdk/logging/model/syslogng/output/elasticsearch_datastream.go
@@ -16,7 +16,7 @@ package output
 
 // +name:"Elasticsearch datastream"
 // +weight:"200"
-type _hugoElasticsearchDatastream interface{} //nolint:deadcode,unused
+type _hugoElasticsearchDatastream any //nolint:deadcode,unused
 
 // +docName:"Sending messages over Elasticsearch datastreams"
 /*
@@ -40,13 +40,13 @@ spec:
           key: password
 {{</ highlight >}}
 */
-type _docSElasticsearchDatastream interface{} //nolint:deadcode,unused
+type _docSElasticsearchDatastream any //nolint:deadcode,unused
 
 // +name:"Elasticsearch datastream"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-elasticsearch-datastream/"
 // +description:"Sending messages over Elasticsearch datastreams"
 // +status:"Testing"
-type _metaElasticsearchDatastream interface{} //nolint:deadcode,unused
+type _metaElasticsearchDatastream any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type ElasticsearchDatastreamOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/file.go
+++ b/pkg/sdk/logging/model/syslogng/output/file.go
@@ -16,7 +16,7 @@ package output
 
 // +name:"File"
 // +weight:"200"
-type _hugoFile interface{} //nolint:deadcode,unused
+type _hugoFile any //nolint:deadcode,unused
 
 // +docName:"File output plugin for syslog-ng"
 // The `file` output stores log records in a plain text file.
@@ -32,13 +32,13 @@ For details on the available options of the output, see the [documentation of th
 
 For available macros like `${YEAR}/${MONTH}/${DAY}` see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-manipulating-messages/customizing-message-format/reference-macros/).
 */
-type _docFile interface{} //nolint:deadcode,unused
+type _docFile any //nolint:deadcode,unused
 
 // +name:"File"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-file/"
 // +description:"SStoring messages in plain-text files"
 // +status:"Testing"
-type _metaFile interface{} //nolint:deadcode,unused
+type _metaFile any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // Documentation: https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-file/

--- a/pkg/sdk/logging/model/syslogng/output/http.go
+++ b/pkg/sdk/logging/model/syslogng/output/http.go
@@ -22,7 +22,7 @@ import (
 
 // +name:"HTTP"
 // +weight:"200"
-type _hugoHTTP interface{} //nolint:deadcode,unused
+type _hugoHTTP any //nolint:deadcode,unused
 
 // +docName:"Sending messages over HTTP"
 /*
@@ -80,13 +80,13 @@ spec:
 
 For details, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-http-nonjava/).
 */
-type _docHTTP interface{} //nolint:deadcode,unused
+type _docHTTP any //nolint:deadcode,unused
 
 // +name:"HTTP"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-http-nonjava/"
 // +description:"Sending messages over HTTP"
 // +status:"Testing"
-type _metaHTTP interface{} //nolint:deadcode,unused
+type _metaHTTP any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type HTTPOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/loggly.go
+++ b/pkg/sdk/logging/model/syslogng/output/loggly.go
@@ -18,7 +18,7 @@ import "github.com/cisco-open/operator-tools/pkg/secret"
 
 // +name:"Loggly output"
 // +weight:"200"
-type _hugoLoggly interface{} //nolint:deadcode,unused
+type _hugoLoggly any //nolint:deadcode,unused
 
 // +docName:"Loggly output plugin for syslog-ng"
 /*
@@ -31,13 +31,13 @@ For details on the available options of the output, see the [documentation of th
 
 You need a Loggly account and your user token to use this output.
 */
-type _docLoggly interface{} //nolint:deadcode,unused
+type _docLoggly any //nolint:deadcode,unused
 
 // +name:"Loggly"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-loggly/"
 // +description:"Send your logs to loggly"
 // +status:"Testing"
-type _metaLoggly interface{} //nolint:deadcode,unused
+type _metaLoggly any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // Documentation: https://github.com/syslog-ng/syslog-ng/blob/master/scl/loggly/loggly.conf

--- a/pkg/sdk/logging/model/syslogng/output/logscale.go
+++ b/pkg/sdk/logging/model/syslogng/output/logscale.go
@@ -18,7 +18,7 @@ import "github.com/cisco-open/operator-tools/pkg/secret"
 
 // +name:"LogScale"
 // +weight:"200"
-type _hugoLogScale interface{} //nolint:deadcode,unused
+type _hugoLogScale any //nolint:deadcode,unused
 
 // +docName:"Storing messages in Falcon LogScale"
 // The `LogScale` output sends log records over HTTP to Falcon's LogScale.
@@ -47,13 +47,13 @@ spec:
       reliable: true
 {{</ highlight >}}
 */
-type _docLogScale interface{} //nolint:deadcode,unused
+type _docLogScale any //nolint:deadcode,unused
 
 // +name:"Falcon LogScale"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/crowdstrike-falcon/"
 // +description:"Storing messages in Falcon's LogScale over http"
 // +status:"Testing"
-type _metaLogScale interface{} //nolint:deadcode,unused
+type _metaLogScale any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type LogScaleOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/loki.go
+++ b/pkg/sdk/logging/model/syslogng/output/loki.go
@@ -20,7 +20,7 @@ import (
 
 // +name:"Loki"
 // +weight:"200"
-type _hugoLoki interface{} //nolint:deadcode,unused
+type _hugoLoki any //nolint:deadcode,unused
 
 // +docName:"Sending messages to Loki over gRPC"
 /*
@@ -53,13 +53,13 @@ spec:
 
 For details on the available options of the output, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-loki/). For available macros like `$PROGRAM` and `$HOST` see https://axoflow.com/docs/axosyslog-core/chapter-manipulating-messages/customizing-message-format/reference-macros/
 */
-type _docLoki interface{} //nolint:deadcode,unused
+type _docLoki any //nolint:deadcode,unused
 
 // +name:"Loki"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-loki/"
 // +description:"Sending messages to Loki over gRPC"
 // +status:"Testing"
-type _metaLoki interface{} //nolint:deadcode,unused
+type _metaLoki any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type LokiOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/mongodb.go
+++ b/pkg/sdk/logging/model/syslogng/output/mongodb.go
@@ -20,7 +20,7 @@ import (
 
 // +name:"MongoDB"
 // +weight:"200"
-type _hugoMongoDB interface{} //nolint:deadcode,unused
+type _hugoMongoDB any //nolint:deadcode,unused
 
 // +docName:"Sending messages from a local network to an MongoDB database"
 /*
@@ -45,13 +45,13 @@ spec:
 
 For more information, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-mongodb/).
 */
-type _docMongoDB interface{} //nolint:deadcode,unused
+type _docMongoDB any //nolint:deadcode,unused
 
 // +name:"MongoDB Destination"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-mongodb/"
 // +description:"Sending messages into MongoDB Server"
 // +status:"Testing"
-type _metaMongoDB interface{} //nolint:deadcode,unused
+type _metaMongoDB any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type MongoDB struct {

--- a/pkg/sdk/logging/model/syslogng/output/mqtt.go
+++ b/pkg/sdk/logging/model/syslogng/output/mqtt.go
@@ -16,7 +16,7 @@ package output
 
 // +name:"MQTT"
 // +weight:"200"
-type _hugoMQTT interface{} //nolint:deadcode,unused
+type _hugoMQTT any //nolint:deadcode,unused
 
 // +docName:"Sending messages from a local network to an MQTT broker"
 /*
@@ -36,13 +36,13 @@ spec:
     topic: test/demo
 {{</ highlight >}}
 */
-type _docMQTT interface{} //nolint:deadcode,unused
+type _docMQTT any //nolint:deadcode,unused
 
 // +name:"MQTT Destination"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-mqtt-intro/"
 // +description:"Sending messages over MQTT Protocol"
 // +status:"Testing"
-type _metaMQTT interface{} //nolint:deadcode,unused
+type _metaMQTT any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type MQTT struct {

--- a/pkg/sdk/logging/model/syslogng/output/openobserve.go
+++ b/pkg/sdk/logging/model/syslogng/output/openobserve.go
@@ -16,7 +16,7 @@ package output
 
 // +name:"OpenObserve"
 // +weight:"200"
-type _hugoOpenobserve interface{} //nolint:deadcode,unused
+type _hugoOpenobserve any //nolint:deadcode,unused
 
 // +docName:"Sending messages over OpenObserve"
 /*
@@ -47,13 +47,13 @@ spec:
 
 For details on the available options of the output, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/openobserve/).
 */
-type _docOpenobserve interface{} //nolint:deadcode,unused
+type _docOpenobserve any //nolint:deadcode,unused
 
 // +name:"OpenObserve"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/openobserve/"
 // +description:"Sending messages over OpenObserve"
 // +status:"Testing"
-type _metaOpenobserve interface{} //nolint:deadcode,unused
+type _metaOpenobserve any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type OpenobserveOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/opentelemetry.go
+++ b/pkg/sdk/logging/model/syslogng/output/opentelemetry.go
@@ -18,7 +18,7 @@ import "github.com/kube-logging/logging-operator/pkg/sdk/logging/model/syslogng/
 
 // +name:"OpenTelemetry output"
 // +weight:"200"
-type _hugoOpenTelemetry interface{} //nolint:deadcode,unused
+type _hugoOpenTelemetry any //nolint:deadcode,unused
 
 // +docName:"Sending fluent structured messages over OpenTelemetry GRPC"
 /*
@@ -40,13 +40,13 @@ spec:
 {{</ highlight >}}
 
 */
-type _docOpenTelemetry interface{} //nolint:deadcode,unused
+type _docOpenTelemetry any //nolint:deadcode,unused
 
 // +name:"OpenTelemetry"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/opentelemetry/"
 // +description:"Sending messages over OpenTelemetry GRPC"
 // +status:"Testing"
-type _metaOTLP interface{} //nolint:deadcode,unused
+type _metaOTLP any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type OpenTelemetryOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/redis.go
+++ b/pkg/sdk/logging/model/syslogng/output/redis.go
@@ -20,7 +20,7 @@ import (
 
 // +name:"Redis"
 // +weight:"200"
-type _hugoRedis interface{} //nolint:deadcode,unused
+type _hugoRedis any //nolint:deadcode,unused
 
 // +docName:"Sending messages from a local network to the Redis server"
 /*
@@ -48,13 +48,13 @@ spec:
 
 For details on the available options of the output, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-redis/).
 */
-type _docRedis interface{} //nolint:deadcode,unused
+type _docRedis any //nolint:deadcode,unused
 
 // +name:"Redis Server Destination"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-redis/"
 // +description:"Sending messages from local network to the Redis server"
 // +status:"Testing"
-type _metaRedis interface{} //nolint:deadcode,unused
+type _metaRedis any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type RedisOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/s3.go
+++ b/pkg/sdk/logging/model/syslogng/output/s3.go
@@ -20,7 +20,7 @@ import (
 
 // +name:"S3"
 // +weight:"200"
-type _hugoS3 interface{} //nolint:deadcode,unused
+type _hugoS3 any //nolint:deadcode,unused
 
 // +docName:"Sending messages from a local network to a S3 (compatible) server"
 /*
@@ -53,13 +53,13 @@ spec:
 
 For available macros like `$PROGRAM` and `$HOST`,  see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-manipulating-messages/customizing-message-format/reference-macros/).
 */
-type _docS3 interface{} //nolint:deadcode,unused
+type _docS3 any //nolint:deadcode,unused
 
 // +name:"S3 Destination"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-s3/"
 // +description:"Sending messages from a local network to a S3 (compatible) server"
 // +status:"Testing"
-type _metaS3 interface{} //nolint:deadcode,unused
+type _metaS3 any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type S3Output struct {

--- a/pkg/sdk/logging/model/syslogng/output/splunk_hec.go
+++ b/pkg/sdk/logging/model/syslogng/output/splunk_hec.go
@@ -18,7 +18,7 @@ import "github.com/cisco-open/operator-tools/pkg/secret"
 
 // +name:"SplunkHEC"
 // +weight:"200"
-type _hugoSplunkHEC interface{} //nolint:deadcode,unused
+type _hugoSplunkHEC any //nolint:deadcode,unused
 
 // +docName:"Sending messages over Splunk HEC"
 /*
@@ -43,13 +43,13 @@ spec:
             key: token
 {{</ highlight >}}
 */
-type _docSplunkHEC interface{} //nolint:deadcode,unused
+type _docSplunkHEC any //nolint:deadcode,unused
 
 // +name:"SplunkHEC"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/syslog-ng-with-splunk/
 // +description:"Sending messages over Splunk HEC"
 // +status:"Testing"
-type _metaSplunkHEC interface{} //nolint:deadcode,unused
+type _metaSplunkHEC any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type SplunkHECOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/sumologic_http.go
+++ b/pkg/sdk/logging/model/syslogng/output/sumologic_http.go
@@ -18,7 +18,7 @@ import "github.com/cisco-open/operator-tools/pkg/secret"
 
 // +name:"Sumo Logic HTTP"
 // +weight:"200"
-type _hugoSumologicHTTP interface{} //nolint:deadcode,unused
+type _hugoSumologicHTTP any //nolint:deadcode,unused
 
 // +docName:"Storing messages in Sumo Logic over http"
 // The `sumologic-http` output sends log records over HTTP to Sumo Logic.
@@ -65,13 +65,13 @@ spec:
 
 For details on the available options of the output, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-sumologic-intro/destination-sumologic-http/).
 */
-type _docSumologicHTTP interface{} //nolint:deadcode,unused
+type _docSumologicHTTP any //nolint:deadcode,unused
 
 // +name:"Sumo Logic HTTP"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-sumologic-intro/destination-sumologic-http/"
 // +description:"Storing messages in Sumo Logic over http"
 // +status:"Testing"
-type _metaSumologicHTTP interface{} //nolint:deadcode,unused
+type _metaSumologicHTTP any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type SumologicHTTPOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/sumologic_syslog.go
+++ b/pkg/sdk/logging/model/syslogng/output/sumologic_syslog.go
@@ -16,7 +16,7 @@ package output
 
 // +name:"Sumo Logic Syslog"
 // +weight:"200"
-type _hugoSumologicSyslog interface{} //nolint:deadcode,unused
+type _hugoSumologicSyslog any //nolint:deadcode,unused
 
 // +docName:"Storing messages in Sumo Logic over syslog"
 /*
@@ -26,13 +26,13 @@ The `sumologic-syslog` output sends log records over HTTP to Sumo Logic. For det
 
 You need a Sumo Logic account to use this output. For details, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-sumologic-intro/).
 */
-type _docSumologicSyslog interface{} //nolint:deadcode,unused
+type _docSumologicSyslog any //nolint:deadcode,unused
 
 // +name:"Sumo Logic Syslog"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/destination-sumologic-intro/destination-sumologic-syslog/"
 // +description:"Storing messages in Sumo Logic over syslog"
 // +status:"Testing"
-type _metaSumologicSyslog interface{} //nolint:deadcode,unused
+type _metaSumologicSyslog any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type SumologicSyslogOutput struct {

--- a/pkg/sdk/logging/model/syslogng/output/syslog.go
+++ b/pkg/sdk/logging/model/syslogng/output/syslog.go
@@ -16,7 +16,7 @@ package output
 
 // +name:"Syslog (RFC5424) output"
 // +weight:"200"
-type _hugoSyslogOutput interface{} //nolint:deadcode,unused
+type _hugoSyslogOutput any //nolint:deadcode,unused
 
 // +docName:"Syslog output configuration"
 /*
@@ -91,13 +91,13 @@ spec:
 
 For details on the available options of the output, see the [documentation of the AxoSyslog syslog-ng distribution](https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-syslog/).
 */
-type _docSyslogOutput interface{} //nolint:deadcode,unused
+type _docSyslogOutput any //nolint:deadcode,unused
 
 // +name:"Syslog output configuration"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-syslog/"
 // +description:"Syslog output configuration"
 // +status:"Testing"
-type _metaSyslogOutput interface{} //nolint:deadcode,unused
+type _metaSyslogOutput any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 // Documentation: https://axoflow.com/docs/axosyslog-core/chapter-destinations/configuring-destinations-syslog/

--- a/pkg/sdk/logging/model/syslogng/output/tls.go
+++ b/pkg/sdk/logging/model/syslogng/output/tls.go
@@ -18,17 +18,17 @@ import "github.com/cisco-open/operator-tools/pkg/secret"
 
 // +name:"TLS config for syslog-ng outputs"
 // +weight:"200"
-type _hugoTLS interface{} //nolint:deadcode,unused
+type _hugoTLS any //nolint:deadcode,unused
 
 // +docName:"TLS config for syslog-ng outputs"
 // For details on how TLS configuration works in syslog-ng, see the [AxoSyslog Core documentation](https://axoflow.com/docs/axosyslog-core/chapter-encrypted-transport-tls/).
-type _docTLS interface{} //nolint:deadcode,unused
+type _docTLS any //nolint:deadcode,unused
 
 // +name:"TLS config for syslog-ng outputs"
 // +url:"https://axoflow.com/docs/axosyslog-core/chapter-encrypted-transport-tls/"
 // +description:"TLS config for syslog-ng outputs"
 // +status:"Testing"
-type _metaTLS interface{} //nolint:deadcode,unused
+type _metaTLS any //nolint:deadcode,unused
 
 // +kubebuilder:object:generate=true
 type TLS struct {

--- a/pkg/sdk/logging/model/types/stringmaps.go
+++ b/pkg/sdk/logging/model/types/stringmaps.go
@@ -18,13 +18,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	"emperror.dev/errors"
 	"github.com/cisco-open/operator-tools/pkg/secret"
 )
 
-type Converter func(interface{}) (string, error)
+type Converter func(any) (string, error)
 
 type StructToStringMapper struct {
 	TagName         string
@@ -47,7 +48,7 @@ func (s *StructToStringMapper) WithConverter(name string, c Converter) *StructTo
 	return s
 }
 
-func (s *StructToStringMapper) StringsMap(in interface{}) (map[string]string, error) {
+func (s *StructToStringMapper) StringsMap(in any) (map[string]string, error) {
 	out := make(map[string]string)
 	err := s.fillMap(strctVal(in), out)
 	return out, err
@@ -189,7 +190,7 @@ func (s *StructToStringMapper) processField(field reflect.StructField, value ref
 	return nil
 }
 
-func strctVal(s interface{}) reflect.Value {
+func strctVal(s any) reflect.Value {
 	v := reflect.ValueOf(s)
 
 	// if pointer get the underlying element≤
@@ -209,8 +210,7 @@ func (s *StructToStringMapper) structFields(value reflect.Value) []reflect.Struc
 
 	var f []reflect.StructField
 
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
+	for field := range t.Fields() {
 		// we can't access the value of unexported fields
 		if field.PkgPath != "" {
 			continue
@@ -247,13 +247,7 @@ type tagOptions []string
 
 // Has returns true if the given option is available in tagOptions
 func (t tagOptions) Has(opt string) bool {
-	for _, tagOpt := range t {
-		if tagOpt == opt {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(t, opt)
 }
 
 // Has returns true if the given option is available in tagOptions

--- a/pkg/sdk/logging/model/types/stringmaps_test.go
+++ b/pkg/sdk/logging/model/types/stringmaps_test.go
@@ -199,7 +199,7 @@ func TestConversion(t *testing.T) {
 		Field int `json:"field" plugin:"converter:magic"`
 	}
 
-	converter := func(f interface{}) (string, error) {
+	converter := func(f any) (string, error) {
 		if converted, ok := f.(int); ok {
 			return strconv.Itoa(converted), nil
 		}

--- a/pkg/sdk/logging/model/types/types.go
+++ b/pkg/sdk/logging/model/types/types.go
@@ -136,7 +136,7 @@ func (p PluginParams) Equals(target PluginParams) error {
 
 type Params = map[string]string
 
-func NewFlatDirective(meta PluginMeta, config interface{}, secretLoader secret.SecretLoader) (Directive, error) {
+func NewFlatDirective(meta PluginMeta, config any, secretLoader secret.SecretLoader) (Directive, error) {
 	directive := &GenericDirective{
 		PluginMeta: meta,
 	}

--- a/pkg/sdk/logging/plugins/plugin.go
+++ b/pkg/sdk/logging/plugins/plugin.go
@@ -49,9 +49,9 @@ type DirectiveConverter interface {
 func CreateOutput(outputSpec v1beta1.OutputSpec, outputName string, secretLoader secret.SecretLoader) (types.Directive, error) {
 	v := reflect.ValueOf(outputSpec)
 	var converters []DirectiveConverter
-	for i := 0; i < v.NumField(); i++ {
-		if v.Field(i).Kind() == reflect.Pointer && !v.Field(i).IsNil() {
-			if converter, ok := v.Field(i).Interface().(DirectiveConverter); ok {
+	for _, field := range v.Fields() {
+		if field.Kind() == reflect.Pointer && !field.IsNil() {
+			if converter, ok := field.Interface().(DirectiveConverter); ok {
 				converters = append(converters, converter)
 			}
 		}
@@ -73,9 +73,9 @@ func CreateFilter(filter v1beta1.Filter, id string, secretLoader secret.SecretLo
 func CreateFilterWithOptions(filter v1beta1.Filter, id string, secretLoader secret.SecretLoader, options *CreateFilterOptions) (types.Directive, error) {
 	v := reflect.ValueOf(filter)
 	var converters []DirectiveConverter
-	for i := 0; i < v.NumField(); i++ {
-		if v.Field(i).Kind() == reflect.Pointer && !v.Field(i).IsNil() {
-			if converter, ok := v.Field(i).Interface().(DirectiveConverter); ok {
+	for _, field := range v.Fields() {
+		if field.Kind() == reflect.Pointer && !field.IsNil() {
+			if converter, ok := field.Interface().(DirectiveConverter); ok {
 				converters = append(converters, converter)
 			}
 		}


### PR DESCRIPTION
## Summary

golangci-lint gains the `modernize` analyzer, and the tree is updated to satisfy it across all
three modules.

The changes are mechanical and behaviour-preserving: `range` over an integer in place of a
three-clause loop, `slices` and `maps` helpers in place of hand-written loops, the `min` and
`max` builtins, and `new(x)` in place of a local variable taken by address.

One helper went with them. `persistentVolumeModePointer` wrapped `new(mode)` for a single
caller, which the `inline` analyzer flags, so the call is inlined and the helper removed.

## Test plan

- [x] `make lint` reports no issues on the root, SDK and e2e modules
- [x] `make test` passes
- [x] `make check-diff` exits 0, so no generated file drifts