### PR TITLE
refactor(e2e): shrink what common exports to what is actually called

### DIFF
--- a/e2e/common/cluster.go
+++ b/e2e/common/cluster.go
@@ -54,7 +54,7 @@ func GetTestCluster(clusterName string, opts ...cluster.Option) (Cluster, error)
 	var restCfg *rest.Config
 	var c cluster.Cluster
 
-	kubeconfig, err = KindClusterKubeconfig(clusterName)
+	kubeconfig, err = kindClusterKubeconfig(clusterName)
 	if err != nil {
 		return nil, errors.WrapIfWithDetails(err, "getting kubeconfig of kind cluster", "clusterName", clusterName)
 	}
@@ -86,12 +86,12 @@ func GetTestCluster(clusterName string, opts ...cluster.Option) (Cluster, error)
 // failing here would not remove the leftover the next run recreates anyway.
 func DeleteTestClusterOrLog(t *testing.T, clusterName string) {
 	t.Helper()
-	if err := DeleteTestCluster(clusterName); err != nil {
+	if err := deleteTestCluster(clusterName); err != nil {
 		t.Logf("deleting cluster %q: %v", clusterName, err)
 	}
 }
 
-func DeleteTestCluster(clusterName string) error {
+func deleteTestCluster(clusterName string) error {
 	kubeconfig, err := clusterKubeconfigPath(clusterName)
 	if err != nil {
 		return err

--- a/e2e/common/kind.go
+++ b/e2e/common/kind.go
@@ -80,7 +80,7 @@ func removeIfExists(path string) error {
 	return nil
 }
 
-func KindClusterKubeconfig(name string) ([]byte, error) {
+func kindClusterKubeconfig(name string) ([]byte, error) {
 	kubeconfig, err := clusterKubeconfigPath(name)
 	if err != nil {
 		return nil, err

--- a/e2e/common/setup/loggingoperator.go
+++ b/e2e/common/setup/loggingoperator.go
@@ -38,7 +38,7 @@ func LoggingOperator(t *testing.T, c common.Cluster, opts ...LoggingOperatorOpti
 		o.ApplyToLoggingOperatorOptions(opt)
 	}
 
-	restClientGetter, err := NewRESTClientGetter(c.KubeConfigFilePath(), opt.Namespace)
+	restClientGetter, err := newRESTClientGetter(c.KubeConfigFilePath(), opt.Namespace)
 	if err != nil {
 		t.Fatalf("helm rest client getter: %s", err)
 	}

--- a/e2e/common/setup/restclientgetter.go
+++ b/e2e/common/setup/restclientgetter.go
@@ -30,7 +30,7 @@ type RESTClientGetter struct {
 	clientconfig clientcmd.ClientConfig
 }
 
-func NewRESTClientGetter(kubeconfigPath string, namespace string) (*RESTClientGetter, error) {
+func newRESTClientGetter(kubeconfigPath string, namespace string) (*RESTClientGetter, error) {
 	kubeconfigContent, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return nil, err

--- a/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
+++ b/e2e/elasticsearch-multiversion/elasticsearch_multiversion_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kube-logging/logging-operator/e2e/common"
-	"github.com/kube-logging/logging-operator/e2e/common/setup"
 	"github.com/kube-logging/logging-operator/e2e/internal/harness"
 	"github.com/kube-logging/logging-operator/e2e/internal/image"
 	"github.com/kube-logging/logging-operator/e2e/internal/wait"
@@ -494,10 +493,7 @@ func TestElasticsearch_MultiVersion(t *testing.T) {
 	}
 	env.Create(&flow)
 
-	setup.LogProducer(t, env.Client, setup.LogProducerOptionFunc(func(options *setup.LogProducerOptions) {
-		options.Namespace = ns
-		options.Labels = producerLabels
-	}))
+	env.StartLogProducer(ns, producerLabels)
 
 	t.Log("Waiting for components to be ready...")
 	env.WaitFor(


### PR DESCRIPTION
Part of #2291 §5.8, and deliberately the mechanical half — it makes the remaining decision visible rather than taking it.

### Three exports with no caller outside their own package

`DeleteTestCluster` is used only by `DeleteTestClusterOrLog`, `KindClusterKubeconfig` only by `GetTestCluster`, and `NewRESTClientGetter` only by `LoggingOperator`. Checked repo-wide rather than just under `e2e/`. Exporting them offers a suite a lifecycle the harness already owns.

### One suite call that had outlived itself

`elasticsearch-multiversion` was the last suite calling `setup.LogProducer` directly. `env.StartLogProducer` is the same call with the same two options — same `t`, same client — so the suite no longer imports `common/setup` at all.

### What this leaves, which is the point

`common` now exports eight things, and they split cleanly:

| harness is the only caller | suites still reach for |
| --- | --- |
| `GetTestCluster` | `CmdEnv` |
| `DeleteTestClusterOrLog` | `RequireNoError` |
| `Initialize` | `SetupCurlPod` |
| `LoggingOperator` | |
| `LogProducer` | |

The left column is a mechanical fold into `internal/harness`, though it drags the `Cluster` interface and the `kindCluster` implementation with it, so it wants its own PR. The right column is the seam #2325 is about, and this PR does not settle it.

One thing worth recording for whoever does settle it: `RequireNoError` is not a `require.NoError` wrapper. It prints `errors.GetDetails`, so the operator's structured errors survive, and swapping it for testify would quietly lose that.

### Verification

`golangci-lint run --max-same-issues=0 --max-issues-per-linter=0` reports 0 issues in `e2e/`, `make check-diff` is clean, and `go mod tidy` leaves `go.mod` unchanged.

Against real clusters, with `fluentbit-multitenant` as an untouched control: `elasticsearch-multiversion` 354s, control 186s. The elasticsearch run is the one that matters here, since it carries the `LogProducer` substitution — its dump shows the producer deployed, and its document-count assertions only pass if logs actually flowed through it.
