### PR TITLE
refactor(e2e): name each suite package after its directory

### DIFF
--- a/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
+++ b/e2e/fluentd-aggregator-detached-multiple-failures/fluentd_aggregator_detached_multiple_failures_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fluentd_aggregator
+package fluentd_aggregator_detached_multiple_failures
 
 import (
 	"testing"

--- a/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
+++ b/e2e/fluentd-aggregator-detached/fluentd_aggregator_detached_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fluentd_aggregator
+package fluentd_aggregator_detached
 
 import (
 	"testing"

--- a/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
+++ b/e2e/fluentd-aggregator-namespacelabel/fluentd_aggregator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fluentd_aggregator
+package fluentd_aggregator_namespacelabel
 
 import (
 	"testing"

--- a/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
+++ b/e2e/syslog-ng-aggregator-detached/syslog_ng_aggregator_detached_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package syslong_ng_aggregator
+package syslog_ng_aggregator_detached
 
 import (
 	"testing"

--- a/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
+++ b/e2e/syslog-ng-aggregator/syslog_ng_aggregator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package syslong_ng_aggregator
+package syslog_ng_aggregator
 
 import (
 	"testing"


### PR DESCRIPTION
The naming half of #2291 §5.7, which every migration batch deferred.

Four directories shared `package fluentd_aggregator` and two shared a misspelled `syslong_ng_aggregator`. A panic or a coverage row named a package that did not say which of four suites it came from.

Six of the thirteen suites already derive the package name from the directory, hyphens as underscores. This applies that to the other five, so the name is derivable rather than remembered:

| directory | was | now |
| --- | --- | --- |
| `syslog-ng-aggregator` | `syslong_ng_aggregator` | `syslog_ng_aggregator` |
| `syslog-ng-aggregator-detached` | `syslong_ng_aggregator` | `syslog_ng_aggregator_detached` |
| `fluentd-aggregator-detached` | `fluentd_aggregator` | `fluentd_aggregator_detached` |
| `fluentd-aggregator-detached-multiple-failures` | `fluentd_aggregator` | `fluentd_aggregator_detached_multiple_failures` |
| `fluentd-aggregator-namespacelabel` | `fluentd_aggregator` | `fluentd_aggregator_namespacelabel` |

Every suite is a leaf that nothing imports, so the change is the declaration line in five files and nothing else. `syslong` no longer appears anywhere in the tree.

### Two I left alone, as they are judgement rather than typo

`logging_metrics_monitoring` is the only suite directory using underscores rather than hyphens, and the only one using an external test package (`..._test`). Renaming the directory would change the `E2E_TEST` path and the CI matrix, and the external test package is a legitimate idiom rather than a mistake — so both seemed worth asking about rather than folding into a rename PR.

### Verification

Each of the five still compiles as its own test binary, `go list` still selects thirteen suites, and `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` reports 0 issues in `e2e/`.

Against real clusters, with `fluentbit-multitenant` as an untouched control: `syslog-ng-aggregator` 122s, control 82s.
