### PR TITLE
feat: add liveness/readiness probes to the operator manager Deployment

### DIFF
--- a/charts/logging-operator/README.md
+++ b/charts/logging-operator/README.md
@@ -55,6 +55,9 @@ Use `createCustomResource=false` with Helm v3 to avoid trying to create CRDs fro
 | telemetry-controller.install | bool | `false` | Toggle to install and upgrade Telemetry Controller from a subchart. |
 | http.port | int | `8080` | HTTP listen port number. |
 | http.service | object | `{"annotations":{},"clusterIP":"None","labels":{},"type":"ClusterIP"}` | Service definition for query http service. |
+| healthProbe.port | int | `8081` | Health probe (healthz/readyz) listen port number. Must be kept in sync with the `-health-probe-bind-address` manager flag if overridden through `extraArgs`. |
+| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"health"},"initialDelaySeconds":15,"periodSeconds":20}` | Liveness probe configuration for the logging-operator manager pod. |
+| readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"health"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe configuration for the logging-operator manager pod. |
 | rbac.enabled | bool | `true` | Create rbac service account and roles. |
 | rbac.retainOnDelete | bool | `false` | Keep the operators RBAC resources after the operator is deleted to allow removing pending finalizers. |
 | rbac.createAggregatedViewClusterRole | bool | `false` | Create ClusterRole that extend the existing view ClusterRole to interact with logging-operator CRDs # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles |

--- a/charts/logging-operator/templates/deployment.yaml
+++ b/charts/logging-operator/templates/deployment.yaml
@@ -56,6 +56,16 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.http.port }}
+            - name: health
+              containerPort: {{ .Values.healthProbe.port }}
+        {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         {{- with .Values.env }}
           env: {{ toYaml . | nindent 12 }}
         {{- end }}

--- a/charts/logging-operator/values.yaml
+++ b/charts/logging-operator/values.yaml
@@ -68,6 +68,26 @@ http:
     # Labels to query http service
     labels: {}
 
+healthProbe:
+  # -- Health probe (healthz/readyz) listen port number. Must be kept in sync with the `-health-probe-bind-address` manager flag if overridden through `extraArgs`.
+  port: 8081
+
+# -- Liveness probe configuration for the logging-operator manager pod.
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: health
+  initialDelaySeconds: 15
+  periodSeconds: 20
+
+# -- Readiness probe configuration for the logging-operator manager pod.
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: health
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
 rbac:
   # -- Create rbac service account and roles.
   enabled: true

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -84,6 +85,7 @@ func init() {
 
 func main() {
 	var metricsAddr string
+	var healthProbeAddr string
 	var enableLeaderElection bool
 	var verboseLogging bool
 	var loggingOutputFormat string
@@ -98,6 +100,7 @@ func main() {
 	var syncPeriod string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "The address the health probe (healthz/readyz) endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
@@ -151,10 +154,11 @@ func main() {
 	klog.SetLogger(zapLogger)
 
 	mgrOptions := ctrl.Options{
-		Scheme:           scheme,
-		Metrics:          metricsserver.Options{BindAddress: metricsAddr},
-		LeaderElection:   enableLeaderElection,
-		LeaderElectionID: "logging-operator." + loggingv1beta1.GroupVersion.Group,
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		HealthProbeBindAddress: healthProbeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "logging-operator." + loggingv1beta1.GroupVersion.Group,
 	}
 
 	if os.Getenv("ENABLE_WEBHOOKS") == "true" {
@@ -202,6 +206,11 @@ func main() {
 
 	if err := detectContainerRuntime(ctx, mgr.GetAPIReader()); err != nil {
 		setupLog.Error(err, "failed to detect container runtime")
+		os.Exit(1)
+	}
+
+	if err := setupHealthChecks(mgr); err != nil {
+		setupLog.Error(err, "unable to set up health checks")
 		os.Exit(1)
 	}
 
@@ -341,6 +350,14 @@ func detectContainerRuntime(ctx context.Context, c client.Reader) error {
 	}
 
 	return nil
+}
+
+func setupHealthChecks(mgr ctrl.Manager) error {
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return err
+	}
+
+	return mgr.AddReadyzCheck("readyz", healthz.Ping)
 }
 
 func setupCustomCache(mgrOptions *ctrl.Options, syncPeriod string, namespace string, loggingRef string, watchLabeledChildren bool) (*ctrl.Options, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,91 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// TestHealthProbesRespondOK exercises the same manager wiring used in main():
+// a HealthProbeBindAddress plus AddHealthzCheck/AddReadyzCheck registrations,
+// and verifies the resulting /healthz and /readyz endpoints respond 200 OK.
+func TestHealthProbesRespondOK(t *testing.T) {
+	testEnv := &envtest.Environment{
+		BinaryAssetsDirectory: os.Getenv("ENVTEST_BINARY_ASSETS"),
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("unable to start test environment: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Errorf("unable to stop test environment: %v", err)
+		}
+	})
+
+	const healthAddr = "127.0.0.1:18734"
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: healthAddr,
+	})
+	if err != nil {
+		t.Fatalf("unable to create manager: %v", err)
+	}
+
+	if err := setupHealthChecks(mgr); err != nil {
+		t.Fatalf("unable to set up health checks: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- mgr.Start(ctx) }()
+
+	for _, path := range []string{"healthz", "readyz"} {
+		var resp *http.Response
+		var reqErr error
+		for range 50 {
+			resp, reqErr = http.Get(fmt.Sprintf("http://%s/%s", healthAddr, path))
+			if reqErr == nil {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if reqErr != nil {
+			t.Fatalf("/%s endpoint never became available: %v", path, reqErr)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("/%s returned status %d, want %d", path, resp.StatusCode, http.StatusOK)
+		}
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Errorf("manager exited with error: %v", err)
+	}
+}


### PR DESCRIPTION
Motivation:
The logging-operator controller Deployment (the manager pod itself, not the
fluentd/fluent-bit/syslog-ng data-plane pods) has no liveness/readiness
probes and no supported way to configure one. The manager binary never
exposed a /healthz or /readyz endpoint at all, so Kubernetes has no way to
detect a hung controller process (e.g. a stuck reconcile loop or a wedged
leader-election client) and restart it automatically. This is an
operability gap, not a crash or outage in current behavior: the operator
runs fine today, it simply cannot be automatically restarted if it hangs.

Approach:
- main.go: add a `-health-probe-bind-address` flag (default `:8081`,
  matching the existing `-metrics-addr` flag's style/pattern), wire it into
  ctrl.Options.HealthProbeBindAddress, and add a setupHealthChecks(mgr)
  helper that registers mgr.AddHealthzCheck("healthz", healthz.Ping) and
  mgr.AddReadyzCheck("readyz", healthz.Ping) - the standard kubebuilder
  scaffold pattern.
- charts/logging-operator/values.yaml + templates/deployment.yaml: add a
  named "health" container port and configurable livenessProbe/
  readinessProbe blocks (httpGet against /healthz and /readyz), following
  the same toYaml-passthrough idiom already used for resources/
  securityContext/env in this template. Defaults use kubebuilder's
  canonical initialDelaySeconds/periodSeconds values.
- README.md regenerated with the real helm-docs v1.14.2 tool (matching the
  version pinned in the Makefile), not hand-written.

Validation:
- go build ./... and go vet ./... are clean.
- gofmt -l and golangci-lint run ./... (repo-pinned v2.12.2) report no
  issues.
- helm lint and helm template --show-only templates/deployment.yaml render
  the new port/probes correctly, with the probe httpGet.port matching the
  named container port.
- make manifests / make fmt / make docs / helm-docs produce no diff beyond
  this change, so `make check-diff` passes.
- Added main_test.go: TestHealthProbesRespondOK starts a real envtest API
  server (kube-apiserver + etcd, no live cluster), builds a manager with
  HealthProbeBindAddress set, calls the new setupHealthChecks(mgr) function
  directly, and polls /healthz and /readyz over HTTP expecting 200 OK.
  Verified fail-then-pass: with main.go's changes stashed, `go test -run
  TestHealthProbesRespondOK .` fails to compile (setupHealthChecks
  undefined); restored, it passes in ~3-4s
  (ENVTEST_BINARY_ASSETS=$(pwd)/bin/envtest/bin go test -run
  TestHealthProbesRespondOK -v .).
- Disclosure: this repo's `make test` / CI "Test" job only runs `go test`
  under pkg/sdk/..., controllers/..., and e2e/common|internal - it does not
  run the root package's tests, so main_test.go is not exercised by CI and
  was only validated by running it manually as above. No live Kubernetes
  cluster (kind/kubectl) was available in this environment to verify actual
  kubelet-driven probe behavior against a real Pod; only Helm template
  rendering and the in-process envtest check were verified.

Report: https://github.com/kube-logging/logging-operator/issues/2346
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

---
AI assistance: this change was drafted with Claude Code.

Fixes #2346