### PR TITLE
fix(model): mark defaultFlow outputs active

### DIFF
--- a/pkg/resources/model/reconciler.go
+++ b/pkg/resources/model/reconciler.go
@@ -64,6 +64,11 @@ func NewValidationReconciler( //nolint: gocyclo
 			output.Status.Problems = append(output.Status.Problems,
 				validateOutputSpec(output.Spec.OutputSpec, secrets.OutputSecretLoaderForNamespace(output.Namespace))...)
 			output.Status.ProblemsCount = len(output.Status.Problems)
+
+			// The default flow references cluster outputs from the Logging spec, so the flow loops below never see them
+			if defaultFlow := resources.Logging.Spec.DefaultFlowSpec; defaultFlow != nil && output.Status.ProblemsCount == 0 && slices.Contains(defaultFlow.GlobalOutputRefs, output.Name) {
+				output.Status.Active = new(true)
+			}
 		}
 
 		for i := range resources.Fluentd.Outputs {

--- a/pkg/resources/model/reconciler_test.go
+++ b/pkg/resources/model/reconciler_test.go
@@ -14,7 +14,95 @@
 
 package model
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/cisco-open/operator-tools/pkg/secret"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/api/v1beta1"
+	"github.com/kube-logging/logging-operator/pkg/sdk/logging/model/output"
+)
+
+type stubSecretLoaderFactory struct {
+	client client.Client
+}
+
+func (f stubSecretLoaderFactory) OutputSecretLoaderForNamespace(namespace string) secret.SecretLoader {
+	return secret.NewSecretLoader(f.client, namespace, "", &secret.MountSecrets{})
+}
+
+// Regression: a ClusterOutput referenced only by Logging.spec.defaultFlow.globalOutputRefs
+// is rendered into the fluentd config by FlowForDefaultFlow, but the validation reconciler
+// reported it as inactive because it only looked at Flow and ClusterFlow references.
+func TestValidationReconciler_DefaultFlowRef(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputSpec v1beta1.OutputSpec
+		refs       []string
+		want       bool
+	}{
+		{
+			name:       "valid output becomes active",
+			outputSpec: v1beta1.OutputSpec{NullOutputConfig: output.NewNullOutputConfig()},
+			refs:       []string{"general"},
+			want:       true,
+		},
+		{
+			// Same semantics as the flow and clusterflow loops: no target configured is a problem
+			name:       "output with problems stays inactive",
+			outputSpec: v1beta1.OutputSpec{},
+			refs:       []string{"general"},
+			want:       false,
+		},
+		{
+			name:       "unreferenced output stays inactive",
+			outputSpec: v1beta1.OutputSpec{NullOutputConfig: output.NewNullOutputConfig()},
+			refs:       []string{"other"},
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterOutput := v1beta1.ClusterOutput{
+				ObjectMeta: metav1.ObjectMeta{Name: "general", Namespace: "test"},
+				Spec:       v1beta1.ClusterOutputSpec{OutputSpec: tt.outputSpec},
+			}
+			logging := loggingFor()
+			logging.Spec.DefaultFlowSpec = &v1beta1.DefaultFlowSpec{GlobalOutputRefs: tt.refs}
+
+			scheme := runtime.NewScheme()
+			if err := v1beta1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add to scheme: %v", err)
+			}
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&clusterOutput, &logging).
+				WithStatusSubresource(&clusterOutput, &logging).
+				Build()
+
+			res := LoggingResources{
+				Logging: logging,
+				Fluentd: FluentdLoggingResources{ClusterOutputs: ClusterOutputs{clusterOutput}},
+			}
+
+			reconcile := NewValidationReconciler(cl, res, stubSecretLoaderFactory{client: cl}, logr.Discard())
+			if _, err := reconcile(context.Background()); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			active := res.Fluentd.ClusterOutputs[0].Status.Active
+			if got := active != nil && *active; got != tt.want {
+				t.Errorf("Status.Active = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func Test_hasIntersection(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
The validation reconciler reset every fluentd ClusterOutput to Active=false and only flipped it back for Spec.ErrorOutputRef or refs coming from a Flow/ClusterFlow. Outputs referenced solely by Logging.spec.defaultFlow.globalOutputRefs stayed inactive even though FlowForDefaultFlow renders them into the fluentd config, so both the status field and the resource state metrics reported an in-use output as unused.

Add a regression test covering a ClusterOutput reachable only through defaultFlow.