### PR TITLE
refactor(e2e): move three more suites onto the harness

### DIFF
--- a/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
+++ b/e2e/fluentbit-agent-namespace/fluentbit_agent_namespace_test.go
@@ -15,242 +15,109 @@
 package fluentbit_agent_namespace
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/cisco-open/operator-tools/pkg/types"
-	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
 	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/image"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
-	v1beta1 "github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-var TestTempDir string
-
-func init() {
-	var ok bool
-	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
-	if !ok {
-		TestTempDir = "../.."
-	}
-	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
-	if err != nil {
-		panic(err)
-	}
-}
-
-var (
-	tags           = "time"
-	realTimeBuffer = &output.Buffer{
-		Tags:        &tags,
-		Timekey:     "1s",
-		TimekeyWait: "0s",
-	}
+const (
+	release    = "fluentbit-agents-namespace"
+	nsControl  = "logging"
+	nsAgents   = "logging-fluentbit-agents"
+	nsProducer = "default"
+	tag        = "tag_fluentbit_agents"
 )
 
-var producerLabels = map[string]string{
-	"my-unique-label": "log-producer",
+var producerLabels = map[string]string{"my-unique-label": "log-producer"}
+
+func realTimeBuffer() *output.Buffer {
+	tags := "time"
+	return &output.Buffer{Tags: &tags, Timekey: "1s", TimekeyWait: "0s"}
 }
 
 // Verifies that Fluentbit agents are deployed to a dedicated namespace when
-// logging.spec.fluentBitAgentNamespace is set, while the aggregator stays in the control namespace.
+// logging.spec.fluentBitAgentNamespace is set, while the aggregator stays in
+// the control namespace.
 func TestFluentbitAgentDedicatedNamespace(t *testing.T) {
-	common.Initialize(t)
+	env := harness.New(t).
+		WithCluster(release).
+		WithRelease(release).
+		WithControlNamespace(nsControl).
+		WithNamespaces(nsAgents).
+		Start()
 
-	nsControl := "logging"
-	nsAgents := "logging-fluentbit-agents"
-	release := "fluentbit-agents-namespace"
-	tag := "tag_fluentbit_agents"
-
-	common.WithCluster(release, t, func(t *testing.T, c common.Cluster) {
-		// Install logging-operator Helm chart with test-receiver in control namespace
-		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
-			options.Namespace = nsControl
-			options.NameOverride = release
-		}))
-
-		ctx := context.Background()
-
-		// Ensure fluentbit agent namespace exists
-		common.RequireNoError(t, c.GetClient().Create(ctx, &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: nsAgents,
-			},
-		}))
-
-		// Create ClusterOutput pointing to test-receiver in control namespace
-		httpOut := v1beta1.ClusterOutput{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "http",
-				Namespace: nsControl,
-			},
-			Spec: v1beta1.ClusterOutputSpec{
-				OutputSpec: v1beta1.OutputSpec{
-					LoggingRef: "infra",
-					HTTPOutput: &output.HTTPOutputConfig{
-						Endpoint:    harness.ReceiverURL(release, tag),
-						ContentType: "application/json",
-						Buffer:      realTimeBuffer,
-					},
-				},
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &httpOut))
-
-		// Match producer pods cluster-wide
-		clusterFlow := v1beta1.ClusterFlow{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "flow",
-				Namespace: nsControl,
-			},
-			Spec: v1beta1.ClusterFlowSpec{
+	out := &v1beta1.ClusterOutput{
+		ObjectMeta: metav1.ObjectMeta{Name: "http", Namespace: nsControl},
+		Spec: v1beta1.ClusterOutputSpec{
+			OutputSpec: v1beta1.OutputSpec{
 				LoggingRef: "infra",
-				Match: []v1beta1.ClusterMatch{
-					{
-						ClusterSelect: &v1beta1.ClusterSelect{
-							Labels: producerLabels,
-						},
-					},
-				},
-				GlobalOutputRefs: []string{httpOut.Name},
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &clusterFlow))
-
-		// Create FluentBit agent (standalone) bound to the same loggingRef
-		agent := v1beta1.FluentbitAgent{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "infra",
-			},
-			Spec: v1beta1.FluentbitSpec{
-				LoggingRef: "infra",
-				ConfigHotReload: &v1beta1.HotReload{
-					Image: image.ConfigReloader().Spec(),
-				},
-				BufferVolumeImage: image.NodeExporter().Spec(),
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &agent))
-
-		// Create Logging with control namespace and dedicated FluentbitAgentNamespace
-		logging := v1beta1.Logging{
-			ObjectMeta: metav1.ObjectMeta{Name: "infra"},
-			Spec: v1beta1.LoggingSpec{
-				LoggingRef:              "infra",
-				ControlNamespace:        nsControl,
-				FluentbitAgentNamespace: nsAgents,
-				FluentdSpec: &v1beta1.FluentdSpec{
-					Image:               image.Fluentd().Spec(),
-					ConfigReloaderImage: image.ConfigReloader().Spec(),
-					BufferVolumeImage:   image.NodeExporter().Spec(),
-					DisablePvc:          true,
-					Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    apiresource.MustParse("50m"),
-						corev1.ResourceMemory: apiresource.MustParse("50M"),
-					}},
+				HTTPOutput: &output.HTTPOutputConfig{
+					Endpoint:    env.Receiver.URL(tag),
+					ContentType: "application/json",
+					Buffer:      realTimeBuffer(),
 				},
 			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
+		},
+	}
+	env.Create(out)
 
-		// Start a log producer in the default namespace
-		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
-			options.Namespace = "default"
-			options.Labels = producerLabels
-		}))
-
-		fluentBitLabels := map[string]string{
-			types.NameLabel: "fluentbit",
-		}
-		aggregatorLabels := map[string]string{
-			types.NameLabel:      "fluentd",
-			types.ComponentLabel: "fluentd",
-		}
-		operatorLabels := map[string]string{
-			types.NameLabel: release,
-		}
-
-		require.Eventually(t, func() bool {
-			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
-				t.Log("waiting for the operator")
-				return false
-			}
-			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
-				t.Log("waiting for the producer")
-				return false
-			}
-			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels), client.InNamespace(nsControl)); !aggregatorRunning() {
-				t.Log("waiting for the aggregator in control namespace")
-				return false
-			}
-			if fluentbitRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(fluentBitLabels), client.InNamespace(nsAgents)); !fluentbitRunning() {
-				t.Log("waiting for the fluentbit daemonset in fluentbit agent namespace")
-				return false
-			}
-
-			cmd := common.CmdEnv(exec.Command("kubectl",
-				"logs",
-				"-n", nsControl,
-				"--tail", "30",
-				"-l", fmt.Sprintf("%s=%s", types.NameLabel, harness.ReceiverName(release))), c)
-			rawOut, err := cmd.Output()
-			if err != nil {
-				t.Logf("failed to get log consumer logs: %v", err)
-				return false
-			}
-			t.Logf("log consumer logs: %s", rawOut)
-			return strings.Contains(string(rawOut), tag)
-		}, 5*time.Minute, 3*time.Second)
-	}, func(t *testing.T, c common.Cluster) error {
-		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
-		t.Logf("Printing cluster logs to %s", path)
-		err := c.PrintLogs(common.PrintLogConfig{
-			Namespaces: []string{nsControl, nsAgents, "default"},
-			FilePath:   path,
-			Limit:      100 * 1000,
-		})
-		if err != nil {
-			return err
-		}
-
-		loggingOperatorName := "logging-operator-" + release
-		t.Logf("Collecting coverage files from logging-operator: %s/%s", nsControl, loggingOperatorName)
-		err = c.CollectTestCoverageFiles(nsControl, loggingOperatorName)
-		if err != nil {
-			t.Logf("Failed collecting coverage files: %s", err)
-		}
-		return nil
-	}, func(o *cluster.Options) {
-		if o.Scheme == nil {
-			o.Scheme = runtime.NewScheme()
-		}
-		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
+	env.Create(&v1beta1.ClusterFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "flow", Namespace: nsControl},
+		Spec: v1beta1.ClusterFlowSpec{
+			LoggingRef: "infra",
+			Match: []v1beta1.ClusterMatch{
+				{ClusterSelect: &v1beta1.ClusterSelect{Labels: producerLabels}},
+			},
+			GlobalOutputRefs: []string{out.Name},
+		},
 	})
+
+	env.Create(&v1beta1.FluentbitAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "infra"},
+		Spec: v1beta1.FluentbitSpec{
+			LoggingRef: "infra",
+			ConfigHotReload: &v1beta1.HotReload{
+				Image: image.ConfigReloader().Spec(),
+			},
+			BufferVolumeImage: image.NodeExporter().Spec(),
+		},
+	})
+
+	env.Create(&v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: "infra"},
+		Spec: v1beta1.LoggingSpec{
+			LoggingRef:              "infra",
+			ControlNamespace:        nsControl,
+			FluentbitAgentNamespace: nsAgents,
+			FluentdSpec: &v1beta1.FluentdSpec{
+				Image:               image.Fluentd().Spec(),
+				ConfigReloaderImage: image.ConfigReloader().Spec(),
+				BufferVolumeImage:   image.NodeExporter().Spec(),
+				DisablePvc:          true,
+				Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("50m"),
+					corev1.ResourceMemory: resource.MustParse("50M"),
+				}},
+			},
+		},
+	})
+
+	env.StartLogProducer(nsProducer, producerLabels)
+
+	env.WaitFor(
+		wait.Operator(release),
+		wait.Producer(producerLabels),
+		wait.FluentdAggregator(nsControl),
+		wait.Fluentbit(nsAgents),
+	)
+
+	env.Receiver.MustReceive(tag)
 }

--- a/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
+++ b/e2e/fluentbit-hotreload/fluentbit_hotreload_test.go
@@ -58,7 +58,7 @@ func TestFluentbitHotReload(t *testing.T) {
 
 	env.StartLogProducer(nsTenant, producerLabels)
 
-	env.WaitForRunning(
+	env.WaitFor(
 		wait.Operator(release),
 		wait.Producer(producerLabels),
 		wait.FluentdAggregator(nsInfra),

--- a/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
+++ b/e2e/fluentbit-multitenant/fluentbit_multitenant_test.go
@@ -56,7 +56,7 @@ func TestFluentbitSingleTenantPlusInfra(t *testing.T) {
 
 	env.StartLogProducer(nsTenant, producerLabels)
 
-	env.WaitForRunning(
+	env.WaitFor(
 		wait.Operator(release),
 		wait.Producer(producerLabels),
 		wait.FluentdAggregator(nsInfra),

--- a/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
+++ b/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
@@ -15,26 +15,12 @@
 package fluentd_aggregator
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
 	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/image"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
@@ -42,208 +28,105 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-var TestTempDirUnnamed string
+const (
+	clusterName = "fluentd-detached-unnamed"
+	release     = "e2e"
+	ns          = "testing-1"
+	testTag     = "test.fluentd_aggregator_multiworker_multiple_detached_failure"
+)
 
-func init() {
-	var ok bool
-	TestTempDirUnnamed, ok = os.LookupEnv("PROJECT_DIR")
-	if !ok {
-		TestTempDirUnnamed = "../.."
-	}
-	TestTempDirUnnamed = filepath.Join(TestTempDirUnnamed, "build/_test")
-	err := os.MkdirAll(TestTempDirUnnamed, os.FileMode(0o755))
-	if err != nil {
-		panic(err)
+var producerLabels = map[string]string{"my-unique-label": "log-producer"}
+
+// detachedFluentd is the spec both excess configs carry: identical on purpose,
+// so neither can be the one the Logging picks.
+func detachedFluentd(name string) *v1beta1.FluentdConfig {
+	return &v1beta1.FluentdConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: v1beta1.FluentdSpec{
+			Image:               image.Fluentd().Spec(),
+			ConfigReloaderImage: image.ConfigReloader().Spec(),
+			BufferVolumeImage:   image.NodeExporter().Spec(),
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("200M"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("250m"),
+					corev1.ResourceMemory: resource.MustParse("50M"),
+				},
+			},
+			BufferVolumeMetrics: &v1beta1.Metrics{},
+			Scaling: &v1beta1.FluentdScaling{
+				Replicas: 1,
+				Drain: v1beta1.FluentdDrainConfig{
+					Enabled: true,
+					Image:   image.DrainWatch().Spec(),
+				},
+			},
+			Workers: 2,
+		},
 	}
 }
 
 func TestFluentdAggregator_detached_multiple_failure(t *testing.T) {
-	common.Initialize(t)
-	ns := "testing-1"
-	releaseNameOverride := "e2e"
-	testTag := "test.fluentd_aggregator_multiworker_multiple_detached_failure"
-	outputName := "test-output"
-	flowName := "test-flow"
-	common.WithCluster("fluentd-detached-unnamed", t, func(t *testing.T, c common.Cluster) {
-		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
-			options.Namespace = ns
-			options.NameOverride = releaseNameOverride
-		}))
+	env := harness.New(t).
+		WithCluster(clusterName).
+		WithRelease(release).
+		WithControlNamespace(ns).
+		Start()
 
-		ctx := context.Background()
-
-		logging := v1beta1.Logging{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fluentd-aggregator-multiworker-test",
-				Namespace: ns,
-			},
-			Spec: v1beta1.LoggingSpec{
-				EnableRecreateWorkloadOnImmutableFieldChange: true,
-				ControlNamespace: ns,
-				FluentbitSpec: &v1beta1.FluentbitSpec{
-					Network: &v1beta1.FluentbitNetwork{
-						Keepalive: new(false),
-					},
-					ConfigHotReload: &v1beta1.HotReload{
-						Image: image.ConfigReloader().Spec(),
-					},
-					BufferVolumeImage: image.NodeExporter().Spec(),
+	env.Create(&v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: "fluentd-aggregator-multiworker-test", Namespace: ns},
+		Spec: v1beta1.LoggingSpec{
+			EnableRecreateWorkloadOnImmutableFieldChange: true,
+			ControlNamespace: ns,
+			FluentbitSpec: &v1beta1.FluentbitSpec{
+				Network: &v1beta1.FluentbitNetwork{
+					Keepalive: new(false),
 				},
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
-
-		fluentd1 := v1beta1.FluentdConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "not-to-be-used-fluentd-1",
-				Namespace: ns,
-			},
-			Spec: v1beta1.FluentdSpec{
-				Image:               image.Fluentd().Spec(),
-				ConfigReloaderImage: image.ConfigReloader().Spec(),
-				BufferVolumeImage:   image.NodeExporter().Spec(),
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("200M"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("250m"),
-						corev1.ResourceMemory: resource.MustParse("50M"),
-					},
+				ConfigHotReload: &v1beta1.HotReload{
+					Image: image.ConfigReloader().Spec(),
 				},
-				BufferVolumeMetrics: &v1beta1.Metrics{},
-				Scaling: &v1beta1.FluentdScaling{
-					Replicas: 1,
-					Drain: v1beta1.FluentdDrainConfig{
-						Enabled: true,
-						Image:   image.DrainWatch().Spec(),
-					},
-				},
-				Workers: 2,
+				BufferVolumeImage: image.NodeExporter().Spec(),
 			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &fluentd1))
-
-		fluentd2 := v1beta1.FluentdConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "not-to-be-used-fluentd-2",
-				Namespace: ns,
-			},
-			Spec: v1beta1.FluentdSpec{
-				Image:               image.Fluentd().Spec(),
-				ConfigReloaderImage: image.ConfigReloader().Spec(),
-				BufferVolumeImage:   image.NodeExporter().Spec(),
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("500m"),
-						corev1.ResourceMemory: resource.MustParse("200M"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("250m"),
-						corev1.ResourceMemory: resource.MustParse("50M"),
-					},
-				},
-				BufferVolumeMetrics: &v1beta1.Metrics{},
-				Scaling: &v1beta1.FluentdScaling{
-					Replicas: 1,
-					Drain: v1beta1.FluentdDrainConfig{
-						Enabled: true,
-						Image:   image.DrainWatch().Spec(),
-					},
-				},
-				Workers: 2,
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &fluentd2))
-
-		t.Logf("fluentd is: %v", fluentd1)
-		tags := "time"
-		output := v1beta1.Output{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      outputName,
-				Namespace: ns,
-			},
-			Spec: v1beta1.OutputSpec{
-				HTTPOutput: &output.HTTPOutputConfig{
-					Endpoint:    harness.ReceiverURL(releaseNameOverride, testTag),
-					ContentType: "application/json",
-					Buffer: &output.Buffer{
-						Type:        "file",
-						Tags:        &tags,
-						Timekey:     "1s",
-						TimekeyWait: "0s",
-					},
-				},
-			},
-		}
-
-		producerLabels := map[string]string{
-			"my-unique-label": "log-producer",
-		}
-
-		common.RequireNoError(t, c.GetClient().Create(ctx, &output))
-		flow := v1beta1.Flow{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      flowName,
-				Namespace: ns,
-			},
-			Spec: v1beta1.FlowSpec{
-				Match: []v1beta1.Match{
-					{
-						Select: &v1beta1.Select{
-							Labels: producerLabels,
-						},
-					},
-				},
-				LocalOutputRefs: []string{output.Name},
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &flow))
-
-		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
-			options.Namespace = ns
-			options.Labels = producerLabels
-		}))
-
-		require.Eventually(t, func() bool {
-			if rv := wait.CheckExcessFluentdStatus(t, c.GetClient(), ctx, &fluentd1); !rv {
-				return false
-			}
-			if rv := wait.CheckExcessFluentdStatus(t, c.GetClient(), ctx, &fluentd2); !rv {
-				return false
-			}
-			return true
-		}, 5*time.Minute, 3*time.Second)
-	}, func(t *testing.T, c common.Cluster) error {
-		path := filepath.Join(TestTempDirUnnamed, fmt.Sprintf("cluster-%s.log", t.Name()))
-		t.Logf("Printing cluster logs to %s", path)
-		err := c.PrintLogs(common.PrintLogConfig{
-			Namespaces: []string{ns, "default"},
-			FilePath:   path,
-			Limit:      100 * 1000,
-		})
-		if err != nil {
-			return err
-		}
-
-		loggingOperatorName := "logging-operator-" + releaseNameOverride
-		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
-		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
-		if err != nil {
-			t.Logf("Failed collecting coverage files: %s", err)
-		}
-
-		return nil
-	}, func(o *cluster.Options) {
-		if o.Scheme == nil {
-			o.Scheme = runtime.NewScheme()
-		}
-		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
+		},
 	})
+
+	first, second := "not-to-be-used-fluentd-1", "not-to-be-used-fluentd-2"
+	env.Create(detachedFluentd(first), detachedFluentd(second))
+
+	tags := "time"
+	out := &v1beta1.Output{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-output", Namespace: ns},
+		Spec: v1beta1.OutputSpec{
+			HTTPOutput: &output.HTTPOutputConfig{
+				Endpoint:    env.Receiver.URL(testTag),
+				ContentType: "application/json",
+				Buffer: &output.Buffer{
+					Type:        "file",
+					Tags:        &tags,
+					Timekey:     "1s",
+					TimekeyWait: "0s",
+				},
+			},
+		},
+	}
+	env.Create(out)
+
+	env.Create(&v1beta1.Flow{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-flow", Namespace: ns},
+		Spec: v1beta1.FlowSpec{
+			Match: []v1beta1.Match{
+				{Select: &v1beta1.Select{Labels: producerLabels}},
+			},
+			LocalOutputRefs: []string{out.Name},
+		},
+	})
+
+	env.StartLogProducer(ns, producerLabels)
+
+	// Neither config attaches, so nothing aggregates and no tag arrives; the
+	// verdict is the status the operator writes back onto both.
+	env.WaitFor(wait.ExcessFluentd(ns, first), wait.ExcessFluentd(ns, second))
 }

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -15,30 +15,12 @@
 package fluentd_aggregator
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/cisco-open/operator-tools/pkg/types"
-	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
-	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
 	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/image"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
@@ -46,199 +28,103 @@ import (
 	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
 )
 
-var TestTempDir string
+const (
+	clusterName = "fluentd-aggregator"
+	release     = "e2e"
+	ns          = "testing-1"
+	labeledNs   = "labeled-namespace"
+	testTag     = "test.fluentd_aggregator_nslabel"
+)
 
-func init() {
-	var ok bool
-	TestTempDir, ok = os.LookupEnv("PROJECT_DIR")
-	if !ok {
-		TestTempDir = "../.."
-	}
-	TestTempDir = filepath.Join(TestTempDir, "build/_test")
-	err := os.MkdirAll(TestTempDir, os.FileMode(0o755))
-	if err != nil {
-		panic(err)
-	}
-}
+var producerLabels = map[string]string{"my-unique-label": "log-producer"}
 
 func TestFluentdAggregator_NamespaceLabel(t *testing.T) {
-	common.Initialize(t)
-	ns := "testing-1"
-	releaseNameOverride := "e2e"
-	testTag := "test.fluentd_aggregator_nslabel"
-	outputName := "test-output"
-	flowName := "test-flow"
+	env := harness.New(t).
+		WithCluster(clusterName).
+		WithRelease(release).
+		WithControlNamespace(ns).
+		WithNamespaces(labeledNs).
+		Start()
 
-	labeledNamespaceName := "labeled-namespace"
-
-	common.WithCluster("fluentd-aggregator", t, func(t *testing.T, c common.Cluster) {
-		setup.LoggingOperator(t, c, setup.LoggingOperatorOptionFunc(func(options *setup.LoggingOperatorOptions) {
-			options.Namespace = ns
-			options.NameOverride = releaseNameOverride
-		}))
-
-		ctx := context.Background()
-
-		labeledNamespace := corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: labeledNamespaceName,
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &labeledNamespace))
-
-		logging := v1beta1.Logging{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fluentd-aggregator-nslabel-test",
-			},
-			Spec: v1beta1.LoggingSpec{
-				EnableRecreateWorkloadOnImmutableFieldChange: true,
-				ControlNamespace: ns,
-				FluentbitSpec: &v1beta1.FluentbitSpec{
-					Network: &v1beta1.FluentbitNetwork{
-						Keepalive: new(false),
-					},
-					ConfigHotReload: &v1beta1.HotReload{
-						Image: image.ConfigReloader().Spec(),
-					},
-					BufferVolumeImage: image.NodeExporter().Spec(),
-					FilterKubernetes:  v1beta1.FilterKubernetes{
-						// Namespace labels enrichment is enabled by default starting with version 4.9
-						// NamespaceLabels: "On",
-					},
+	env.Create(&v1beta1.Logging{
+		ObjectMeta: metav1.ObjectMeta{Name: "fluentd-aggregator-nslabel-test"},
+		Spec: v1beta1.LoggingSpec{
+			EnableRecreateWorkloadOnImmutableFieldChange: true,
+			ControlNamespace: ns,
+			FluentbitSpec: &v1beta1.FluentbitSpec{
+				Network: &v1beta1.FluentbitNetwork{
+					Keepalive: new(false),
 				},
-				FluentdSpec: &v1beta1.FluentdSpec{
-					Image:               image.Fluentd().Spec(),
-					ConfigReloaderImage: image.ConfigReloader().Spec(),
-					BufferVolumeImage:   image.NodeExporter().Spec(),
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("500m"),
-							corev1.ResourceMemory: resource.MustParse("200M"),
-						},
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("250m"),
-							corev1.ResourceMemory: resource.MustParse("50M"),
-						},
+				ConfigHotReload: &v1beta1.HotReload{
+					Image: image.ConfigReloader().Spec(),
+				},
+				BufferVolumeImage: image.NodeExporter().Spec(),
+				FilterKubernetes:  v1beta1.FilterKubernetes{
+					// Namespace labels enrichment is enabled by default starting with version 4.9
+					// NamespaceLabels: "On",
+				},
+			},
+			FluentdSpec: &v1beta1.FluentdSpec{
+				Image:               image.Fluentd().Spec(),
+				ConfigReloaderImage: image.ConfigReloader().Spec(),
+				BufferVolumeImage:   image.NodeExporter().Spec(),
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("200M"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("250m"),
+						corev1.ResourceMemory: resource.MustParse("50M"),
 					},
 				},
 			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &logging))
-		tags := "time"
-		output := v1beta1.ClusterOutput{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      outputName,
-				Namespace: logging.Spec.ControlNamespace,
-			},
-			Spec: v1beta1.ClusterOutputSpec{
-				OutputSpec: v1beta1.OutputSpec{
-					HTTPOutput: &output.HTTPOutputConfig{
-						Endpoint:    harness.ReceiverURL(releaseNameOverride, testTag),
-						ContentType: "application/json",
-						Buffer: &output.Buffer{
-							Type:        "file",
-							Tags:        &tags,
-							Timekey:     "1s",
-							TimekeyWait: "0s",
-						},
-					},
-				},
-			},
-		}
-
-		common.RequireNoError(t, c.GetClient().Create(ctx, &output))
-		flow := v1beta1.ClusterFlow{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      flowName,
-				Namespace: logging.Spec.ControlNamespace,
-			},
-			Spec: v1beta1.ClusterFlowSpec{
-				Match: []v1beta1.ClusterMatch{
-					{
-						ClusterSelect: &v1beta1.ClusterSelect{
-							NamespaceLabels: map[string]string{
-								"kubernetes.io/metadata.name": labeledNamespaceName,
-							},
-						},
-					},
-				},
-				GlobalOutputRefs: []string{output.Name},
-			},
-		}
-		common.RequireNoError(t, c.GetClient().Create(ctx, &flow))
-
-		aggregatorLabels := map[string]string{
-			types.NameLabel:      "fluentd",
-			types.ComponentLabel: "fluentd",
-		}
-		operatorLabels := map[string]string{
-			types.NameLabel: releaseNameOverride,
-		}
-		// used to find the producer only, not used to filter logs
-		producerLabels := map[string]string{
-			"my-unique-label": "log-producer",
-		}
-
-		setup.LogProducer(t, c.GetClient(), setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
-			options.Namespace = labeledNamespaceName
-			options.Labels = producerLabels
-		}))
-
-		require.Eventually(t, func() bool {
-			if operatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(operatorLabels))(); !operatorRunning {
-				t.Log("waiting for the operator")
-				return false
-			}
-			if producerRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(producerLabels))(); !producerRunning {
-				t.Log("waiting for the producer")
-				return false
-			}
-			if aggregatorRunning := wait.AnyPodShouldBeRunning(t, c.GetClient(), client.MatchingLabels(aggregatorLabels)); !aggregatorRunning() {
-				t.Log("waiting for the aggregator")
-				return false
-			}
-
-			cmd := common.CmdEnv(exec.Command("kubectl",
-				"logs",
-				"-n", ns,
-				"-l", fmt.Sprintf("%s=%s", types.NameLabel, harness.ReceiverName(releaseNameOverride))), c)
-			rawOut, err := cmd.Output()
-			if err != nil {
-				t.Logf("failed to get log consumer logs: %v", err)
-				return false
-			}
-			t.Logf("log consumer logs: %s", rawOut)
-			return strings.Contains(string(rawOut), testTag)
-		}, 5*time.Minute, 3*time.Second)
-	}, func(t *testing.T, c common.Cluster) error {
-		path := filepath.Join(TestTempDir, fmt.Sprintf("cluster-%s.log", t.Name()))
-		t.Logf("Printing cluster logs to %s", path)
-		err := c.PrintLogs(common.PrintLogConfig{
-			Namespaces: []string{ns, "default"},
-			FilePath:   path,
-			Limit:      100 * 1000,
-		})
-		if err != nil {
-			return err
-		}
-
-		loggingOperatorName := "logging-operator-" + releaseNameOverride
-		t.Logf("Collecting coverage files from logging-operator: %s/%s", ns, loggingOperatorName)
-		err = c.CollectTestCoverageFiles(ns, loggingOperatorName)
-		if err != nil {
-			t.Logf("Failed collecting coverage files: %s", err)
-		}
-
-		return nil
-	}, func(o *cluster.Options) {
-		if o.Scheme == nil {
-			o.Scheme = runtime.NewScheme()
-		}
-		common.RequireNoError(t, v1beta1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, apiextensionsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, appsv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, batchv1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, corev1.AddToScheme(o.Scheme))
-		common.RequireNoError(t, rbacv1.AddToScheme(o.Scheme))
+		},
 	})
+
+	tags := "time"
+	out := &v1beta1.ClusterOutput{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-output", Namespace: ns},
+		Spec: v1beta1.ClusterOutputSpec{
+			OutputSpec: v1beta1.OutputSpec{
+				HTTPOutput: &output.HTTPOutputConfig{
+					Endpoint:    env.Receiver.URL(testTag),
+					ContentType: "application/json",
+					Buffer: &output.Buffer{
+						Type:        "file",
+						Tags:        &tags,
+						Timekey:     "1s",
+						TimekeyWait: "0s",
+					},
+				},
+			},
+		},
+	}
+	env.Create(out)
+
+	env.Create(&v1beta1.ClusterFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-flow", Namespace: ns},
+		Spec: v1beta1.ClusterFlowSpec{
+			Match: []v1beta1.ClusterMatch{
+				{
+					ClusterSelect: &v1beta1.ClusterSelect{
+						NamespaceLabels: map[string]string{
+							"kubernetes.io/metadata.name": labeledNs,
+						},
+					},
+				},
+			},
+			GlobalOutputRefs: []string{out.Name},
+		},
+	})
+
+	env.StartLogProducer(labeledNs, producerLabels)
+
+	env.WaitFor(
+		wait.Operator(release),
+		wait.Producer(producerLabels),
+		wait.FluentdAggregator(ns),
+	)
+
+	env.Receiver.MustReceive(testTag)
 }

--- a/e2e/internal/harness/harness.go
+++ b/e2e/internal/harness/harness.go
@@ -202,7 +202,7 @@ func (e *Env) StartLogProducer(namespace string, labels map[string]string) {
 	}))
 }
 
-func (e *Env) WaitForRunning(conditions ...wait.Condition) {
+func (e *Env) WaitFor(conditions ...wait.Condition) {
 	e.T.Helper()
 
 	var outstanding pending

--- a/e2e/internal/wait/condition.go
+++ b/e2e/internal/wait/condition.go
@@ -19,7 +19,10 @@ import (
 
 	"github.com/cisco-open/operator-tools/pkg/types"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
 )
 
 // Condition carries no testing.T and no client, so a suite can name one without
@@ -71,6 +74,14 @@ func Producer(labels map[string]string) Condition {
 	return PodRunning("producer", client.MatchingLabels(labels))
 }
 
+// Fluentbit is the agent daemonset, which a suite naming a
+// fluentBitAgentNamespace expects somewhere other than the control namespace.
+func Fluentbit(namespace string) Condition {
+	return PodRunning("fluentbit in "+namespace,
+		client.MatchingLabels{types.NameLabel: "fluentbit"},
+		client.InNamespace(namespace))
+}
+
 func FluentdAggregator(namespace string) Condition {
 	return aggregator("fluentd", namespace)
 }
@@ -83,4 +94,22 @@ func aggregator(kind, namespace string) Condition {
 	return PodRunning(kind+" aggregator in "+namespace,
 		client.MatchingLabels{types.NameLabel: kind, types.ComponentLabel: kind},
 		client.InNamespace(namespace))
+}
+
+// ExcessFluentd is a FluentdConfig the operator refused because another is
+// already attached to the Logging: it reports problems, names no logging, and
+// is not active.
+func ExcessFluentd(namespace, name string) Condition {
+	return Condition{
+		Name: "excess FluentdConfig " + name,
+		Met: func(ctx context.Context, cl client.Reader) (bool, error) {
+			var config v1beta1.FluentdConfig
+			if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &config); err != nil {
+				return false, err
+			}
+			return len(config.Status.Problems) > 0 &&
+				config.Status.Logging == "" &&
+				!ptr.Deref(config.Status.Active, true), nil
+		},
+	}
 }

--- a/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
+++ b/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
@@ -154,7 +154,7 @@ func TestSyslogNGIsRunningAndForwardingLogs(t *testing.T) {
 	env.Create(logging, output, flow)
 	env.StartLogProducer(ns, producerLabels)
 
-	env.WaitForRunning(
+	env.WaitFor(
 		wait.Operator(release),
 		wait.Producer(producerLabels),
 		wait.SyslogNGAggregator(ns),

--- a/e2e/watch-selector/watch_selector_test.go
+++ b/e2e/watch-selector/watch_selector_test.go
@@ -85,7 +85,7 @@ func TestWatchSelectors(t *testing.T) {
 	}
 	env.Create(unmanagedSecret)
 
-	env.WaitForRunning(
+	env.WaitFor(
 		wait.Pod(ns, logging.Name+"-fluentd-0"),
 		wait.Pod(unmanagedNS, "fluentd-0"),
 	)


### PR DESCRIPTION
Three more suites onto the harness, and the two waits they needed that it did not have.

| suite | lines |
| --- | --- |
| `fluentd-aggregator-namespacelabel` | 244 → 130 |
| `fluentbit-agent-namespace` | 256 → 123 |
| `fluentd-aggregator-detached-multiple-failures` | 249 → 132 |

The detached one is in this batch on purpose. It is the only remaining suite whose verdict is not log delivery — it asserts the operator writes rejection status onto two competing `FluentdConfig`s — so it is the shape most likely to need an escape hatch, and better found now than after eight more suites.

### Additions

- **`wait.ExcessFluentd(namespace, name)`.** The `Condition` form of `CheckExcessFluentdStatus`: problems reported, no logging named, not active. The old `(t, client, ctx, obj)` signature cannot be a value, so the suite could not express its own verdict without it. The three detached suites still on that form pick this up as they migrate.
- **`wait.Fluentbit(namespace)`.** The agent daemonset, which a suite naming a `fluentBitAgentNamespace` expects outside the control namespace.
- **`WaitForRunning` is now `WaitFor`**, six call sites. Its argument has always been a `Condition` rather than a pod, and the excess-config one is the first that is not about something running.

Two additions for three suites, both landing with a caller.

### Stated rather than silent

`fluentd-aggregator-namespacelabel` and `fluentd-aggregator-detached-multiple-failures` waited on the aggregator cluster-wide and now wait on it in the one namespace they use. Neither can change a verdict, since that is where the aggregator already was.

The `fluentd_aggregator` package name is shared with three other directories and the `TestTempDirUnnamed` variable is gone with the boilerplate; renaming the packages belongs with the rest of the naming work.

### Verification

`golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` reports 0 issues in `e2e/`, and all four commits build, vet and test on their own.

Against real clusters, with `fluentbit-multitenant` as an untouched control: `fluentd-aggregator-namespacelabel` 88s, `fluentbit-agent-namespace` 86s, `fluentd-aggregator-detached-multiple-failures` 44s, control 84s.

The assertions are checked rather than assumed. Both delivery suites applied the endpoint through `env.Receiver.URL`, and the detached one only passes once the operator has written the status — a config that was never reconciled has an empty `Problems`, so the condition cannot pass early.
