### PR TITLE
annotations for logging-operator deployment in charts/logging-operator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Users define `Flow`/`Output` CRDs (or their cluster-scoped equivalents) to route
 ```
 logging-operator/
 ├── .github/                         # GitHub Actions workflows
-├── charts/logging-operator/         # Helm chart (synced with manifests via make manifests)
+├── charts/logging-operator/         # Helm chart (CRDs via make manifests, README via make helm-docs)
 ├── controllers/
 │   ├── logging/                     # Core reconcilers (Logging, LoggingRoute, TelemetryController, AxoSyslog)
 │   └── extensions/                  # EventTailer and HostTailer reconcilers
@@ -66,8 +66,14 @@ make manifests
 # Regenerate Go code (deepcopy, etc.)
 make codegen
 
-# Full generation cycle after any API type change (codegen + fmt + manifests + docs)
+# Full generation cycle after any API type change (codegen + fmt + manifests + docs + helm-docs)
 make generate
+
+# Regenerate the chart README from values.yaml — CI fails `make check-diff` without it
+make helm-docs
+
+# What CI enforces: runs `generate`, then fails if anything is left uncommitted
+make check-diff
 
 # Format all code
 make fmt

--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -48,6 +48,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | fullnameOverride | string | `""` | A name to substitute for the full names of resources. |
 | namespaceOverride | string | `""` | A namespace override for the app. |
 | annotations | object | `{}` | Define annotations for logging-operator pods. |
+| deploymentAnnotations | object | `{}` | Define annotations for logging-operator deployment |
 | createCustomResource | bool | `false` | Deploy CRDs used by Logging operator. |
 | logging-operator-crds.install | bool | `false` | Toggle to install and upgrade CRDs from a subchart. Make sure to use it with `--skip-crds` to avoid conflicts. [More info about limitations on CRDs in Helm 3](https://helm.sh/docs/topics/charts/#limitations-on-crds) |
 | logging-operator-crds.annotations | object | `{}` | Annotations to be added to all CRDs |
@@ -97,7 +98,7 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | logging.configCheck | object | `{}` | configCheck provides possibility for timeout-based configuration checks https://kube-logging.dev/docs/whats-new/#timeout-based-configuration-checks |
 | logging.enableRecreateWorkloadOnImmutableFieldChange | bool | `false` | EnableRecreateWorkloadOnImmutableFieldChange enables the operator to recreate the fluentbit daemonset and the fluentd statefulset (and possibly other resource in the future) in case there is a change in an immutable field that otherwise couldn’t be managed with a simple update. |
 | logging.enableDockerParserCompatibilityForCRI | bool | `false` | EnableDockerParserCompatibilityForCRI enables Docker log format compatibility for CRI workloads. |
-| logging.enableRawFluentdFilter | bool | `false` | enableRawFluentdFilter enables the use of the Raw filter for fluentd. This allows users to configure custom or unexposed Fluentd filters via raw configuration. Break-glass setting: enabling it lets every user who can create a Flow or ClusterFlow in this logging domain inject arbitrary configuration (and thereby run arbitrary code) into the shared Fluentd aggregator, which processes all tenants' logs and mounts output credentials and TLS keys.  Enable it only if you trust all Flow authors. Disabling it again does not retroactively remove already rendered raw configuration: delete the offending Flow, rotate the aggregator's credentials and restart it. |
+| logging.enableRawFluentdFilter | bool | `false` | enableRawFluentdFilter enables the use of the Raw filter for fluentd. This allows users to configure custom or unexposed Fluentd filters via raw configuration. Break-glass setting: enabling it lets every user who can create a Flow or ClusterFlow in this logging domain inject arbitrary configuration (and thereby run arbitrary code) into the shared Fluentd aggregator, which processes all tenants' logs and mounts output credentials and TLS keys. Enable it only if you trust all Flow authors. Disabling it again does not retroactively remove already rendered raw configuration: delete the offending Flow, rotate the aggregator's credentials and restart it. |
 | logging.clusterFlows | list | `[]` | ClusterFlows to deploy |
 | logging.clusterOutputs | list | `[]` | ClusterOutputs to deploy |
 | logging.eventTailer.enabled | bool | `false` | Enable EventTailer |

--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "logging-operator.namespace" . }}
   labels:
 {{ include "logging-operator.labels" . | indent 4 }}
+{{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -58,10 +62,10 @@ spec:
         {{- if .Values.securityContext }}
           securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
         {{- end }}
-        {{- with .Values.volumeMounts }} 
+        {{- with .Values.volumeMounts }}
           volumeMounts: {{ toYaml . | nindent 12 }}
         {{- end }}
-    {{- with .Values.volumes }} 
+    {{- with .Values.volumes }}
       volumes: {{ toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.podSecurityContext }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -37,6 +37,9 @@ namespaceOverride: ""
 # -- Define annotations for logging-operator pods.
 annotations: {}
 
+# -- Define annotations for logging-operator deployment
+deploymentAnnotations: {}
+
 # -- Deploy CRDs used by Logging operator.
 createCustomResource: false
 
@@ -104,8 +107,8 @@ podSecurityContext: {}
 securityContext: {}
 #  allowPrivilegeEscalation: false
 #  readOnlyRootFilesystem: true
-  # capabilities:
-  #   drop: ["ALL"]
+#  capabilities:
+#    drop: ["ALL"]
 
 # -- Operator priorityClassName.
 priorityClassName: ~
@@ -146,7 +149,6 @@ podLabels: {}
 
 # Logging resources configuration.
 logging:
-
   # -- Logging resources are disabled by default
   enabled: false
 
@@ -227,7 +229,7 @@ logging:
   enableDockerParserCompatibilityForCRI: false
 
   # -- enableRawFluentdFilter enables the use of the Raw filter for fluentd. This allows users to configure custom or unexposed Fluentd filters via raw configuration.
-  # Break-glass setting: enabling it lets every user who can create a Flow or ClusterFlow in this logging domain inject arbitrary configuration (and thereby run arbitrary code) into the shared Fluentd aggregator, which processes all tenants' logs and mounts output credentials and TLS keys. 
+  # Break-glass setting: enabling it lets every user who can create a Flow or ClusterFlow in this logging domain inject arbitrary configuration (and thereby run arbitrary code) into the shared Fluentd aggregator, which processes all tenants' logs and mounts output credentials and TLS keys.
   # Enable it only if you trust all Flow authors. Disabling it again does not retroactively remove already rendered raw configuration: delete the offending Flow, rotate the aggregator's credentials and restart it.
   enableRawFluentdFilter: false
 
@@ -293,33 +295,33 @@ logging:
     # -- List of hostTailers configurations
     instances: []
     # - name: hosttailer
-      # -- Namespace of the HostTailer resource. Defaults to the Helm release namespace when omitted.
-      # namespace: custom-namespace
-      # -- Enable hostTailer
-      # enabled: true
-      # -- workloadMetaOverrides of HostTailer
-      # workloadMetaOverrides: {}
-      # -- workloadOverrides of HostTailer
-      # workloadOverrides: {}
-      # -- configure fileTailers of HostTailer
-      # fileTailers:
-      # - name: sample-file
-      #   path: /var/log/sample-file
-      #   disabled: false
-      #   buffer_max_size:
-      #   buffer_chunk_size:
-      #   skip_long_lines:
-      #   read_from_head: false
-      #   containerOverrides:
-      #   image:
-      # -- configure systemdTailers of HostTailer
-      # systemdTailers:
-      # - name: system-sample
-      #   disabled: false
-      #   systemdFilter: kubelet.service
-      #   maxEntries: 20
-      #   containerOverrides:
-      #   image:
+    #   # -- Namespace of the HostTailer resource. Defaults to the Helm release namespace when omitted.
+    #   namespace: custom-namespace
+    #   # -- Enable hostTailer
+    #   enabled: true
+    #   # -- workloadMetaOverrides of HostTailer
+    #   workloadMetaOverrides: {}
+    #   # -- workloadOverrides of HostTailer
+    #   workloadOverrides: {}
+    #   # -- configure fileTailers of HostTailer
+    #   fileTailers:
+    #   - name: sample-file
+    #     path: /var/log/sample-file
+    #     disabled: false
+    #     buffer_max_size:
+    #     buffer_chunk_size:
+    #     skip_long_lines:
+    #     read_from_head: false
+    #     containerOverrides:
+    #     image:
+    #   # -- configure systemdTailers of HostTailer
+    #   systemdTailers:
+    #   - name: system-sample
+    #     disabled: false
+    #     systemdFilter: kubelet.service
+    #     maxEntries: 20
+    #     containerOverrides:
+    #     image:
 
 testReceiver:
   enabled: false
@@ -344,4 +346,3 @@ extraManifests: []
   #     name: extra-manifest
   #   data:
   #     extra-data: "value"
-


### PR DESCRIPTION
deploymentAnnotations added to values.yaml and templated into logging-operator deployment.
needed when using tools such as keel.